### PR TITLE
fix: reduce timer countdown rendering and persistence work

### DIFF
--- a/packages/teacher/src/features/widgets/timer/components/HamsterAnimation.tsx
+++ b/packages/teacher/src/features/widgets/timer/components/HamsterAnimation.tsx
@@ -1,68 +1,109 @@
-import React from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { useAnimationFrame } from '@shared/hooks/useAnimationFrame';
 
 interface HamsterAnimationProps {
-  pulseAngle: number;
-  isOnColoredArc?: boolean;
+  isRunning: boolean;
+  progress: number;
 }
 
-export const HamsterAnimation: React.FC<HamsterAnimationProps> = ({ pulseAngle, isOnColoredArc = true }) => (
-  <g transform={`rotate(${pulseAngle} 50 50)`}>
-    <g transform="translate(50, 8) scale(0.9, -0.9)">
-      {!isOnColoredArc ? (
-        // Shocked hamster on grey arc
-        <>
-          {/* Spiky fur sticking out all around */}
-          <g stroke="#8B4513" strokeWidth="0.5" fill="none">
-            <line x1="0" y1="-5" x2="0" y2="-8" />
-            <line x1="3.5" y1="-3.5" x2="5.7" y2="-5.7" />
-            <line x1="5" y1="0" x2="8" y2="0" />
-            <line x1="3.5" y1="3.5" x2="5.7" y2="5.7" />
-            <line x1="0" y1="5" x2="0" y2="8" />
-            <line x1="-3.5" y1="3.5" x2="-5.7" y2="5.7" />
-            <line x1="-5" y1="0" x2="-8" y2="0" />
-            <line x1="-3.5" y1="-3.5" x2="-5.7" y2="-5.7" />
-            <line x1="2.5" y1="-4.3" x2="3.5" y2="-6.5" />
-            <line x1="4.3" y1="-2.5" x2="6.5" y2="-3.5" />
-            <line x1="-2.5" y1="-4.3" x2="-3.5" y2="-6.5" />
-            <line x1="-4.3" y1="-2.5" x2="-6.5" y2="-3.5" />
-          </g>
-          {/* Body */}
-          <ellipse cx="0" cy="0" rx="6" ry="4.5" fill="#D2691E" stroke="#8B4513" strokeWidth="0.8" />
-          {/* Oversized shocked head */}
-          <circle cx="-4" cy="-1.5" r="5" fill="#DEB887" stroke="#8B4513" strokeWidth="0.8" />
-          {/* Ears (bigger) */}
-          <circle cx="-6.5" cy="-4.5" r="1.8" fill="#D2691E" />
-          <circle cx="-1.5" cy="-4.5" r="1.8" fill="#D2691E" />
-          {/* Wide shocked eyes */}
-          <circle cx="-5.5" cy="-1.5" r="1.2" fill="#fff" />
-          <circle cx="-2.5" cy="-1.5" r="1.2" fill="#fff" />
-          <circle cx="-5.5" cy="-1.5" r="0.8" fill="#000" />
-          <circle cx="-2.5" cy="-1.5" r="0.8" fill="#000" />
-          {/* Shocked mouth (O shape) */}
-          <ellipse cx="-4" cy="1" rx="0.8" ry="1.2" fill="#000" />
-        </>
-      ) : (
-        // Normal hamster on colored arc
-        <>
-          <ellipse cx="0" cy="0" rx="6" ry="4.5" fill="#D2691E" stroke="#8B4513" strokeWidth="0.8" />
-          <circle cx="-4" cy="-1.5" r="3.5" fill="#DEB887" stroke="#8B4513" strokeWidth="0.8" />
-          <circle cx="-5.5" cy="-3.5" r="1.3" fill="#D2691E" />
-          <circle cx="-2.5" cy="-3.5" r="1.3" fill="#D2691E" />
-          <circle cx="-5" cy="-1.5" r="0.7" fill="#000" />
-          <circle cx="-3" cy="-1.5" r="0.7" fill="#000" />
-          <circle cx="-4.8" cy="-1.8" r="0.3" fill="#fff" />
-          <circle cx="-2.8" cy="-1.8" r="0.3" fill="#fff" />
-          <circle cx="-6.5" cy="-0.5" r="0.4" fill="#8B4513" />
-        </>
-      )}
-      {/* Static legs */}
-      <g>
-        <ellipse cx="-2.5" cy="3.5" rx="1" ry="1.5" fill="#654321" stroke="#3D2611" strokeWidth="0.3" />
-        <ellipse cx="-4" cy="3.5" rx="1" ry="1.5" fill="#654321" stroke="#3D2611" strokeWidth="0.3" />
-        <ellipse cx="1.5" cy="3.5" rx="1" ry="1.5" fill="#654321" stroke="#3D2611" strokeWidth="0.3" />
-        <ellipse cx="3" cy="3.5" rx="1" ry="1.5" fill="#654321" stroke="#3D2611" strokeWidth="0.3" />
+export const HamsterAnimation: React.FC<HamsterAnimationProps> = React.memo(({ isRunning, progress }) => {
+  const [pulseAngle, setPulseAngle] = useState(0);
+  const startTimeRef = useRef<number | null>(null);
+
+  useAnimationFrame(
+    (_, timestamp) => {
+      if (startTimeRef.current === null) {
+        startTimeRef.current = timestamp;
+      }
+
+      const elapsed = timestamp - startTimeRef.current;
+      setPulseAngle(0 - (elapsed / 1000) * 120);
+    },
+    { isActive: isRunning }
+  );
+
+  useEffect(() => {
+    if (!isRunning) {
+      setPulseAngle(0);
+      startTimeRef.current = null;
+    }
+  }, [isRunning]);
+
+  const isOnColoredArc = useMemo(() => {
+    let hamsterAngleInArcCoords = (pulseAngle - 90) % 360;
+    if (hamsterAngleInArcCoords < 0) {
+      hamsterAngleInArcCoords += 360;
+    }
+
+    const arcStartAngle = 270;
+    const arcExtent = progress * 360;
+
+    if (progress === 0) {
+      return false;
+    }
+
+    if (progress >= 0.9999) {
+      return true;
+    }
+
+    let angleFromStart = hamsterAngleInArcCoords - arcStartAngle;
+    if (angleFromStart < 0) {
+      angleFromStart += 360;
+    }
+
+    return angleFromStart <= arcExtent;
+  }, [progress, pulseAngle]);
+
+  return (
+    <g transform={`rotate(${pulseAngle} 50 50)`}>
+      <g transform="translate(50, 8) scale(0.9, -0.9)">
+        {!isOnColoredArc ? (
+          <>
+            <g stroke="#8B4513" strokeWidth="0.5" fill="none">
+              <line x1="0" y1="-5" x2="0" y2="-8" />
+              <line x1="3.5" y1="-3.5" x2="5.7" y2="-5.7" />
+              <line x1="5" y1="0" x2="8" y2="0" />
+              <line x1="3.5" y1="3.5" x2="5.7" y2="5.7" />
+              <line x1="0" y1="5" x2="0" y2="8" />
+              <line x1="-3.5" y1="3.5" x2="-5.7" y2="5.7" />
+              <line x1="-5" y1="0" x2="-8" y2="0" />
+              <line x1="-3.5" y1="-3.5" x2="-5.7" y2="-5.7" />
+              <line x1="2.5" y1="-4.3" x2="3.5" y2="-6.5" />
+              <line x1="4.3" y1="-2.5" x2="6.5" y2="-3.5" />
+              <line x1="-2.5" y1="-4.3" x2="-3.5" y2="-6.5" />
+              <line x1="-4.3" y1="-2.5" x2="-6.5" y2="-3.5" />
+            </g>
+            <ellipse cx="0" cy="0" rx="6" ry="4.5" fill="#D2691E" stroke="#8B4513" strokeWidth="0.8" />
+            <circle cx="-4" cy="-1.5" r="5" fill="#DEB887" stroke="#8B4513" strokeWidth="0.8" />
+            <circle cx="-6.5" cy="-4.5" r="1.8" fill="#D2691E" />
+            <circle cx="-1.5" cy="-4.5" r="1.8" fill="#D2691E" />
+            <circle cx="-5.5" cy="-1.5" r="1.2" fill="#fff" />
+            <circle cx="-2.5" cy="-1.5" r="1.2" fill="#fff" />
+            <circle cx="-5.5" cy="-1.5" r="0.8" fill="#000" />
+            <circle cx="-2.5" cy="-1.5" r="0.8" fill="#000" />
+            <ellipse cx="-4" cy="1" rx="0.8" ry="1.2" fill="#000" />
+          </>
+        ) : (
+          <>
+            <ellipse cx="0" cy="0" rx="6" ry="4.5" fill="#D2691E" stroke="#8B4513" strokeWidth="0.8" />
+            <circle cx="-4" cy="-1.5" r="3.5" fill="#DEB887" stroke="#8B4513" strokeWidth="0.8" />
+            <circle cx="-5.5" cy="-3.5" r="1.3" fill="#D2691E" />
+            <circle cx="-2.5" cy="-3.5" r="1.3" fill="#D2691E" />
+            <circle cx="-5" cy="-1.5" r="0.7" fill="#000" />
+            <circle cx="-3" cy="-1.5" r="0.7" fill="#000" />
+            <circle cx="-4.8" cy="-1.8" r="0.3" fill="#fff" />
+            <circle cx="-2.8" cy="-1.8" r="0.3" fill="#fff" />
+            <circle cx="-6.5" cy="-0.5" r="0.4" fill="#8B4513" />
+          </>
+        )}
+        <g>
+          <ellipse cx="-2.5" cy="3.5" rx="1" ry="1.5" fill="#654321" stroke="#3D2611" strokeWidth="0.3" />
+          <ellipse cx="-4" cy="3.5" rx="1" ry="1.5" fill="#654321" stroke="#3D2611" strokeWidth="0.3" />
+          <ellipse cx="1.5" cy="3.5" rx="1" ry="1.5" fill="#654321" stroke="#3D2611" strokeWidth="0.3" />
+          <ellipse cx="3" cy="3.5" rx="1" ry="1.5" fill="#654321" stroke="#3D2611" strokeWidth="0.3" />
+        </g>
+        <path d="M 4.5 0 Q 7 -1.5 8.5 1" stroke="#8B4513" strokeWidth="1.2" fill="none" strokeLinecap="round" />
       </g>
-      <path d="M 4.5 0 Q 7 -1.5 8.5 1" stroke="#8B4513" strokeWidth="1.2" fill="none" strokeLinecap="round" />
     </g>
-  </g>
-);
+  );
+});

