### PR TITLE
refactor: remove redundant derived effects and polling

### DIFF
--- a/packages/shared/constants/events.ts
+++ b/packages/shared/constants/events.ts
@@ -1,0 +1,5 @@
+/**
+ * Shared event names for cross-component communication
+ */
+
+export const STICKER_MODE_CHANGE_EVENT = 'sticker-mode-change';

--- a/packages/student/App.tsx
+++ b/packages/student/App.tsx
@@ -470,7 +470,7 @@ const App: React.FC = () => {
           onJoin={handleJoin}
           onLeaveSession={handleLeaveSession}
           currentSessionCode={currentSessionCode}
-          defaultName={studentName}
+          name={studentName}
           onNameChange={setStudentName}
           isDarkMode={isDarkMode}
           onToggleDarkMode={toggleDarkMode}

--- a/packages/student/components/HandoutActivity.tsx
+++ b/packages/student/components/HandoutActivity.tsx
@@ -31,16 +31,6 @@ const HandoutActivity: React.FC<HandoutActivityProps> = ({
   const [isActive, setIsActive] = useState(initialIsActive);
   const [copiedId, setCopiedId] = useState<string | null>(null);
 
-  // Update isActive when prop changes
-  useEffect(() => {
-    setIsActive(initialIsActive);
-  }, [initialIsActive]);
-
-  // Update items when prop changes
-  useEffect(() => {
-    setItems(initialItems);
-  }, [initialItems]);
-
   // Listen for room state changes using shared hook
   useWidgetStateChange({
     socket,

--- a/packages/student/components/JoinForm.tsx
+++ b/packages/student/components/JoinForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { FaSun, FaMoon, FaTriangleExclamation } from 'react-icons/fa6';
 import { isValidSessionCode, sanitizeStudentName } from '@shared/utils/validation';
 
@@ -6,8 +6,8 @@ interface JoinFormProps {
   onJoin: (code: string, name: string) => Promise<void>;
   onLeaveSession?: () => void;
   currentSessionCode?: string;
-  defaultName?: string;
-  onNameChange?: (name: string) => void;
+  name: string;
+  onNameChange: (name: string) => void;
   isDarkMode?: boolean;
   onToggleDarkMode?: () => void;
   isCompact?: boolean;
@@ -15,16 +15,10 @@ interface JoinFormProps {
   isRecovering?: boolean;
 }
 
-const JoinForm: React.FC<JoinFormProps> = ({ onJoin, onLeaveSession, currentSessionCode, defaultName = '', onNameChange, isDarkMode, onToggleDarkMode, isCompact = false, isConnected = false, isRecovering = false }) => {
+const JoinForm: React.FC<JoinFormProps> = ({ onJoin, onLeaveSession, currentSessionCode, name, onNameChange, isDarkMode, onToggleDarkMode, isCompact = false, isConnected = false, isRecovering = false }) => {
   const [code, setCode] = useState('');
-  const [name, setName] = useState(defaultName);
   const [error, setError] = useState('');
   const [isLoading, setIsLoading] = useState(false);
-
-  // Update local name when defaultName changes
-  useEffect(() => {
-    setName(defaultName);
-  }, [defaultName]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -50,7 +44,7 @@ const JoinForm: React.FC<JoinFormProps> = ({ onJoin, onLeaveSession, currentSess
       return;
     }
 
-    // Name is now optional, use default if empty
+    // Name is optional, sanitise whatever is currently in the controlled field
     const finalName = sanitizeStudentName(name);
 
     setIsLoading(true);
@@ -58,10 +52,8 @@ const JoinForm: React.FC<JoinFormProps> = ({ onJoin, onLeaveSession, currentSess
       await onJoin(code, finalName);
       // Clear the code field on success but keep the name
       setCode('');
-      // Update parent's name state
-      if (onNameChange) {
-        onNameChange(finalName);
-      }
+      // Keep the controlled value in sync with the sanitised submission
+      onNameChange(finalName);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Connection error');
     } finally {
@@ -89,11 +81,7 @@ const JoinForm: React.FC<JoinFormProps> = ({ onJoin, onLeaveSession, currentSess
 
   const handleNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value;
-    setName(value);
-    // Update parent immediately
-    if (onNameChange) {
-      onNameChange(value);
-    }
+    onNameChange(value);
     // Clear error when user starts typing
     if (error) setError('');
   };

--- a/packages/student/components/LinkShareActivity.tsx
+++ b/packages/student/components/LinkShareActivity.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { Socket } from 'socket.io-client';
 import { useWidgetStateChange } from '../hooks/useWidgetStateChange';
 
@@ -77,16 +77,6 @@ const LinkShareActivity: React.FC<LinkShareActivityProps> = ({
   const [submissionCount, setSubmissionCount] = useState(0);
   const [isActive, setIsActive] = useState(initialIsActive);
   const [acceptMode, setAcceptMode] = useState<'links' | 'all'>(initialAcceptMode);
-
-  // Update isActive when prop changes
-  useEffect(() => {
-    setIsActive(initialIsActive);
-  }, [initialIsActive]);
-
-  // Update acceptMode when prop changes
-  useEffect(() => {
-    setAcceptMode(initialAcceptMode);
-  }, [initialAcceptMode]);
 
   // Listen for room state changes using shared hook
   useWidgetStateChange({

--- a/packages/student/components/QuestionsActivity.tsx
+++ b/packages/student/components/QuestionsActivity.tsx
@@ -34,13 +34,6 @@ const QuestionsActivity: React.FC<QuestionsActivityProps> = ({
   const [error, setError] = useState('');
   const [showSuccess, setShowSuccess] = useState(false);
 
-  // Update isActive when prop changes
-  useEffect(() => {
-    if (initialIsActive !== undefined) {
-      setIsActive(initialIsActive);
-    }
-  }, [initialIsActive]);
-
   // Listen for widget state changes using shared hook
   useWidgetStateChange({
     socket,

--- a/packages/student/components/RTFeedbackActivity.tsx
+++ b/packages/student/components/RTFeedbackActivity.tsx
@@ -17,13 +17,6 @@ const RTFeedbackActivity: React.FC<RTFeedbackActivityProps> = ({ socket, roomCod
   const [isSending, setIsSending] = useState(false);
   const [isActive, setIsActive] = useState<boolean>(initialIsActive ?? true); // Use initial state if provided
 
-  // Update isActive when prop changes
-  useEffect(() => {
-    if (initialIsActive !== undefined) {
-      setIsActive(initialIsActive);
-    }
-  }, [initialIsActive]);
-
   // Listen for room state changes using shared hook
   useWidgetStateChange({
     socket,

--- a/packages/teacher/src/app/App.tsx
+++ b/packages/teacher/src/app/App.tsx
@@ -7,6 +7,7 @@ import { SocketProvider } from '../contexts/SocketProvider';
 import { SessionProvider } from '../contexts/SessionContext';
 import { useWorkspace, useServerConnection } from '@shared/hooks/useWorkspace';
 import { MIN_SCREEN_WIDTH, NARROW_SCREEN_WIDTH } from '@shared/constants/screenConstants';
+import { STICKER_MODE_CHANGE_EVENT } from '@shared/constants/events';
 import { useWorkspaceStore } from '../store/workspaceStore.simple';
 import { migrateFromOldFormat } from '@shared/utils/migration';
 import Board from '../features/board/components';
@@ -29,7 +30,6 @@ import { ConfettiProvider } from '../contexts/ConfettiContext';
 import trashSound from '../sounds/trash-crumple.mp3';
 const trashAudio = new Audio(trashSound);
 
-const STICKER_MODE_CHANGE_EVENT = 'sticker-mode-change';
 
 
 

--- a/packages/teacher/src/app/App.tsx
+++ b/packages/teacher/src/app/App.tsx
@@ -29,6 +29,8 @@ import { ConfettiProvider } from '../contexts/ConfettiContext';
 import trashSound from '../sounds/trash-crumple.mp3';
 const trashAudio = new Audio(trashSound);
 
+const STICKER_MODE_CHANGE_EVENT = 'sticker-mode-change';
+
 
 
 function App() {
@@ -50,6 +52,7 @@ function App() {
     typeof window !== 'undefined' ? window.innerWidth < NARROW_SCREEN_WIDTH : false
   );
   const layoutBeforeNarrowRef = useRef<'canvas' | 'column' | null>(null);
+  const stickerStateRef = useRef<{ mode: boolean; type: string | null }>({ mode: false, type: null });
   const [isInitialized, setIsInitialized] = React.useState(false);
   const [stickerMode, setStickerMode] = useState(false);
   const [selectedStickerType, setSelectedStickerType] = useState<string | null>(null);
@@ -78,6 +81,18 @@ function App() {
   useEffect(() => {
     document.documentElement.classList.toggle('dark', theme === 'dark');
   }, [theme]);
+
+  const updateStickerMode = useCallback((mode: boolean, type?: string | null) => {
+    const nextType = mode ? (type ?? stickerStateRef.current.type) : null;
+
+    stickerStateRef.current = { mode, type: nextType };
+    setStickerMode(mode);
+    setSelectedStickerType(nextType);
+
+    window.dispatchEvent(new CustomEvent(STICKER_MODE_CHANGE_EVENT, {
+      detail: { mode, type: nextType }
+    }));
+  }, []);
   
   // Check screen size
   useEffect(() => {
@@ -108,10 +123,9 @@ function App() {
   // Disable sticker mode when switching to column layout
   useEffect(() => {
     if (layoutFormat === 'column' && stickerMode) {
-      setStickerMode(false);
-      setSelectedStickerType(null);
+      updateStickerMode(false);
     }
-  }, [layoutFormat, stickerMode]);
+  }, [layoutFormat, stickerMode, updateStickerMode]);
 
   // Trash sound effect
   useEffect(() => {
@@ -146,8 +160,7 @@ function App() {
       // Exit sticker mode with S or Escape key
       if (stickerMode && (e.key.toLowerCase() === 's' || e.key === 'Escape')) {
         e.preventDefault();
-        setStickerMode(false);
-        setSelectedStickerType(null);
+        updateStickerMode(false);
         return;
       }
 
@@ -199,7 +212,7 @@ function App() {
         clearTimeout(voiceTimeout);
       }
     };
-  }, [stickerMode, lastCommandPress, voiceTimeout, voiceControlEnabled]);
+  }, [stickerMode, lastCommandPress, voiceTimeout, voiceControlEnabled, updateStickerMode]);
 
   // Global paste handler for creating widgets from clipboard content
   useEffect(() => {
@@ -464,30 +477,25 @@ function App() {
       updateWidgetState(widgetId, { stickerType: selectedStickerType });
       
       // Exit sticker mode after placing
-      setStickerMode(false);
-      setSelectedStickerType(null);
+      updateStickerMode(false);
     }
   };
 
   // Make sticker mode functions available globally for toolbar
   useEffect(() => {
     (window as any).setStickerMode = (mode: boolean, type?: string) => {
-      setStickerMode(mode);
-      if (type) {
-        setSelectedStickerType(type);
-      } else if (!mode) {
-        setSelectedStickerType(null);
-      }
+      updateStickerMode(mode, type);
     };
 
-    // Also expose a getter for the toolbar to check state
-    (window as any).getStickerMode = () => stickerMode;
+    (window as any).getStickerState = () => stickerStateRef.current;
+    (window as any).getStickerMode = () => stickerStateRef.current.mode;
 
     return () => {
       delete (window as any).setStickerMode;
+      delete (window as any).getStickerState;
       delete (window as any).getStickerMode;
     };
-  }, [stickerMode]);
+  }, [updateStickerMode]);
 
   // Make voice control functions available globally for toolbar
   useEffect(() => {
@@ -537,8 +545,7 @@ function App() {
                 </div>
                 <button
                   onClick={() => {
-                    setStickerMode(false);
-                    setSelectedStickerType(null);
+                    updateStickerMode(false);
                   }}
                   className="ml-2 text-amber-200 hover:text-white transition-colors"
                   title="Exit sticker mode"

--- a/packages/teacher/src/features/hud/components/BottomBar.tsx
+++ b/packages/teacher/src/features/hud/components/BottomBar.tsx
@@ -29,35 +29,49 @@ const defaultRecentWidgets = [
   WidgetType.TRAFFIC_LIGHT
 ];
 
+const STICKER_MODE_CHANGE_EVENT = 'sticker-mode-change';
+
+const getStickerState = () => {
+  const state = (window as any).getStickerState?.();
+
+  return {
+    mode: state?.mode ?? false,
+    type: state?.type ?? ''
+  };
+};
+
 const BottomBar: React.FC = () => {
   const { recentWidgets, voiceControlEnabled } = useBottomBar();
   const createWidget = useCreateWidget();
   const { showModal, hideModal } = useModal();
   const [showMenu, setShowMenu] = useState(false);
-  const [stickerMode, setStickerMode] = useState(false);
-  const [selectedStickerType, setSelectedStickerType] = useState<string>('');
+  const [{ mode: stickerMode, type: selectedStickerType }, setStickerState] = useState(getStickerState);
   const isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0;
   const { isNear, registerHudElement } = useHudProximityContext();
+
+  const setSelectedStickerType = (type: string) => {
+    setStickerState((current) => ({
+      ...current,
+      type
+    }));
+  };
 
   // Ref callback for registering bottom HUD region
   const bottomRef = React.useCallback((node: HTMLDivElement | null) => {
     registerHudElement('bottom', node);
   }, [registerHudElement]);
 
-  // Sync with global sticker mode state
+  // Sync with sticker mode updates from App
   useEffect(() => {
-    const checkStickerMode = () => {
-      const globalStickerMode = (window as any).getStickerMode?.();
-      if (globalStickerMode !== undefined && globalStickerMode !== stickerMode) {
-        setStickerMode(globalStickerMode);
-      }
+    const syncStickerState = () => {
+      setStickerState(getStickerState());
     };
 
-    // Check periodically for state changes
-    const interval = setInterval(checkStickerMode, 100);
+    syncStickerState();
+    window.addEventListener(STICKER_MODE_CHANGE_EVENT, syncStickerState);
 
-    return () => clearInterval(interval);
-  }, [stickerMode]);
+    return () => window.removeEventListener(STICKER_MODE_CHANGE_EVENT, syncStickerState);
+  }, []);
 
   // Add keyboard shortcut for debug launch all (only in development)
   useEffect(() => {
@@ -104,10 +118,8 @@ const BottomBar: React.FC = () => {
         <StickerPalette
           selectedStickerType={selectedStickerType}
           setSelectedStickerType={setSelectedStickerType}
-          setStickerMode={(mode) => {
-            setStickerMode(mode);
-            // Always pass the current selectedStickerType to the global function
-            (window as any).setStickerMode?.(mode, selectedStickerType);
+          setStickerMode={(mode, type) => {
+            (window as any).setStickerMode?.(mode, type ?? selectedStickerType);
           }}
           stickerMode={stickerMode}
           onClose={hideModal}

--- a/packages/teacher/src/features/hud/components/BottomBar.tsx
+++ b/packages/teacher/src/features/hud/components/BottomBar.tsx
@@ -19,6 +19,7 @@ import LaunchpadIcon from './LaunchpadIcon';
 import { useWorkspaceStore } from '../../../store/workspaceStore.simple';
 import { useHudProximityContext } from '@shared/hooks/useHudProximity';
 import { hudProximity } from '@shared/utils/styles';
+import { STICKER_MODE_CHANGE_EVENT } from '@shared/constants/events';
 
 // Default recent widgets if none are set
 const defaultRecentWidgets = [
@@ -28,8 +29,6 @@ const defaultRecentWidgets = [
   WidgetType.TASK_CUE,
   WidgetType.TRAFFIC_LIGHT
 ];
-
-const STICKER_MODE_CHANGE_EVENT = 'sticker-mode-change';
 
 const getStickerState = () => {
   const state = (window as any).getStickerState?.();

--- a/packages/teacher/src/features/hud/components/Clock.tsx
+++ b/packages/teacher/src/features/hud/components/Clock.tsx
@@ -94,10 +94,7 @@ const Clock: React.FC = () => {
     return 'text-warm-gray-600 dark:text-warm-gray-300';
   };
 
-  // Initialize picker with current end time when dropdown opens
-  useEffect(() => {
-    if (!isDropdownOpen) return;
-
+  const openDropdown = () => {
     if (endTime) {
       const hours = endTime.getHours();
       setSelectedHour(hours % 12 || 12);
@@ -113,8 +110,9 @@ const Clock: React.FC = () => {
       setSelectedMinute(0);
       setSelectedPeriod(hours >= 12 ? 'PM' : 'AM');
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isDropdownOpen]); // Only run when dropdown opens, not on every time tick
+
+    setIsDropdownOpen(true);
+  };
 
   // Set end time from picker
   const handleSetTime = () => {
@@ -204,7 +202,14 @@ const Clock: React.FC = () => {
     <div ref={dropdownRef} className="relative">
       {/* Clock Display - Clickable */}
       <button
-        onClick={() => setIsDropdownOpen(!isDropdownOpen)}
+        onClick={() => {
+          if (isDropdownOpen) {
+            setIsDropdownOpen(false);
+            return;
+          }
+
+          openDropdown();
+        }}
         className={clsx(
           'flex items-center gap-2 font-mono tabular-nums transition-colors duration-300',
           colorClass

--- a/packages/teacher/src/features/hud/components/StickerPalette.tsx
+++ b/packages/teacher/src/features/hud/components/StickerPalette.tsx
@@ -13,7 +13,7 @@ import {
 interface StickerPaletteProps {
   selectedStickerType: string;
   setSelectedStickerType: (type: string) => void;
-  setStickerMode: (mode: boolean) => void;
+  setStickerMode: (mode: boolean, type?: string) => void;
   stickerMode: boolean;
   onClose?: () => void;
 }
@@ -52,9 +52,7 @@ const StickerPalette: React.FC<StickerPaletteProps> = ({
             key={type}
             onClick={() => {
               setSelectedStickerType(type);
-              setStickerMode(true);
-              // Also set the global sticker mode with the type
-              (window as any).setStickerMode?.(true, type);
+              setStickerMode(true, type);
               if (onClose) onClose();
             }}
             className={`group relative flex items-center justify-center p-4 rounded-xl transition-all duration-300 transform hover:scale-110 ${

--- a/packages/teacher/src/features/hud/components/WidgetLaunchpad.tsx
+++ b/packages/teacher/src/features/hud/components/WidgetLaunchpad.tsx
@@ -21,7 +21,6 @@ const categoryTitles: Record<WidgetCategory, string> = {
 const WidgetLaunchpad: React.FC<WidgetLaunchpadProps> = ({ onClose, onSelectWidget }) => {
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedCategory, setSelectedCategory] = useState<WidgetCategory | null>(null);
-  const [highlightedIndex, setHighlightedIndex] = useState<number>(-1);
   const searchInputRef = useRef<HTMLInputElement>(null);
   const widgetRefs = useRef<(HTMLButtonElement | null)[]>([]);
   const { connected: serverConnected } = useServerConnection();
@@ -72,15 +71,8 @@ const WidgetLaunchpad: React.FC<WidgetLaunchpadProps> = ({ onClose, onSelectWidg
       return true;
     });
   }, [searchQuery, selectedCategory]);
-  
-  // Highlight single widget without focusing
-  useEffect(() => {
-    if (filteredWidgets.length === 1) {
-      setHighlightedIndex(0);
-    } else {
-      setHighlightedIndex(-1);
-    }
-  }, [filteredWidgets]);
+
+  const highlightedIndex = filteredWidgets.length === 1 ? 0 : -1;
   
   // Group widgets by category
   const widgetsByCategory = useMemo(() => {

--- a/packages/teacher/src/features/session/components/SessionBanner/index.tsx
+++ b/packages/teacher/src/features/session/components/SessionBanner/index.tsx
@@ -31,6 +31,7 @@ const ActiveSessionBanner: React.FC<ActiveSessionBannerProps> = ({
   const [isExpanded, setIsExpanded] = useState(true);
   const [isReconnecting, setIsReconnecting] = useState(false);
   const sessionIslandRef = useRef<HTMLDivElement>(null);
+  const reconnectTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Auto-expand when disconnected to show status
   useEffect(() => {
@@ -39,6 +40,15 @@ const ActiveSessionBanner: React.FC<ActiveSessionBannerProps> = ({
     }
   }, [connected]);
 
+  // Clear timeout on unmount
+  useEffect(() => {
+    return () => {
+      if (reconnectTimeoutRef.current) {
+        clearTimeout(reconnectTimeoutRef.current);
+      }
+    };
+  }, []);
+
   // Handle reconnection attempt
   const handleReconnect = React.useCallback(() => {
     if (!connected && socket && !socket.connected) {
@@ -46,7 +56,7 @@ const ActiveSessionBanner: React.FC<ActiveSessionBannerProps> = ({
       socket.connect();
 
       // Reset reconnecting state after a timeout
-      setTimeout(() => {
+      reconnectTimeoutRef.current = setTimeout(() => {
         setIsReconnecting(false);
       }, 3000);
     }

--- a/packages/teacher/src/features/session/components/SessionBanner/index.tsx
+++ b/packages/teacher/src/features/session/components/SessionBanner/index.tsx
@@ -52,20 +52,30 @@ const ActiveSessionBanner: React.FC<ActiveSessionBannerProps> = ({
   // Handle reconnection attempt
   const handleReconnect = React.useCallback(() => {
     if (!connected && socket && !socket.connected) {
+      // Clear any existing timeout before creating a new one
+      if (reconnectTimeoutRef.current) {
+        clearTimeout(reconnectTimeoutRef.current);
+      }
+
       setIsReconnecting(true);
       socket.connect();
 
       // Reset reconnecting state after a timeout
       reconnectTimeoutRef.current = setTimeout(() => {
         setIsReconnecting(false);
+        reconnectTimeoutRef.current = null;
       }, 3000);
     }
   }, [connected, socket]);
 
-  // Reset reconnecting state when connection status changes
+  // Reset reconnecting state and clear timeout when connection status changes
   useEffect(() => {
     if (connected) {
       setIsReconnecting(false);
+      if (reconnectTimeoutRef.current) {
+        clearTimeout(reconnectTimeoutRef.current);
+        reconnectTimeoutRef.current = null;
+      }
     }
   }, [connected]);
 

--- a/packages/teacher/src/features/session/components/SessionBanner/index.tsx
+++ b/packages/teacher/src/features/session/components/SessionBanner/index.tsx
@@ -11,48 +11,46 @@ interface SessionBannerProps {
   className?: string;
 }
 
-const SessionBanner: React.FC<SessionBannerProps> = ({
-  className = ''
-}) => {
-  const session = useSession();
-  const { sessionCode, isConnected: connected, closeSession: onClose, serverUrl, studentAppUrl } = session;
+interface ActiveSessionBannerProps {
+  className: string;
+  connected: boolean;
+  displayUrl?: string;
+  onClose: () => void;
+  sessionCode: string;
+  socket: ReturnType<typeof useSession>['socket'];
+}
 
-  // Use studentAppUrl if available (provided by server), fall back to serverUrl
-  const displayUrl = studentAppUrl || serverUrl;
-  const [isExpanded, setIsExpanded] = useState(false);
+const ActiveSessionBanner: React.FC<ActiveSessionBannerProps> = ({
+  className,
+  connected,
+  displayUrl,
+  onClose,
+  sessionCode,
+  socket
+}) => {
+  const [isExpanded, setIsExpanded] = useState(true);
   const [isReconnecting, setIsReconnecting] = useState(false);
   const sessionIslandRef = useRef<HTMLDivElement>(null);
 
-  // Auto-expand when session starts or when disconnected
-  useEffect(() => {
-    if (sessionCode && !isExpanded) {
-      setIsExpanded(true);
-    } else if (!sessionCode) {
-      setIsExpanded(false);
-    }
-  }, [sessionCode]);
-
   // Auto-expand when disconnected to show status
   useEffect(() => {
-    if (!connected && sessionCode) {
+    if (!connected) {
       setIsExpanded(true);
     }
-  }, [connected, sessionCode]);
+  }, [connected]);
 
   // Handle reconnection attempt
   const handleReconnect = React.useCallback(() => {
-    if (!connected && sessionCode) {
-      if (session.socket && !session.socket.connected) {
-        setIsReconnecting(true);
-        session.socket.connect();
+    if (!connected && socket && !socket.connected) {
+      setIsReconnecting(true);
+      socket.connect();
 
-        // Reset reconnecting state after a timeout
-        setTimeout(() => {
-          setIsReconnecting(false);
-        }, 3000);
-      }
+      // Reset reconnecting state after a timeout
+      setTimeout(() => {
+        setIsReconnecting(false);
+      }, 3000);
     }
-  }, [connected, sessionCode, session.socket]);
+  }, [connected, socket]);
 
   // Reset reconnecting state when connection status changes
   useEffect(() => {
@@ -64,14 +62,12 @@ const SessionBanner: React.FC<SessionBannerProps> = ({
   const handleCloseSession = (e: React.MouseEvent) => {
     e.stopPropagation();
     if (window.confirm('Are you sure you want to close this session? All students will be disconnected.')) {
-      if (session.socket && sessionCode) {
-        session.socket.emit('session:close', { sessionCode });
+      if (socket) {
+        socket.emit('session:close', { sessionCode });
       }
       onClose();
     }
   };
-
-  if (!sessionCode) return null;
 
   // Use consistent styling with other HUD elements
   // Base: bg-soft-white/80, backdrop-blur-sm, shadow-md
@@ -148,6 +144,29 @@ const SessionBanner: React.FC<SessionBannerProps> = ({
         </div>
       </div>
     </div>
+  );
+};
+
+const SessionBanner: React.FC<SessionBannerProps> = ({
+  className = ''
+}) => {
+  const session = useSession();
+  const { sessionCode, isConnected: connected, closeSession: onClose, serverUrl, studentAppUrl } = session;
+
+  // Use studentAppUrl if available (provided by server), fall back to serverUrl
+  const displayUrl = studentAppUrl || serverUrl;
+  if (!sessionCode) return null;
+
+  return (
+    <ActiveSessionBanner
+      key={sessionCode}
+      className={className}
+      connected={connected}
+      displayUrl={displayUrl}
+      onClose={onClose}
+      sessionCode={sessionCode}
+      socket={session.socket}
+    />
   );
 };
 

--- a/packages/teacher/src/features/widgets/randomiser/randomiser.tsx
+++ b/packages/teacher/src/features/widgets/randomiser/randomiser.tsx
@@ -88,6 +88,7 @@ function Randomiser({ savedState, onStateChange }: RandomiserProps) {
             // Update displayChoices to show items immediately if there are active choices
             if (activeChoices.length > 0) {
               setDisplayChoices(activeChoices);
+              setResult("Ready to randomise!");
               // Reset animation state to prepare for next randomisation
               resetAnimation();
               setButtonSettings("normal");
@@ -168,15 +169,6 @@ function Randomiser({ savedState, onStateChange }: RandomiserProps) {
       }
     }
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
-
-  // Update result message when choices change
-  useEffect(() => {
-    if (choices.length > 0 && result === "Enter a list to randomise!") {
-      setResult("Ready to randomise!");
-    } else if (choices.length === 0 && result === "Ready to randomise!") {
-      setResult("Enter a list to randomise!");
-    }
-  }, [choices, result]);
 
   return (
     <div className={widgetWrapper} ref={widgetRef}>

--- a/packages/teacher/src/features/widgets/soundEffects/soundEffects.tsx
+++ b/packages/teacher/src/features/widgets/soundEffects/soundEffects.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useMemo, useCallback } from 'react';
+import React, { useEffect, useRef, useMemo, useCallback } from 'react';
 // @ts-ignore
 import {
   FaTrophy,        // Victory
@@ -39,7 +39,7 @@ interface SoundEffectsProps {
 }
 
 const SoundEffects: React.FC<SoundEffectsProps> = ({ isActive = false }) => {
-  const [audioElements, setAudioElements] = useState<Map<string, HTMLAudioElement>>(new Map());
+  const audioElementsRef = useRef<Map<string, HTMLAudioElement>>(new Map());
 
   // Memoize sound effect definitions to prevent recreation on every render
   const soundButtons: SoundButton[] = useMemo(() => [
@@ -55,37 +55,39 @@ const SoundEffects: React.FC<SoundEffectsProps> = ({ isActive = false }) => {
     { name: 'Applause', icon: FaHandsClapping, color: 'bg-sage-500 hover:bg-sage-600', soundFile: applauseSoundFile },
   ], []);
 
-  // Initialize audio elements when sound files are available
+  const soundFilesByName = useMemo(
+    () => new Map(soundButtons.map(({ name, soundFile }) => [name, soundFile])),
+    [soundButtons]
+  );
+
+  // Release any created audio elements when the widget unmounts
   useEffect(() => {
-    const audioMap = new Map<string, HTMLAudioElement>();
-    
-    soundButtons.forEach(button => {
-      if (button.soundFile) {
-        const audio = new Audio(button.soundFile);
-        audio.preload = 'auto';
-        audioMap.set(button.name, audio);
-      }
-    });
-
-    setAudioElements(audioMap);
-
-    // Cleanup
     return () => {
-      audioMap.forEach(audio => {
+      audioElementsRef.current.forEach(audio => {
         audio.pause();
         audio.src = '';
       });
+      audioElementsRef.current.clear();
     };
-  }, [soundButtons]);
+  }, []);
 
-  // Memoize playSound function to prevent recreation on every render
   const playSound = useCallback((soundName: string) => {
-    // Play the sound if available
-    const audio = audioElements.get(soundName);
+    let audio = audioElementsRef.current.get(soundName);
+
+    if (!audio) {
+      const soundFile = soundFilesByName.get(soundName);
+
+      if (soundFile) {
+        audio = new Audio(soundFile);
+        audio.preload = 'auto';
+        audioElementsRef.current.set(soundName, audio);
+      }
+    }
+
     if (audio) {
       // Reset and play
       audio.currentTime = 0;
-      audio.play().catch(error => {
+      audio.play().catch(() => {
         // Error playing sound - silently fail
       });
     }
@@ -98,7 +100,7 @@ const SoundEffects: React.FC<SoundEffectsProps> = ({ isActive = false }) => {
         button.classList.remove('scale-95');
       }, 100);
     }
-  }, [audioElements]);
+  }, [soundFilesByName]);
 
   // Keyboard shortcuts (1-9 for first 9 sounds, 0 for 10th sound)
   useEffect(() => {

--- a/packages/teacher/src/features/widgets/volumeLevel/hooks/useVolumeAnalyzer.ts
+++ b/packages/teacher/src/features/widgets/volumeLevel/hooks/useVolumeAnalyzer.ts
@@ -2,6 +2,7 @@ import { useState, useRef, useCallback, useEffect } from 'react';
 
 interface UseVolumeAnalyzerOptions {
   isEnabled: boolean;
+  isInCooldown?: boolean;
   threshold: number;
   smoothingSamples?: number;
   updateInterval?: number;
@@ -14,6 +15,7 @@ interface UseVolumeAnalyzerOptions {
  */
 export function useVolumeAnalyzer({
   isEnabled,
+  isInCooldown = false,
   threshold,
   smoothingSamples = 10,
   updateInterval = 100,
@@ -22,13 +24,12 @@ export function useVolumeAnalyzer({
   const [volume, setVolume] = useState(0);
   const volumeHistoryRef = useRef<number[]>([]);
   const dataArrayRef = useRef<Uint8Array | null>(null);
-  const isCooldownRef = useRef(false);
+  const isCooldownRef = useRef(isInCooldown);
   const onThresholdExceededRef = useRef(onThresholdExceeded);
 
-  // Update callback ref
-  useEffect(() => {
-    onThresholdExceededRef.current = onThresholdExceeded;
-  }, [onThresholdExceeded]);
+  // Keep refs current without forcing callback recreation downstream.
+  isCooldownRef.current = isInCooldown;
+  onThresholdExceededRef.current = onThresholdExceeded;
 
   // Reset volume when disabled
   useEffect(() => {
@@ -74,11 +75,6 @@ export function useVolumeAnalyzer({
 
     return averageVolume;
   }, [isEnabled, threshold, smoothingSamples]);
-
-  const setCooldown = useCallback((active: boolean) => {
-    isCooldownRef.current = active;
-  }, []);
-
   const startMonitoring = useCallback((analyser: AnalyserNode) => {
     const intervalId = setInterval(() => {
       analyzeVolume(analyser);
@@ -93,7 +89,6 @@ export function useVolumeAnalyzer({
   return {
     volume,
     normalizedVolume: threshold > 0 ? Math.min(volume / threshold, 1) : 0,
-    startMonitoring,
-    setCooldown
+    startMonitoring
   };
 }

--- a/packages/teacher/src/features/widgets/volumeLevel/hooks/useVolumeAnalyzer.ts
+++ b/packages/teacher/src/features/widgets/volumeLevel/hooks/useVolumeAnalyzer.ts
@@ -28,8 +28,13 @@ export function useVolumeAnalyzer({
   const onThresholdExceededRef = useRef(onThresholdExceeded);
 
   // Keep refs current without forcing callback recreation downstream.
-  isCooldownRef.current = isInCooldown;
-  onThresholdExceededRef.current = onThresholdExceeded;
+  useEffect(() => {
+    isCooldownRef.current = isInCooldown;
+  }, [isInCooldown]);
+
+  useEffect(() => {
+    onThresholdExceededRef.current = onThresholdExceeded;
+  }, [onThresholdExceeded]);
 
   // Reset volume when disabled
   useEffect(() => {

--- a/packages/teacher/src/features/widgets/volumeLevel/volumeLevel.tsx
+++ b/packages/teacher/src/features/widgets/volumeLevel/volumeLevel.tsx
@@ -1,5 +1,5 @@
 // Removed Chakra UI imports
-import React, { useCallback, useEffect } from 'react';
+import React, { useCallback } from 'react';
 // @ts-ignore
 import { FaBell, FaMicrophone } from 'react-icons/fa6';
 import ramBellSoundFile from './Ram-Bell-Sound.mp3';
@@ -52,10 +52,10 @@ const AudioVolumeMonitor: React.FC<AudioVolumeMonitorProps> = ({ savedState, onS
     const { 
         volume, 
         normalizedVolume, 
-        startMonitoring, 
-        setCooldown 
+        startMonitoring
     } = useVolumeAnalyzer({
         isEnabled,
+        isInCooldown,
         threshold,
         smoothingSamples: 10,
         updateInterval: 100,
@@ -65,11 +65,6 @@ const AudioVolumeMonitor: React.FC<AudioVolumeMonitorProps> = ({ savedState, onS
             }
         }
     });
-
-    // Update cooldown state in volume analyzer
-    useEffect(() => {
-        setCooldown(isInCooldown);
-    }, [isInCooldown, setCooldown]);
 
     // Audio stream management
     const { analyser } = useAudioStream({


### PR DESCRIPTION
## Summary
- Remove redundant derived effects for widget state syncs (feedback, handout, link share, questions)
- Remove sticker mode polling in favour of reactive updates
- Lazy load sound effect audio and initialise clock picker on open
- Reset session banner state by session, control student join form name

## Context
These derived effects were duplicating state that's already managed reactively through signals/stores. Removing them reduces complexity and potential sync bugs.

## Test plan
- [ ] Verify all widgets still sync state correctly between teacher and student views
- [ ] Check sticker mode updates without polling
- [ ] Confirm sound effects load and play correctly
- [ ] Verify clock picker initialises properly on open
- [ ] Check session banner resets between sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)