### PR TITLE
Fix the timer dark mode so only the circle is visible

### DIFF
--- a/packages/teacher/src/features/widgets/timer/timer.test.tsx
+++ b/packages/teacher/src/features/widgets/timer/timer.test.tsx
@@ -3,6 +3,8 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { vi } from 'vitest';
 import Timer from './timer';
 import { ModalProvider } from '../../../contexts/ModalContext';
+import { useWorkspaceStore } from '../../../store/workspaceStore.simple';
+import { warmGray } from '@shared/constants/colors';
 
 const localStorageMock = {
   getItem: vi.fn(() => null),
@@ -54,6 +56,7 @@ describe('Timer Widget', () => {
     vi.clearAllMocks();
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-03-11T14:00:00'));
+    useWorkspaceStore.setState({ theme: 'light' });
   });
 
   afterEach(() => {
@@ -73,6 +76,15 @@ describe('Timer Widget', () => {
 
     expect(getByExactText('00:00:10')).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /add 1 minute/i })).not.toBeInTheDocument();
+  });
+
+  test('keeps the outer timer shell transparent in dark mode while filling the circle solid dark', () => {
+    useWorkspaceStore.setState({ theme: 'dark' });
+
+    renderWithModal(<Timer />);
+
+    expect(screen.getByTestId('timer-visual-shell')).toHaveClass('dark:bg-transparent');
+    expect(screen.getByTestId('timer-face')).toHaveAttribute('fill', warmGray[800]);
   });
 
   test('keeps manual time edits after finishing segment editing', () => {

--- a/packages/teacher/src/features/widgets/timer/timer.test.tsx
+++ b/packages/teacher/src/features/widgets/timer/timer.test.tsx
@@ -83,7 +83,10 @@ describe('Timer Widget', () => {
 
     renderWithModal(<Timer />);
 
-    expect(screen.getByTestId('timer-visual-shell')).toHaveClass('dark:bg-transparent');
+    const timerVisualShell = screen.getByTestId('timer-visual-shell');
+
+    expect(timerVisualShell).toHaveClass('dark:bg-transparent');
+    expect(timerVisualShell).not.toHaveClass('dark:bg-warm-gray-800/90');
     expect(screen.getByTestId('timer-face')).toHaveAttribute('fill', warmGray[800]);
   });
 

--- a/packages/teacher/src/features/widgets/timer/timer.tsx
+++ b/packages/teacher/src/features/widgets/timer/timer.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useRef, useState } from "react";
 import { useTheme } from "@shared/hooks/useWorkspace";
+import { warmGray } from '@shared/constants/colors';
 import { FaVolumeXmark, FaVolumeLow, FaVolumeHigh } from 'react-icons/fa6';
 import { 
   useTimeSegmentEditor, 
@@ -242,11 +243,12 @@ const Timer: React.FC<TimerProps> = ({ savedState, onStateChange }) => {
     { label: '+2m', seconds: 120, title: 'Add 2 minutes' },
     { label: '+5m', seconds: 300, title: 'Add 5 minutes' }
   ];
+  const timerFaceFill = isDark ? warmGray[800] : 'rgba(250, 250, 249, 0.9)';
 
   return (
     <div className={widgetWrapper}>
       <div
-        className={cn(widgetContainer, "bg-transparent dark:bg-warm-gray-800/90 border-0 relative")}
+        className={cn(widgetContainer, "bg-transparent dark:bg-transparent border-0 relative")}
         style={{
           containerType: 'size',
           ...(showJitter && {
@@ -257,7 +259,10 @@ const Timer: React.FC<TimerProps> = ({ savedState, onStateChange }) => {
         }}
       >
         <div className="flex-1 min-h-0 flex items-center justify-center relative">
-          <div className="absolute flex h-full w-full items-center justify-center rounded-lg bg-transparent shadow-[0_4px_6px_-1px_rgba(0,0,0,0.1),0_2px_4px_-1px_rgba(0,0,0,0.06)] dark:bg-warm-gray-800/90">
+          <div
+            className="absolute flex h-full w-full items-center justify-center bg-transparent dark:bg-transparent"
+            data-testid="timer-visual-shell"
+          >
             <svg className="h-full w-full pointer-events-none" viewBox="0 0 100 100">
               <defs>
                 <linearGradient id="rainbowGradient" gradientUnits="userSpaceOnUse" x1="50" y1="5" x2="50" y2="95">
@@ -333,8 +338,8 @@ const Timer: React.FC<TimerProps> = ({ savedState, onStateChange }) => {
                 cx="50"
                 cy="50"
                 r="40"
-                fill="rgba(250, 250, 249, 0.9)"
-                className="dark:fill-warm-gray-800/90"
+                fill={timerFaceFill}
+                data-testid="timer-face"
               />
 
               <circle


### PR DESCRIPTION
## What changed
- removed the dark rectangular timer backing in dark mode so the widget presents as just the timer circle
- made the timer face use a solid dark fill inside the circle in dark mode
- added a regression test that asserts the outer shell stays transparent while the timer face remains solid dark

## Why
The timer was rendering dark-mode backgrounds on wrapper elements outside the SVG circle. That produced a solid dark outer window behind the timer instead of a standalone circular timer.

## Impact
Teachers using the timer in dark mode now see the intended circular presentation without the extra dark panel around it.

## Validation
- `npm test -- --run src/features/widgets/timer/timer.test.tsx`