--- a/packages/teacher/src/features/widgets/timer/components/TimeDisplay.tsx
+++ b/packages/teacher/src/features/widgets/timer/components/TimeDisplay.tsx
@@ -3,16 +3,28 @@ import { cn, text } from '@shared/utils/styles';
 
 interface TimeDisplayProps {
   time: number;
-  values: string[];
   isEditing: boolean;
   onPause?: () => void;
 }
 
-export const TimeDisplay: React.FC<TimeDisplayProps> = ({ time, values, isEditing, onPause }) => {
+const getDisplayValues = (time: number) => {
+  const hours = Math.floor(time / 3600);
+  const minutes = Math.floor((time % 3600) / 60);
+  const seconds = time % 60;
+
+  return [
+    hours.toString().padStart(2, '0'),
+    minutes.toString().padStart(2, '0'),
+    seconds.toString().padStart(2, '0')
+  ];
+};
+
+export const TimeDisplay: React.FC<TimeDisplayProps> = ({ time, isEditing, onPause }) => {
   if (isEditing) return null;
-  
+
   const baseClasses = cn("leading-none font-bold", text.primary);
-  
+  const values = getDisplayValues(time);
+
   return (
     <div className="flex items-center justify-center w-full h-full cursor-pointer" onClick={onPause}>
       {time >= 3600 ? (

--- a/packages/teacher/src/features/widgets/timer/hooks/useTimeSegmentEditor.ts
+++ b/packages/teacher/src/features/widgets/timer/hooks/useTimeSegmentEditor.ts
@@ -79,16 +79,20 @@ export function useTimeSegmentEditor({
     const hours = Math.floor(totalSeconds / 3600);
     const minutes = Math.floor((totalSeconds % 3600) / 60);
     const seconds = totalSeconds % 60;
-    
+
     const newValues = [
       hours.toString().padStart(2, '0'),
       minutes.toString().padStart(2, '0'),
       seconds.toString().padStart(2, '0')
     ];
-    
+
+    if (newValues.every((value, index) => value === values[index])) {
+      return;
+    }
+
     setValues(newValues);
     setTimeValues([hours, minutes, seconds]);
-  }, []);
+  }, [values]);
 
   return {
     values,

--- a/packages/teacher/src/features/widgets/timer/hooks/useTimerCountdown.ts
+++ b/packages/teacher/src/features/widgets/timer/hooks/useTimerCountdown.ts
@@ -52,10 +52,11 @@ export function useTimerCountdown({ onTimeUp, onTick, restoredState }: UseTimerC
   const [isRunning, setIsRunning] = useState(restored?.isRunning ?? false);
   const [isPaused, setIsPaused] = useState(restored?.isPaused ?? false);
   const [timerFinished, setTimerFinished] = useState(restored?.timerFinished ?? false);
-  const intervalRef = useRef<NodeJS.Timeout | null>(null);
+  const timeoutRef = useRef<NodeJS.Timeout | null>(null);
   const startTimeRef = useRef<number | null>(restored?.isRunning ? Date.now() : null);
   const pausedTimeRef = useRef<number>(restored?.time ?? 0);
   const originalTimeRef = useRef<number>(restored?.originalTime ?? 10);
+  const [scheduleVersion, setScheduleVersion] = useState(0);
   // Track the absolute end time for persistence
   const endTimeRef = useRef<number | null>(
     restored?.isRunning && restored.time > 0 ? Date.now() + restored.time * 1000 : null
@@ -90,44 +91,51 @@ export function useTimerCountdown({ onTimeUp, onTick, restoredState }: UseTimerC
     // Only on mount
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
-  // Handle countdown tick using timestamp-based timing
-  useEffect(() => {
-    if (isRunning && startTimeRef.current !== null) {
-      intervalRef.current = setInterval(() => {
-        const now = Date.now();
-        const elapsed = Math.floor((now - startTimeRef.current!) / 1000);
-        const newTime = Math.max(0, pausedTimeRef.current - elapsed);
 
-        setTime(newTime);
+  const clearScheduledTick = useCallback(() => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+  }, []);
 
-        if (newTime <= 0) {
-          setIsRunning(false);
-          setTimerFinished(true);
-          endTimeRef.current = null;
-          onTimeUpRef.current?.();
-          onTickRef.current?.(0);
-          if (intervalRef.current) {
-            clearInterval(intervalRef.current);
-            intervalRef.current = null;
-          }
-        } else {
-          onTickRef.current?.(newTime);
-        }
-      }, 100); // Check every 100ms for smoother updates
-    } else {
-      if (intervalRef.current) {
-        clearInterval(intervalRef.current);
-        intervalRef.current = null;
-      }
+  const tick = useCallback(() => {
+    const endTime = endTimeRef.current;
+    if (endTime === null) {
+      return;
     }
 
-    return () => {
-      if (intervalRef.current) {
-        clearInterval(intervalRef.current);
-        intervalRef.current = null;
-      }
-    };
-  }, [isRunning]); // Only depend on isRunning
+    const now = Date.now();
+    const newTime = Math.max(0, Math.ceil((endTime - now) / 1000));
+
+    setTime((currentTime) => (currentTime === newTime ? currentTime : newTime));
+
+    if (newTime <= 0) {
+      clearScheduledTick();
+      setIsRunning(false);
+      setTimerFinished(true);
+      endTimeRef.current = null;
+      onTimeUpRef.current?.();
+      onTickRef.current?.(0);
+      return;
+    }
+
+    onTickRef.current?.(newTime);
+
+    const msUntilNextSecond = Math.max(16, endTime - now - (newTime - 1) * 1000);
+    timeoutRef.current = setTimeout(tick, msUntilNextSecond);
+  }, [clearScheduledTick]);
+
+  // Handle countdown tick only when the visible second changes.
+  useEffect(() => {
+    clearScheduledTick();
+
+    if (isRunning && endTimeRef.current !== null) {
+      tick();
+    }
+
+    return clearScheduledTick;
+  }, [clearScheduledTick, isRunning, scheduleVersion, tick]);
 
   const startTimer = useCallback((totalSeconds: number, updateOriginal: boolean = true) => {
     setInitialTime(totalSeconds);
@@ -138,6 +146,7 @@ export function useTimerCountdown({ onTimeUp, onTick, restoredState }: UseTimerC
     startTimeRef.current = Date.now();
     pausedTimeRef.current = totalSeconds;
     endTimeRef.current = Date.now() + totalSeconds * 1000;
+    setScheduleVersion((version) => version + 1);
     // Only update the original time on the very first start, not on resume with edits
     if (updateOriginal) {
       originalTimeRef.current = totalSeconds;
@@ -145,13 +154,14 @@ export function useTimerCountdown({ onTimeUp, onTick, restoredState }: UseTimerC
   }, []);
 
   const pauseTimer = useCallback(() => {
+    clearScheduledTick();
     setIsRunning(false);
     setIsPaused(true);
     // Store the current time when pausing
     pausedTimeRef.current = time;
     startTimeRef.current = null;
     endTimeRef.current = null;
-  }, [time]);
+  }, [clearScheduledTick, time]);
 
   const resumeTimer = useCallback(() => {
     if (time > 0) {
@@ -161,6 +171,7 @@ export function useTimerCountdown({ onTimeUp, onTick, restoredState }: UseTimerC
       startTimeRef.current = Date.now();
       pausedTimeRef.current = time;
       endTimeRef.current = Date.now() + time * 1000;
+      setScheduleVersion((version) => version + 1);
     }
   }, [time]);
 
@@ -178,6 +189,7 @@ export function useTimerCountdown({ onTimeUp, onTick, restoredState }: UseTimerC
   }, []);
 
   const resetTimer = useCallback((newInitialTime: number) => {
+    clearScheduledTick();
     setInitialTime(newInitialTime);
     setTime(newInitialTime);
     setIsRunning(false);
@@ -187,7 +199,7 @@ export function useTimerCountdown({ onTimeUp, onTick, restoredState }: UseTimerC
     pausedTimeRef.current = newInitialTime;
     originalTimeRef.current = newInitialTime;
     endTimeRef.current = null;
-  }, []);
+  }, [clearScheduledTick]);
 
   const adjustTime = useCallback((deltaSeconds: number) => {
     const safeDelta = Math.max(0, Math.floor(deltaSeconds));
@@ -205,6 +217,7 @@ export function useTimerCountdown({ onTimeUp, onTick, restoredState }: UseTimerC
 
       setTime(nextTime);
       setInitialTime(prev => prev + safeDelta);
+      setScheduleVersion((version) => version + 1);
       onTickRef.current?.(nextTime);
       return;
     }
@@ -230,8 +243,8 @@ export function useTimerCountdown({ onTimeUp, onTick, restoredState }: UseTimerC
     originalTime: originalTimeRef.current,
     isRunning,
     isPaused,
-    pausedTimeRemaining: isPaused ? time : pausedTimeRef.current,
-  }), [initialTime, isRunning, isPaused, time]);
+    pausedTimeRemaining: pausedTimeRef.current,
+  }), [initialTime, isRunning, isPaused]);
 
   return {
     time,

--- a/packages/teacher/src/features/widgets/timer/timer.test.tsx
+++ b/packages/teacher/src/features/widgets/timer/timer.test.tsx
@@ -20,6 +20,9 @@ Object.defineProperty(globalThis, 'localStorage', {
 
 vi.mock('./timer-end-2.wav', () => ({ default: 'timer-end-2.wav' }));
 vi.mock('./timer-end-3.mp3', () => ({ default: 'timer-end-3.mp3' }));
+vi.mock('./components/HamsterAnimation', () => ({
+  HamsterAnimation: () => null
+}));
 
 global.HTMLMediaElement.prototype.play = vi.fn(() => Promise.resolve());
 global.HTMLMediaElement.prototype.pause = vi.fn();
@@ -248,6 +251,26 @@ describe('Timer Widget', () => {
 
     expect(getByExactText('00:05:10')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /start/i })).toBeInTheDocument();
+  });
+
+  test('does not persist timer state on every countdown tick while running', () => {
+    const onStateChange = vi.fn();
+
+    renderWithModal(<Timer onStateChange={onStateChange} />);
+
+    onStateChange.mockClear();
+
+    fireEvent.click(screen.getByRole('button', { name: /start/i }));
+
+    expect(onStateChange).toHaveBeenCalledTimes(1);
+
+    onStateChange.mockClear();
+
+    act(() => {
+      vi.advanceTimersByTime(3200);
+    });
+
+    expect(onStateChange).not.toHaveBeenCalled();
   });
 
   test('hides quick-add controls after the timer finishes and still plays audio', () => {

--- a/packages/teacher/src/features/widgets/timer/timer.tsx
+++ b/packages/teacher/src/features/widgets/timer/timer.tsx
@@ -4,7 +4,6 @@ import { FaVolumeXmark, FaVolumeLow, FaVolumeHigh } from 'react-icons/fa6';
 import { 
   useTimeSegmentEditor, 
   useTimerCountdown, 
-  useTimerAnimation, 
   useTimerAudio 
 } from "./hooks";
 import { cn, widgetWrapper, widgetContainer, text, transitions, backgrounds, buttons } from '@shared/utils/styles';
@@ -96,6 +95,7 @@ const Timer: React.FC<TimerProps> = ({ savedState, onStateChange }) => {
 
   // Persist timer state for recovery across remounts.
   const {
+    initialTime,
     time,
     isRunning,
     isPaused,
@@ -127,7 +127,7 @@ const Timer: React.FC<TimerProps> = ({ savedState, onStateChange }) => {
       soundMode,
       segmentValues: segmentEditor.values,
     });
-  }, [onStateChange, getPersistedState, soundMode, segmentEditor.values]);
+  }, [onStateChange, getPersistedState, initialTime, isRunning, isPaused, soundMode, segmentEditor.values, timerFinished]);
   React.useEffect(() => {
     if (timerFinished) {
       setShowJitter(true);
@@ -145,17 +145,15 @@ const Timer: React.FC<TimerProps> = ({ savedState, onStateChange }) => {
   const lastSyncedTimeRef = useRef(time);
 
   React.useEffect(() => {
-    if (segmentEditor.editingSegment === null && time !== lastSyncedTimeRef.current) {
+    if (!isRunning && segmentEditor.editingSegment === null && time !== lastSyncedTimeRef.current) {
       segmentEditor.updateFromTime(time);
+      lastSyncedTimeRef.current = time;
     }
 
-    lastSyncedTimeRef.current = time;
-  }, [time, segmentEditor.editingSegment, segmentEditor.updateFromTime]);
-
-  const { pulseAngle, isHamsterOnColoredArc } = useTimerAnimation({
-    isRunning,
-    progress
-  });
+    if (!isRunning) {
+      lastSyncedTimeRef.current = time;
+    }
+  }, [isRunning, time, segmentEditor.editingSegment, segmentEditor.updateFromTime]);
 
   const handleTargetTimeChange = useCallback(<K extends keyof ClockTimeSelection>(field: K, value: ClockTimeSelection[K]) => {
     setTargetTime(prev => ({
@@ -368,7 +366,7 @@ const Timer: React.FC<TimerProps> = ({ savedState, onStateChange }) => {
               />
 
               {isRunning && time > 0 && (
-                <HamsterAnimation pulseAngle={pulseAngle} isOnColoredArc={isHamsterOnColoredArc} />
+                <HamsterAnimation isRunning={isRunning} progress={progress} />
               )}
             </svg>
 
@@ -390,7 +388,6 @@ const Timer: React.FC<TimerProps> = ({ savedState, onStateChange }) => {
               ) : isRunning && !inEditMode ? (
                 <TimeDisplay
                   time={time}
-                  values={segmentEditor.values}
                   isEditing={false}
                   onPause={pauseTimer}
                 />


### PR DESCRIPTION
## Summary
- replace the timer's 100ms polling loop with second-aligned scheduling so countdown updates only run when the visible second changes
- stop persisting timer widget state on every countdown tick and only persist on meaningful timer state transitions
- isolate the hamster animation from the main timer component and derive the running display directly from `time`
- add a regression test to guard against per-tick persistence churn

## Testing
- `npm run test -w @classroom-widgets/teacher -- timer`
- `npm run build -w @classroom-widgets/teacher`

## Performance Evidence
- browser storage instrumentation previously showed a steady stream of timer-related `localStorage.setItem` calls while the countdown was running; after this change the writes are clustered around start/resume and finish instead of repeating every second
- the follow-up browser trace reduced `useTimerCountdown` callback executions from 100 in the earlier capture to 12 in the post-fix capture, which matches the move away from sub-second polling
