### PR TITLE
feat: use 5-minute intervals for timer target time

### DIFF
--- a/packages/teacher/src/features/widgets/timer/timer.tsx
+++ b/packages/teacher/src/features/widgets/timer/timer.tsx
@@ -517,7 +517,7 @@ const Timer: React.FC<TimerProps> = ({ savedState, onStateChange }) => {
                       text.primary
                     )}
                   >
-                    {Array.from({ length: 60 }, (_, minute) => (
+                    {Array.from({ length: 12 }, (_, index) => index * 5).map((minute) => (
                       <option key={minute} value={minute}>{minute.toString().padStart(2, '0')}</option>
                     ))}
                   </select>


### PR DESCRIPTION
## Summary
- Change the "Until [time]" minute dropdown in the Timer widget from 1-minute steps to 5-minute steps (00, 05, 10, …, 55).

## Test plan
- [ ] Open the Timer widget, expand the "Until" target-time tray, and confirm the minute dropdown only offers 5-minute increments.
- [ ] Verify the default selection (next :00 or :30) still appears as a valid option.
- [ ] Set a target like 3:15 PM and confirm the countdown is computed correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)