### PR TITLE
feat(text-banner): edit-mode toolbar, fonts, code blocks, resize

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -673,6 +673,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -689,6 +690,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -705,6 +707,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -721,6 +724,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -737,6 +741,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -753,6 +758,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -769,6 +775,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -785,6 +792,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -801,6 +809,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -817,6 +826,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -833,6 +843,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -849,6 +860,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -865,6 +877,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -881,6 +894,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -897,6 +911,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -913,6 +928,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -929,6 +945,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -945,6 +962,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -961,6 +979,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -977,6 +996,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -993,6 +1013,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1009,6 +1030,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1025,6 +1047,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1041,6 +1064,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1057,6 +1081,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1073,6 +1098,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -673,7 +673,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -690,7 +689,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -707,7 +705,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -724,7 +721,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -741,7 +737,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -758,7 +753,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -775,7 +769,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -792,7 +785,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -809,7 +801,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -826,7 +817,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -843,7 +833,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -860,7 +849,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -877,7 +865,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -894,7 +881,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -911,7 +897,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -928,7 +913,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -945,7 +929,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -962,7 +945,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -979,7 +961,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -996,7 +977,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1013,7 +993,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1030,7 +1009,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1047,7 +1025,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1064,7 +1041,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1081,7 +1057,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1098,7 +1073,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -3850,6 +3850,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/highlight.js": {
+      "version": "11.11.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
+      "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/html-encoding-sniffer": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
@@ -7540,6 +7549,7 @@
         "@types/react-dom": "^18.2.25",
         "annyang": "^2.6.1",
         "axios": "^1.11.0",
+        "highlight.js": "^11.11.1",
         "qrcode": "^1.5.4",
         "react": "^18.3.1",
         "react-clock": "^5.0.0",

--- a/packages/teacher/index.html
+++ b/packages/teacher/index.html
@@ -13,7 +13,7 @@
     <link rel="manifest" href="/manifest.json" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&family=Lora:ital,wght@0,400;0,600;1,400&family=Roboto+Slab:wght@400;600&family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet">
     <title>Classroom Widgets</title>
   </head>
   <body>

--- a/packages/teacher/package.json
+++ b/packages/teacher/package.json
@@ -23,6 +23,7 @@
     "@types/react-dom": "^18.2.25",
     "annyang": "^2.6.1",
     "axios": "^1.11.0",
+    "highlight.js": "^11.11.1",
     "qrcode": "^1.5.4",
     "react": "^18.3.1",
     "react-clock": "^5.0.0",

--- a/packages/teacher/src/features/hud/components/BottomBar.tsx
+++ b/packages/teacher/src/features/hud/components/BottomBar.tsx
@@ -109,7 +109,7 @@ const BottomBar: React.FC<BottomBarProps> = ({ onToggleLayout }) => {
           }}
         />
       ),
-      className: 'w-full max-w-4xl mx-4 bg-soft-white dark:bg-warm-gray-800 rounded-lg shadow-xl',
+      className: 'w-[calc(100%-2rem)] max-w-4xl bg-soft-white dark:bg-warm-gray-800 rounded-lg shadow-xl',
       noPadding: true
     });
   };

--- a/packages/teacher/src/features/hud/components/BottomBar.tsx
+++ b/packages/teacher/src/features/hud/components/BottomBar.tsx
@@ -109,7 +109,7 @@ const BottomBar: React.FC<BottomBarProps> = ({ onToggleLayout }) => {
           }}
         />
       ),
-      className: 'max-w-4xl bg-soft-white dark:bg-warm-gray-800 rounded-lg shadow-xl',
+      className: 'w-full max-w-4xl mx-4 bg-soft-white dark:bg-warm-gray-800 rounded-lg shadow-xl',
       noPadding: true
     });
   };

--- a/packages/teacher/src/features/hud/components/WidgetLaunchpad.tsx
+++ b/packages/teacher/src/features/hud/components/WidgetLaunchpad.tsx
@@ -114,7 +114,7 @@ const WidgetLaunchpad: React.FC<WidgetLaunchpadProps> = ({ onClose, onSelectWidg
   return (
     <div className="flex flex-col h-full max-h-[600px] bg-white dark:bg-warm-gray-800 rounded-lg">
       {/* Search and filters section */}
-      <div className="p-6 pb-4">
+      <div className="p-4 sm:p-6 sm:pb-4">
         {/* Search input */}
         <div className="relative mb-3">
           <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
@@ -147,7 +147,7 @@ const WidgetLaunchpad: React.FC<WidgetLaunchpadProps> = ({ onClose, onSelectWidg
         </div>
         
         {/* Category filters */}
-        <div className="flex gap-2 mb-3">
+        <div className="flex flex-wrap gap-2 mb-3">
           <button
             onClick={() => setSelectedCategory(null)}
             className={`px-3 py-1 text-xs rounded-full transition-colors ${
@@ -183,7 +183,7 @@ const WidgetLaunchpad: React.FC<WidgetLaunchpadProps> = ({ onClose, onSelectWidg
       </div>
       
       {/* Widget grid */}
-      <div className="flex-1 overflow-y-auto px-6 pb-6">
+      <div className="flex-1 overflow-y-auto px-4 pb-4 sm:px-6 sm:pb-6">
         {filteredWidgets.length === 0 ? (
           <div className="flex flex-col items-center justify-center h-full text-center">
             <svg className="w-16 h-16 text-warm-gray-300 dark:text-warm-gray-600 mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -198,7 +198,7 @@ const WidgetLaunchpad: React.FC<WidgetLaunchpadProps> = ({ onClose, onSelectWidg
           </div>
         ) : selectedCategory ? (
           // Show widgets in selected category
-          <div className="grid grid-cols-4 gap-3">
+          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-3">
             {filteredWidgets.map((widget, index) => {
               const Icon = widget.icon;
               const isDisabled = isNetworkedWidget(widget.type) && !serverConnected;
@@ -240,7 +240,7 @@ const WidgetLaunchpad: React.FC<WidgetLaunchpadProps> = ({ onClose, onSelectWidg
                 <h3 className="text-sm font-medium text-warm-gray-700 dark:text-warm-gray-300 mb-3">
                   {categoryTitles[category]}
                 </h3>
-                <div className="grid grid-cols-4 gap-3">
+                <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-3">
                   {widgets.map((widget) => {
                     const Icon = widget.icon;
                     const isDisabled = isNetworkedWidget(widget.type) && !serverConnected;

--- a/packages/teacher/src/features/widgets/textBanner/fonts.ts
+++ b/packages/teacher/src/features/widgets/textBanner/fonts.ts
@@ -1,0 +1,17 @@
+export type TextBannerFontFamily = 'sans' | 'serif' | 'slab' | 'mono';
+
+export const FONT_FAMILY_STACK: Record<TextBannerFontFamily, string> = {
+  sans: "'Poppins', system-ui, -apple-system, sans-serif",
+  serif: "'Lora', Georgia, 'Times New Roman', serif",
+  slab: "'Roboto Slab', Rockwell, 'Slabo 27px', serif",
+  mono: "'JetBrains Mono', 'Fira Code', Menlo, Consolas, monospace"
+};
+
+export const FONT_FAMILY_LABEL: Record<TextBannerFontFamily, string> = {
+  sans: 'Sans',
+  serif: 'Serif',
+  slab: 'Slab',
+  mono: 'Mono'
+};
+
+export const FONT_FAMILY_ORDER: TextBannerFontFamily[] = ['sans', 'serif', 'slab', 'mono'];

--- a/packages/teacher/src/features/widgets/textBanner/highlight.test.ts
+++ b/packages/teacher/src/features/widgets/textBanner/highlight.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import { normaliseCode, findCodeBlock } from './highlight';
+
+describe('normaliseCode', () => {
+  it('replaces curly single quotes with straight single quotes', () => {
+    expect(normaliseCode("it’s a test")).toBe("it's a test");
+    expect(normaliseCode("‘hello’")).toBe("'hello'");
+  });
+
+  it('replaces curly double quotes with straight double quotes', () => {
+    expect(normaliseCode('“Hello”')).toBe('"Hello"');
+    expect(normaliseCode('„Low quote‟')).toBe('"Low quote"');
+  });
+
+  it('replaces en dash with single hyphen and em dash with double hyphen', () => {
+    expect(normaliseCode('a – b')).toBe('a - b');
+    expect(normaliseCode('a — b')).toBe('a -- b');
+  });
+
+  it('replaces ellipsis with three dots', () => {
+    expect(normaliseCode('wait…')).toBe('wait...');
+  });
+
+  it('leaves already-ascii code untouched', () => {
+    const src = "function greet() { return 'hi'; }";
+    expect(normaliseCode(src)).toBe(src);
+  });
+
+  it('handles a mix of smart punctuation in one string', () => {
+    expect(normaliseCode('“it’s—done…”')).toBe('"it\'s--done..."');
+  });
+});
+
+describe('findCodeBlock', () => {
+  it('finds a fenced block with a language tag', () => {
+    const block = findCodeBlock('```python\nprint("hi")\n```');
+    expect(block).not.toBeNull();
+    expect(block?.language).toBe('python');
+    expect(block?.code).toBe('print("hi")');
+  });
+
+  it('finds a fenced block with no language tag', () => {
+    const block = findCodeBlock('```\nplain text\n```');
+    expect(block).not.toBeNull();
+    expect(block?.language).toBe('');
+    expect(block?.code).toBe('plain text');
+  });
+
+  it('returns null when there is no fence', () => {
+    expect(findCodeBlock('just a regular sentence')).toBeNull();
+  });
+
+  it('returns null when only one fence is present', () => {
+    expect(findCodeBlock('```python\nstill open')).toBeNull();
+  });
+
+  it('preserves indentation inside the block', () => {
+    const block = findCodeBlock('```ts\n  const x = 1;\n  const y = 2;\n```');
+    expect(block?.code).toBe('  const x = 1;\n  const y = 2;');
+  });
+
+  it('tolerates leading whitespace on fence lines', () => {
+    const block = findCodeBlock('  ```rust\nfn main() {}\n  ```');
+    expect(block).not.toBeNull();
+    expect(block?.language).toBe('rust');
+    expect(block?.code).toBe('fn main() {}');
+  });
+
+  it('exposes the match span via .match and .index', () => {
+    const src = '```js\nx\n```';
+    const block = findCodeBlock(src);
+    expect(block?.match).toBe(src);
+    expect(block?.index).toBe(0);
+  });
+
+  it('accepts language tags with hyphens, underscores, and digits', () => {
+    expect(findCodeBlock('```c++\nint x;\n```')?.language).toBe('c++');
+    expect(findCodeBlock('```html5\n<p></p>\n```')?.language).toBe('html5');
+    expect(findCodeBlock('```objective_c\nNSLog(@"");\n```')?.language).toBe('objective_c');
+  });
+});

--- a/packages/teacher/src/features/widgets/textBanner/highlight.ts
+++ b/packages/teacher/src/features/widgets/textBanner/highlight.ts
@@ -64,7 +64,14 @@ function ensureStyles() {
 
 async function loadHighlighter(): Promise<HLJSApi> {
   if (!hljsPromise) {
-    hljsPromise = import('highlight.js').then((mod) => mod.default);
+    hljsPromise = import('highlight.js')
+      .then((mod) => mod.default)
+      .catch((err) => {
+        // Drop the cached rejection so the next attempt can retry the chunk
+        // load after a transient network failure.
+        hljsPromise = null;
+        throw err;
+      });
   }
   return hljsPromise;
 }

--- a/packages/teacher/src/features/widgets/textBanner/highlight.ts
+++ b/packages/teacher/src/features/widgets/textBanner/highlight.ts
@@ -8,7 +8,7 @@ const STYLE_ID = 'text-banner-hljs-styles';
 const HLJS_CSS = `
 .text-banner-code {
   display: block;
-  width: 100%;
+  max-width: 100%;
   text-align: left;
   white-space: pre;
   font-family: 'JetBrains Mono', 'Fira Code', Menlo, Consolas, monospace;
@@ -16,7 +16,7 @@ const HLJS_CSS = `
   border-radius: 0.5rem;
   background: rgba(0, 0, 0, 0.35);
   color: #f5f5f5;
-  overflow-x: auto;
+  margin: 0;
 }
 .text-banner-code .hljs-comment,
 .text-banner-code .hljs-quote { color: #9ca3af; font-style: italic; }
@@ -74,10 +74,18 @@ export interface HighlightedCode {
   language: string;
 }
 
+export const normaliseCode = (input: string) =>
+  input
+    .replace(/[‘’‚‛]/g, "'")
+    .replace(/[“”„‟]/g, '"')
+    .replace(/–/g, '-')
+    .replace(/—/g, '--')
+    .replace(/…/g, '...');
+
 export async function highlightCode(code: string, language?: string): Promise<HighlightedCode> {
   ensureStyles();
   const hljs = await loadHighlighter();
-  const trimmed = code.replace(/\n+$/, '');
+  const trimmed = normaliseCode(code.replace(/\n+$/, ''));
   if (language && hljs.getLanguage(language)) {
     const result = hljs.highlight(trimmed, { language, ignoreIllegals: true });
     return { html: result.value, language: result.language ?? language };

--- a/packages/teacher/src/features/widgets/textBanner/highlight.ts
+++ b/packages/teacher/src/features/widgets/textBanner/highlight.ts
@@ -1,0 +1,107 @@
+import type { HLJSApi } from 'highlight.js';
+
+let hljsPromise: Promise<HLJSApi> | null = null;
+let stylesInjected = false;
+
+const STYLE_ID = 'text-banner-hljs-styles';
+
+const HLJS_CSS = `
+.text-banner-code {
+  display: block;
+  width: 100%;
+  text-align: left;
+  white-space: pre;
+  font-family: 'JetBrains Mono', 'Fira Code', Menlo, Consolas, monospace;
+  padding: 0.6em 0.85em;
+  border-radius: 0.5rem;
+  background: rgba(0, 0, 0, 0.35);
+  color: #f5f5f5;
+  overflow-x: auto;
+}
+.text-banner-code .hljs-comment,
+.text-banner-code .hljs-quote { color: #9ca3af; font-style: italic; }
+.text-banner-code .hljs-keyword,
+.text-banner-code .hljs-selector-tag,
+.text-banner-code .hljs-literal,
+.text-banner-code .hljs-section,
+.text-banner-code .hljs-link { color: #f9a8d4; }
+.text-banner-code .hljs-string,
+.text-banner-code .hljs-attr,
+.text-banner-code .hljs-symbol,
+.text-banner-code .hljs-bullet { color: #bef264; }
+.text-banner-code .hljs-number,
+.text-banner-code .hljs-meta,
+.text-banner-code .hljs-built_in,
+.text-banner-code .hljs-builtin-name { color: #fdba74; }
+.text-banner-code .hljs-title,
+.text-banner-code .hljs-name,
+.text-banner-code .hljs-type,
+.text-banner-code .hljs-class .hljs-title { color: #93c5fd; }
+.text-banner-code .hljs-variable,
+.text-banner-code .hljs-template-variable,
+.text-banner-code .hljs-attribute { color: #fde68a; }
+.text-banner-code .hljs-tag,
+.text-banner-code .hljs-regexp,
+.text-banner-code .hljs-deletion { color: #fca5a5; }
+.text-banner-code .hljs-addition { color: #86efac; }
+.text-banner-code .hljs-emphasis { font-style: italic; }
+.text-banner-code .hljs-strong { font-weight: 600; }
+`;
+
+function ensureStyles() {
+  if (stylesInjected) return;
+  if (typeof document === 'undefined') return;
+  if (document.getElementById(STYLE_ID)) {
+    stylesInjected = true;
+    return;
+  }
+  const style = document.createElement('style');
+  style.id = STYLE_ID;
+  style.textContent = HLJS_CSS;
+  document.head.appendChild(style);
+  stylesInjected = true;
+}
+
+async function loadHighlighter(): Promise<HLJSApi> {
+  if (!hljsPromise) {
+    hljsPromise = import('highlight.js').then((mod) => mod.default);
+  }
+  return hljsPromise;
+}
+
+export interface HighlightedCode {
+  html: string;
+  language: string;
+}
+
+export async function highlightCode(code: string, language?: string): Promise<HighlightedCode> {
+  ensureStyles();
+  const hljs = await loadHighlighter();
+  const trimmed = code.replace(/\n+$/, '');
+  if (language && hljs.getLanguage(language)) {
+    const result = hljs.highlight(trimmed, { language, ignoreIllegals: true });
+    return { html: result.value, language: result.language ?? language };
+  }
+  const result = hljs.highlightAuto(trimmed);
+  return { html: result.value, language: result.language ?? 'plaintext' };
+}
+
+const CODE_BLOCK_RE = /^[ \t]*```([a-zA-Z0-9_+-]*)\n([\s\S]*?)\n[ \t]*```[ \t]*$/m;
+
+export interface ParsedCodeBlock {
+  language: string;
+  code: string;
+  match: string;
+  index: number;
+}
+
+export function findCodeBlock(text: string): ParsedCodeBlock | null {
+  const match = CODE_BLOCK_RE.exec(text);
+  if (!match) return null;
+  return {
+    language: match[1] || '',
+    code: match[2],
+    match: match[0],
+    index: match.index
+  };
+}

--- a/packages/teacher/src/features/widgets/textBanner/hooks/useAutoFontSize.ts
+++ b/packages/teacher/src/features/widgets/textBanner/hooks/useAutoFontSize.ts
@@ -9,6 +9,8 @@ interface UseAutoFontSizeOptions {
   padding?: number;
   /** When true, only constrain by width — let height grow freely. */
   widthOnly?: boolean;
+  /** Any external value whose change should force a recalculation (e.g. font family). */
+  fontFamily?: string;
 }
 
 /**
@@ -21,7 +23,8 @@ export function useAutoFontSize({
   maxSize = 200,
   minSize = 12,
   padding = 32,
-  widthOnly = false
+  widthOnly = false,
+  fontFamily
 }: UseAutoFontSizeOptions) {
   const [fontSize, setFontSize] = useState(24);
 
@@ -65,14 +68,14 @@ export function useAutoFontSize({
   // Recalculate on text or mode change
   useEffect(() => {
     calculateFontSize();
-  }, [text, widthOnly]);
+  }, [text, widthOnly, maxSize, minSize, padding, fontFamily]);
 
   // Recalculate on window resize
   useEffect(() => {
     const handleResize = () => calculateFontSize();
     window.addEventListener('resize', handleResize);
     return () => window.removeEventListener('resize', handleResize);
-  }, [text, widthOnly]);
+  }, [text, widthOnly, maxSize, minSize, padding, fontFamily]);
 
   // Recalculate when container size changes (from react-rnd resize)
   useEffect(() => {
@@ -85,7 +88,7 @@ export function useAutoFontSize({
     resizeObserver.observe(containerRef.current);
 
     return () => resizeObserver.disconnect();
-  }, [text, widthOnly]);
+  }, [text, widthOnly, maxSize, minSize, padding, fontFamily]);
 
   return fontSize;
 }

--- a/packages/teacher/src/features/widgets/textBanner/textBanner.tsx
+++ b/packages/teacher/src/features/widgets/textBanner/textBanner.tsx
@@ -256,99 +256,104 @@ const TextBanner: React.FC<TextBannerProps> = ({ savedState, onStateChange }) =>
     >
       {controlsVisible && (
         <div
-          className="flex-shrink-0 m-2 z-20 flex items-center gap-1.5 px-2 py-1.5 rounded-full bg-warm-gray-900/85 dark:bg-black/80 text-soft-white backdrop-blur-sm shadow-lg text-xs select-none self-center max-w-[calc(100%-1rem)] flex-wrap justify-center"
+          className="flex-shrink-0 m-2 z-20 flex flex-col items-center gap-1 px-2 py-1.5 rounded-2xl bg-warm-gray-900/85 dark:bg-black/80 text-soft-white backdrop-blur-sm shadow-lg text-xs select-none self-center max-w-[calc(100%-1rem)]"
           onMouseDown={preventToolbarBlur}
           onClick={stopAll}
           onDoubleClick={stopAll}
         >
-          {/* Colour swatches + click-to-recolour lock */}
-          <div className="flex items-center gap-1">
-            {colorCombinations.map((combo, idx) => (
+          {/* Row 1: colours + lock | fonts | dismiss */}
+          <div className="flex items-center gap-1.5 flex-wrap justify-center">
+            {/* Colour swatches + click-to-recolour lock */}
+            <div className="flex items-center gap-1">
+              {colorCombinations.map((combo, idx) => (
+                <button
+                  key={combo.swatch}
+                  type="button"
+                  onClick={() => updateState({ colorIndex: idx })}
+                  className={cn(
+                    'w-5 h-5 rounded-full border transition-transform hover:scale-110',
+                    idx === colorIndex ? 'border-soft-white ring-2 ring-soft-white/40' : 'border-warm-gray-500'
+                  )}
+                  style={{ backgroundColor: combo.swatch }}
+                  aria-label={`Use colour ${idx + 1}`}
+                />
+              ))}
               <button
-                key={combo.swatch}
                 type="button"
-                onClick={() => updateState({ colorIndex: idx })}
+                onClick={() => updateState({ clickToRecolour: !clickToRecolour })}
                 className={cn(
-                  'w-5 h-5 rounded-full border transition-transform hover:scale-110',
-                  idx === colorIndex ? 'border-soft-white ring-2 ring-soft-white/40' : 'border-warm-gray-500'
+                  'w-7 h-7 ml-1 flex items-center justify-center rounded-full transition-colors',
+                  clickToRecolour ? 'hover:bg-warm-gray-700/60' : 'bg-soft-white text-warm-gray-900'
                 )}
-                style={{ backgroundColor: combo.swatch }}
-                aria-label={`Use colour ${idx + 1}`}
-              />
-            ))}
+                aria-label={clickToRecolour ? 'Disable click-to-recolour' : 'Enable click-to-recolour'}
+                title={clickToRecolour ? 'Click cycles colour — click to lock' : 'Colour locked — click to unlock'}
+              >
+                {clickToRecolour ? <FaLockOpen className="w-3 h-3" /> : <FaLock className="w-3 h-3" />}
+              </button>
+            </div>
+
+            <span className="w-px h-5 bg-warm-gray-500/60 mx-0.5" aria-hidden />
+
+            {/* Font family */}
+            <div className="flex items-center gap-1">
+              {FONT_FAMILY_ORDER.map((family) => (
+                <button
+                  key={family}
+                  type="button"
+                  onClick={() => updateState({ fontFamily: family })}
+                  className={cn(
+                    'px-2 py-1 rounded-md text-[11px] leading-none transition-colors',
+                    fontFamily === family
+                      ? 'bg-soft-white text-warm-gray-900'
+                      : 'hover:bg-warm-gray-700/60'
+                  )}
+                  style={{ fontFamily: FONT_FAMILY_STACK[family] }}
+                  title={FONT_FAMILY_LABEL[family]}
+                  aria-label={`Use ${FONT_FAMILY_LABEL[family]} font`}
+                >
+                  Aa
+                </button>
+              ))}
+            </div>
+
+            <span className="w-px h-5 bg-warm-gray-500/60 mx-0.5" aria-hidden />
+
+            {/* Dismiss */}
             <button
               type="button"
-              onClick={() => updateState({ clickToRecolour: !clickToRecolour })}
-              className={cn(
-                'w-7 h-7 ml-1 flex items-center justify-center rounded-full transition-colors',
-                clickToRecolour ? 'hover:bg-warm-gray-700/60' : 'bg-soft-white text-warm-gray-900'
-              )}
-              aria-label={clickToRecolour ? 'Disable click-to-recolour' : 'Enable click-to-recolour'}
-              title={clickToRecolour ? 'Click cycles colour — click to lock' : 'Colour locked — click to unlock'}
+              onClick={() => setControlsVisible(false)}
+              className="w-7 h-7 flex items-center justify-center rounded-full hover:bg-warm-gray-700/60"
+              aria-label="Hide controls"
+              title="Hide controls"
             >
-              {clickToRecolour ? <FaLockOpen className="w-3 h-3" /> : <FaLock className="w-3 h-3" />}
+              <FaXmark className="w-3 h-3" />
             </button>
           </div>
 
-          <span className="w-px h-5 bg-warm-gray-500/60 mx-0.5" aria-hidden />
-
-          {/* Font size */}
-          <button
-            type="button"
-            onClick={() => adjustFontCap(-FONT_SIZE_STEP)}
-            disabled={fontSizeCap <= MIN_FONT_SIZE_CAP}
-            className="w-7 h-7 flex items-center justify-center rounded-full hover:bg-warm-gray-700/60 disabled:opacity-40"
-            aria-label="Decrease maximum font size"
-            title="Decrease size"
-          >
-            <FaMinus className="w-3 h-3" />
-          </button>
-          <span className="text-[10px] tabular-nums w-6 text-center opacity-80">{fontSizeCap}</span>
-          <button
-            type="button"
-            onClick={() => adjustFontCap(FONT_SIZE_STEP)}
-            disabled={fontSizeCap >= MAX_FONT_SIZE_CAP}
-            className="w-7 h-7 flex items-center justify-center rounded-full hover:bg-warm-gray-700/60 disabled:opacity-40"
-            aria-label="Increase maximum font size"
-            title="Increase size"
-          >
-            <FaPlus className="w-3 h-3" />
-          </button>
-
-          <span className="w-px h-5 bg-warm-gray-500/60 mx-0.5" aria-hidden />
-
-          {/* Font family */}
-          <div className="flex items-center gap-1">
-            {FONT_FAMILY_ORDER.map((family) => (
-              <button
-                key={family}
-                type="button"
-                onClick={() => updateState({ fontFamily: family })}
-                className={cn(
-                  'px-2 py-1 rounded-md text-[11px] leading-none transition-colors',
-                  fontFamily === family
-                    ? 'bg-soft-white text-warm-gray-900'
-                    : 'hover:bg-warm-gray-700/60'
-                )}
-                style={{ fontFamily: FONT_FAMILY_STACK[family] }}
-                title={FONT_FAMILY_LABEL[family]}
-                aria-label={`Use ${FONT_FAMILY_LABEL[family]} font`}
-              >
-                Aa
-              </button>
-            ))}
+          {/* Row 2: font size */}
+          <div className="flex items-center gap-1.5">
+            <button
+              type="button"
+              onClick={() => adjustFontCap(-FONT_SIZE_STEP)}
+              disabled={fontSizeCap <= MIN_FONT_SIZE_CAP}
+              className="w-7 h-7 flex items-center justify-center rounded-full hover:bg-warm-gray-700/60 disabled:opacity-40"
+              aria-label="Decrease maximum font size"
+              title="Decrease size"
+            >
+              <FaMinus className="w-3 h-3" />
+            </button>
+            <span className="text-[10px] tabular-nums w-8 text-center opacity-80">{fontSizeCap}px</span>
+            <button
+              type="button"
+              onClick={() => adjustFontCap(FONT_SIZE_STEP)}
+              disabled={fontSizeCap >= MAX_FONT_SIZE_CAP}
+              className="w-7 h-7 flex items-center justify-center rounded-full hover:bg-warm-gray-700/60 disabled:opacity-40"
+              aria-label="Increase maximum font size"
+              title="Increase size"
+            >
+              <FaPlus className="w-3 h-3" />
+            </button>
           </div>
-
-          {/* Dismiss */}
-          <button
-            type="button"
-            onClick={() => setControlsVisible(false)}
-            className="w-7 h-7 flex items-center justify-center rounded-full hover:bg-warm-gray-700/60"
-            aria-label="Hide controls"
-            title="Hide controls"
-          >
-            <FaXmark className="w-3 h-3" />
-          </button>
         </div>
       )}
 

--- a/packages/teacher/src/features/widgets/textBanner/textBanner.tsx
+++ b/packages/teacher/src/features/widgets/textBanner/textBanner.tsx
@@ -50,6 +50,19 @@ const normaliseText = (value: string) => (value.length > 0 ? value : PLACEHOLDER
 const SMART_PUNCT_RE = /[‘’‚‛“”„‟–—…]/;
 const hasCodeFence = (value: string) => /```/.test(value);
 
+// Returns true when the caret is between an opening and closing ``` fence.
+const isCursorInsideFence = (text: string, cursor: number) => {
+  let count = 0;
+  let i = 0;
+  while (true) {
+    const next = text.indexOf('```', i);
+    if (next === -1 || next >= cursor) break;
+    count++;
+    i = next + 3;
+  }
+  return count % 2 === 1;
+};
+
 const formatInlineText = (line: string) => {
   const tokens = line.split(/(\*_[^_]+_\*|\*[^*]+\*|_[^_]+_|~[^~]+~|`[^`]+`)/g);
   return tokens.map((token, index) => {
@@ -229,7 +242,7 @@ const TextBanner: React.FC<TextBannerProps> = ({ savedState, onStateChange }) =>
       setControlsVisible(false);
       return;
     }
-    if (e.key === 'Tab' && hasCodeFence(editText)) {
+    if (e.key === 'Tab' && isCursorInsideFence(editText, e.currentTarget.selectionStart)) {
       e.preventDefault();
       const ta = e.currentTarget;
       const start = ta.selectionStart;
@@ -558,6 +571,10 @@ const TextBanner: React.FC<TextBannerProps> = ({ savedState, onStateChange }) =>
           role="separator"
           aria-orientation="horizontal"
           aria-label="Resize banner height (use arrow keys)"
+          aria-valuenow={Math.round(effectiveColumnHeight ?? widgetRef.current?.offsetHeight ?? DEFAULT_COLUMN_HEIGHT)}
+          aria-valuemin={MIN_COLUMN_HEIGHT}
+          aria-valuemax={MAX_COLUMN_HEIGHT}
+          aria-valuetext={`${Math.round(effectiveColumnHeight ?? widgetRef.current?.offsetHeight ?? DEFAULT_COLUMN_HEIGHT)} pixels`}
           tabIndex={0}
           onMouseDown={handleResizeMouseDown}
           onKeyDown={handleResizeKeyDown}

--- a/packages/teacher/src/features/widgets/textBanner/textBanner.tsx
+++ b/packages/teacher/src/features/widgets/textBanner/textBanner.tsx
@@ -261,7 +261,7 @@ const TextBanner: React.FC<TextBannerProps> = ({ savedState, onStateChange }) =>
           onClick={stopAll}
           onDoubleClick={stopAll}
         >
-          {/* Colour swatches */}
+          {/* Colour swatches + click-to-recolour lock */}
           <div className="flex items-center gap-1">
             {colorCombinations.map((combo, idx) => (
               <button
@@ -276,6 +276,18 @@ const TextBanner: React.FC<TextBannerProps> = ({ savedState, onStateChange }) =>
                 aria-label={`Use colour ${idx + 1}`}
               />
             ))}
+            <button
+              type="button"
+              onClick={() => updateState({ clickToRecolour: !clickToRecolour })}
+              className={cn(
+                'w-7 h-7 ml-1 flex items-center justify-center rounded-full transition-colors',
+                clickToRecolour ? 'hover:bg-warm-gray-700/60' : 'bg-soft-white text-warm-gray-900'
+              )}
+              aria-label={clickToRecolour ? 'Disable click-to-recolour' : 'Enable click-to-recolour'}
+              title={clickToRecolour ? 'Click cycles colour — click to lock' : 'Colour locked — click to unlock'}
+            >
+              {clickToRecolour ? <FaLockOpen className="w-3 h-3" /> : <FaLock className="w-3 h-3" />}
+            </button>
           </div>
 
           <span className="w-px h-5 bg-warm-gray-500/60 mx-0.5" aria-hidden />
@@ -326,22 +338,6 @@ const TextBanner: React.FC<TextBannerProps> = ({ savedState, onStateChange }) =>
               </button>
             ))}
           </div>
-
-          <span className="w-px h-5 bg-warm-gray-500/60 mx-0.5" aria-hidden />
-
-          {/* Click-to-recolour toggle */}
-          <button
-            type="button"
-            onClick={() => updateState({ clickToRecolour: !clickToRecolour })}
-            className={cn(
-              'w-7 h-7 flex items-center justify-center rounded-full transition-colors',
-              clickToRecolour ? 'hover:bg-warm-gray-700/60' : 'bg-soft-white text-warm-gray-900'
-            )}
-            aria-label={clickToRecolour ? 'Disable click-to-recolour' : 'Enable click-to-recolour'}
-            title={clickToRecolour ? 'Click cycles colour — click to lock' : 'Colour locked — click to unlock'}
-          >
-            {clickToRecolour ? <FaLockOpen className="w-3 h-3" /> : <FaLock className="w-3 h-3" />}
-          </button>
 
           {/* Dismiss */}
           <button

--- a/packages/teacher/src/features/widgets/textBanner/textBanner.tsx
+++ b/packages/teacher/src/features/widgets/textBanner/textBanner.tsx
@@ -1,25 +1,44 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef, useMemo, useCallback } from 'react';
+import { FaMinus, FaPlus, FaLock, FaLockOpen, FaXmark } from 'react-icons/fa6';
 import { useAutoFontSize } from './hooks';
+import {
+  FONT_FAMILY_STACK,
+  FONT_FAMILY_LABEL,
+  FONT_FAMILY_ORDER,
+  TextBannerFontFamily
+} from './fonts';
+import { findCodeBlock, highlightCode, type HighlightedCode } from './highlight';
 import { cn, widgetContainer } from '@shared/utils/styles';
 import { useWidgetState } from '@shared/hooks/useWidgetState';
 import { useWorkspaceStore } from '../../../store/workspaceStore.simple';
 
-interface TextBannerProps {
-  savedState?: { text: string; colorIndex?: number };
-  onStateChange?: (state: { text: string; colorIndex: number }) => void;
+interface TextBannerState {
+  text: string;
+  colorIndex: number;
+  fontFamily: TextBannerFontFamily;
+  fontSizeCap: number;
+  clickToRecolour: boolean;
 }
 
-// Define color combinations with high contrast
+interface TextBannerProps {
+  savedState?: Partial<TextBannerState> & { text: string };
+  onStateChange?: (state: TextBannerState) => void;
+}
+
 const colorCombinations = [
-  { bg: 'bg-terracotta-500 dark:bg-terracotta-600', text: 'text-soft-white dark:text-white' },
-  { bg: 'bg-sage-600 dark:bg-sage-700', text: 'text-soft-white dark:text-white' },
-  { bg: 'bg-warm-gray-800 dark:bg-warm-gray-900', text: 'text-soft-white dark:text-warm-gray-100' },
-  { bg: 'bg-dusty-rose-600 dark:bg-dusty-rose-700', text: 'text-soft-white dark:text-white' },
-  { bg: 'bg-soft-white dark:bg-warm-gray-200', text: 'text-warm-gray-900 dark:text-warm-gray-900' },
-  { bg: 'bg-blue-600 dark:bg-blue-700', text: 'text-soft-white dark:text-white' }
+  { bg: 'bg-terracotta-500 dark:bg-terracotta-600', text: 'text-soft-white dark:text-white', swatch: '#d97757' },
+  { bg: 'bg-sage-600 dark:bg-sage-700', text: 'text-soft-white dark:text-white', swatch: '#5c7560' },
+  { bg: 'bg-warm-gray-800 dark:bg-warm-gray-900', text: 'text-soft-white dark:text-warm-gray-100', swatch: '#3f3a36' },
+  { bg: 'bg-dusty-rose-600 dark:bg-dusty-rose-700', text: 'text-soft-white dark:text-white', swatch: '#b96370' },
+  { bg: 'bg-soft-white dark:bg-warm-gray-200', text: 'text-warm-gray-900 dark:text-warm-gray-900', swatch: '#f8f5f0' },
+  { bg: 'bg-blue-600 dark:bg-blue-700', text: 'text-soft-white dark:text-white', swatch: '#2563eb' }
 ];
 
 const PLACEHOLDER_TEXT = 'Double-click to edit';
+const DEFAULT_FONT_SIZE_CAP = 96;
+const MIN_FONT_SIZE_CAP = 24;
+const MAX_FONT_SIZE_CAP = 220;
+const FONT_SIZE_STEP = 16;
 
 const normaliseText = (value: string) => (value.length > 0 ? value : PLACEHOLDER_TEXT);
 
@@ -77,48 +96,63 @@ const renderFormattedText = (value: string) => {
 
 const TextBanner: React.FC<TextBannerProps> = ({ savedState, onStateChange }) => {
   const isColumnLayout = useWorkspaceStore((state) => state.layoutFormat === 'column');
-  const normalisedSavedState = savedState
+
+  const initialState: TextBannerState = {
+    text: PLACEHOLDER_TEXT,
+    colorIndex: 0,
+    fontFamily: 'sans',
+    fontSizeCap: DEFAULT_FONT_SIZE_CAP,
+    clickToRecolour: true
+  };
+
+  const normalisedSavedState: TextBannerState | undefined = savedState
     ? {
         text: normaliseText(savedState.text),
-        colorIndex: savedState.colorIndex ?? 0
+        colorIndex: savedState.colorIndex ?? 0,
+        fontFamily: savedState.fontFamily ?? 'sans',
+        fontSizeCap: savedState.fontSizeCap ?? DEFAULT_FONT_SIZE_CAP,
+        clickToRecolour: savedState.clickToRecolour ?? true
       }
     : undefined;
 
-  const { state, updateState } = useWidgetState({
-    initialState: { text: PLACEHOLDER_TEXT, colorIndex: 0 },
+  const { state, updateState } = useWidgetState<TextBannerState>({
+    initialState,
     savedState: normalisedSavedState,
     onStateChange
   });
 
-  const { text, colorIndex } = state;
+  const { text, colorIndex, fontFamily, fontSizeCap, clickToRecolour } = state;
+
   const [isEditing, setIsEditing] = useState(false);
   const [editText, setEditText] = useState(text);
-  const containerRef = useRef<HTMLDivElement>(null);
+  const [controlsVisible, setControlsVisible] = useState(() => !savedState);
+
+  const widgetRef = useRef<HTMLDivElement>(null);
+  const textAreaContainerRef = useRef<HTMLDivElement>(null);
   const textRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const clickTimerRef = useRef<number | null>(null);
   const mouseDownPosRef = useRef<{ x: number; y: number } | null>(null);
 
-  // Use auto font size hook
-  // In column layout, only constrain by width so text drives the widget height
+  const codeBlock = useMemo(() => findCodeBlock(text), [text]);
+  const isCodeBlockOnly = codeBlock?.match.trim() === text.trim();
+
   const fontSize = useAutoFontSize({
     text,
-    containerRef,
+    containerRef: textAreaContainerRef,
     textRef,
-    maxSize: 180,
-    minSize: isColumnLayout ? 24 : 12,
+    maxSize: fontSizeCap,
+    minSize: isColumnLayout ? 18 : 12,
     padding: 32,
     widthOnly: isColumnLayout
   });
 
-  // Select all text when entering edit mode
   useEffect(() => {
     if (isEditing && textareaRef.current) {
       textareaRef.current.select();
     }
   }, [isEditing]);
 
-  // Prevent delayed colour changes from firing after unmount.
   useEffect(() => {
     return () => {
       if (clickTimerRef.current !== null) {
@@ -128,19 +162,34 @@ const TextBanner: React.FC<TextBannerProps> = ({ savedState, onStateChange }) =>
     };
   }, []);
 
-  const commitText = (nextText: string) => {
+  // Dismiss controls on outside click (when not editing)
+  useEffect(() => {
+    if (!controlsVisible || isEditing) return;
+    const handler = (event: MouseEvent) => {
+      if (!widgetRef.current) return;
+      if (!widgetRef.current.contains(event.target as Node)) {
+        setControlsVisible(false);
+      }
+    };
+    document.addEventListener('mousedown', handler, true);
+    return () => document.removeEventListener('mousedown', handler, true);
+  }, [controlsVisible, isEditing]);
+
+  const commitText = useCallback((nextText: string) => {
     updateState({ text: normaliseText(nextText) });
-  };
+  }, [updateState]);
 
   const handleBlur = () => {
     commitText(editText);
     setIsEditing(false);
+    setControlsVisible(false);
   };
 
-  const handleKeyDown = (e: React.KeyboardEvent) => {
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === 'Escape') {
       commitText(editText);
       setIsEditing(false);
+      setControlsVisible(false);
     }
   };
 
@@ -151,63 +200,262 @@ const TextBanner: React.FC<TextBannerProps> = ({ savedState, onStateChange }) =>
     return Math.sqrt(dx * dx + dy * dy) > 5;
   };
 
-  const handleClick = (e: React.MouseEvent) => {
+  const handleTextAreaClick = (e: React.MouseEvent) => {
     if (isEditing || e.detail !== 1 || wasDrag(e)) return;
+    if (!clickToRecolour) return;
     if (clickTimerRef.current) {
       window.clearTimeout(clickTimerRef.current);
     }
     clickTimerRef.current = window.setTimeout(() => {
-      const nextIndex = (colorIndex + 1) % colorCombinations.length;
-      updateState({ colorIndex: nextIndex });
+      updateState({ colorIndex: (colorIndex + 1) % colorCombinations.length });
       clickTimerRef.current = null;
     }, 500);
   };
 
-  const handleDoubleClick = (e: React.MouseEvent) => {
-    if (wasDrag(e)) return;
+  const enterEditMode = () => {
     if (clickTimerRef.current) {
       window.clearTimeout(clickTimerRef.current);
       clickTimerRef.current = null;
     }
     setIsEditing(true);
-    setEditText(text);
+    setEditText(text === PLACEHOLDER_TEXT ? '' : text);
+    setControlsVisible(true);
+  };
+
+  const handleDoubleClick = (e: React.MouseEvent) => {
+    if (wasDrag(e)) return;
+    enterEditMode();
   };
 
   const currentColors = colorCombinations[colorIndex];
 
+  const stopAll = (e: React.SyntheticEvent) => {
+    e.stopPropagation();
+  };
+
+  const adjustFontCap = (delta: number) => {
+    const next = Math.min(MAX_FONT_SIZE_CAP, Math.max(MIN_FONT_SIZE_CAP, fontSizeCap + delta));
+    updateState({ fontSizeCap: next });
+  };
+
   return (
     <div
-      ref={containerRef}
-      className={cn(widgetContainer, currentColors.bg, "items-center justify-center p-4 relative overflow-hidden transition-colors duration-300 cursor-pointer")}
-      onMouseDown={(e) => { mouseDownPosRef.current = { x: e.clientX, y: e.clientY }; }}
-      onClick={handleClick}
+      ref={widgetRef}
+      className={cn(
+        widgetContainer,
+        currentColors.bg,
+        'relative overflow-hidden transition-colors duration-300 flex flex-col'
+      )}
       onDoubleClick={handleDoubleClick}
     >
-      {isEditing ? (
-        <textarea
-          ref={textareaRef}
-          value={editText}
-          onChange={(e) => setEditText(e.target.value)}
-          onKeyDown={handleKeyDown}
-          onBlur={handleBlur}
-          onMouseDown={(e) => e.stopPropagation()}
-          onClick={(e) => e.stopPropagation()}
-          className="w-full h-full p-4 text-xl bg-soft-white dark:bg-warm-gray-700 text-warm-gray-800 dark:text-warm-gray-200 rounded-md resize-none focus:outline-none focus:ring-2 focus:ring-terracotta-600 dark:focus:ring-terracotta-500"
-          placeholder="Enter your message..."
-          autoFocus
-        />
-      ) : (
+      {controlsVisible && (
         <div
-          ref={textRef}
-          className={cn(currentColors.text, "text-center leading-tight select-none")}
-          style={{ fontSize: `${fontSize}px` }}
-          title="Double-click to edit"
+          className="flex-shrink-0 m-2 z-20 flex items-center gap-1.5 px-2 py-1.5 rounded-full bg-warm-gray-900/85 dark:bg-black/80 text-soft-white backdrop-blur-sm shadow-lg text-xs select-none self-center max-w-[calc(100%-1rem)] flex-wrap justify-center"
+          onMouseDown={stopAll}
+          onClick={stopAll}
+          onDoubleClick={stopAll}
         >
-          {renderFormattedText(text)}
+          {/* Colour swatches */}
+          <div className="flex items-center gap-1">
+            {colorCombinations.map((combo, idx) => (
+              <button
+                key={combo.swatch}
+                type="button"
+                onClick={() => updateState({ colorIndex: idx })}
+                className={cn(
+                  'w-5 h-5 rounded-full border transition-transform hover:scale-110',
+                  idx === colorIndex ? 'border-soft-white ring-2 ring-soft-white/40' : 'border-warm-gray-500'
+                )}
+                style={{ backgroundColor: combo.swatch }}
+                aria-label={`Use colour ${idx + 1}`}
+              />
+            ))}
+          </div>
+
+          <span className="w-px h-5 bg-warm-gray-500/60 mx-0.5" aria-hidden />
+
+          {/* Font size */}
+          <button
+            type="button"
+            onClick={() => adjustFontCap(-FONT_SIZE_STEP)}
+            disabled={fontSizeCap <= MIN_FONT_SIZE_CAP}
+            className="w-7 h-7 flex items-center justify-center rounded-full hover:bg-warm-gray-700/60 disabled:opacity-40"
+            aria-label="Decrease maximum font size"
+            title="Decrease size"
+          >
+            <FaMinus className="w-3 h-3" />
+          </button>
+          <span className="text-[10px] tabular-nums w-6 text-center opacity-80">{fontSizeCap}</span>
+          <button
+            type="button"
+            onClick={() => adjustFontCap(FONT_SIZE_STEP)}
+            disabled={fontSizeCap >= MAX_FONT_SIZE_CAP}
+            className="w-7 h-7 flex items-center justify-center rounded-full hover:bg-warm-gray-700/60 disabled:opacity-40"
+            aria-label="Increase maximum font size"
+            title="Increase size"
+          >
+            <FaPlus className="w-3 h-3" />
+          </button>
+
+          <span className="w-px h-5 bg-warm-gray-500/60 mx-0.5" aria-hidden />
+
+          {/* Font family */}
+          <div className="flex items-center gap-1">
+            {FONT_FAMILY_ORDER.map((family) => (
+              <button
+                key={family}
+                type="button"
+                onClick={() => updateState({ fontFamily: family })}
+                className={cn(
+                  'px-2 py-1 rounded-md text-[11px] leading-none transition-colors',
+                  fontFamily === family
+                    ? 'bg-soft-white text-warm-gray-900'
+                    : 'hover:bg-warm-gray-700/60'
+                )}
+                style={{ fontFamily: FONT_FAMILY_STACK[family] }}
+                title={FONT_FAMILY_LABEL[family]}
+                aria-label={`Use ${FONT_FAMILY_LABEL[family]} font`}
+              >
+                Aa
+              </button>
+            ))}
+          </div>
+
+          <span className="w-px h-5 bg-warm-gray-500/60 mx-0.5" aria-hidden />
+
+          {/* Click-to-recolour toggle */}
+          <button
+            type="button"
+            onClick={() => updateState({ clickToRecolour: !clickToRecolour })}
+            className={cn(
+              'w-7 h-7 flex items-center justify-center rounded-full transition-colors',
+              clickToRecolour ? 'hover:bg-warm-gray-700/60' : 'bg-soft-white text-warm-gray-900'
+            )}
+            aria-label={clickToRecolour ? 'Disable click-to-recolour' : 'Enable click-to-recolour'}
+            title={clickToRecolour ? 'Click cycles colour — click to lock' : 'Colour locked — click to unlock'}
+          >
+            {clickToRecolour ? <FaLockOpen className="w-3 h-3" /> : <FaLock className="w-3 h-3" />}
+          </button>
+
+          {/* Dismiss */}
+          <button
+            type="button"
+            onClick={() => setControlsVisible(false)}
+            className="w-7 h-7 flex items-center justify-center rounded-full hover:bg-warm-gray-700/60"
+            aria-label="Hide controls"
+            title="Hide controls"
+          >
+            <FaXmark className="w-3 h-3" />
+          </button>
         </div>
       )}
+
+      <div
+        ref={textAreaContainerRef}
+        className={cn(
+          'flex-1 flex items-center justify-center p-4 relative',
+          clickToRecolour && !isEditing ? 'cursor-pointer' : ''
+        )}
+        onMouseDown={(e) => {
+          mouseDownPosRef.current = { x: e.clientX, y: e.clientY };
+        }}
+        onClick={handleTextAreaClick}
+      >
+        {isEditing ? (
+          <textarea
+            ref={textareaRef}
+            value={editText}
+            onChange={(e) => setEditText(e.target.value)}
+            onKeyDown={handleKeyDown}
+            onBlur={handleBlur}
+            onMouseDown={(e) => e.stopPropagation()}
+            onClick={(e) => e.stopPropagation()}
+            style={{ fontFamily: FONT_FAMILY_STACK[fontFamily] }}
+            className="w-full h-full p-4 text-base bg-soft-white dark:bg-warm-gray-700 text-warm-gray-800 dark:text-warm-gray-200 rounded-md resize-none focus:outline-none focus:ring-2 focus:ring-terracotta-600 dark:focus:ring-terracotta-500"
+            placeholder="Enter your message... (use ```language for code blocks)"
+            autoFocus
+          />
+        ) : isCodeBlockOnly && codeBlock ? (
+          <CodeBlockRender
+            ref={textRef}
+            code={codeBlock.code}
+            language={codeBlock.language}
+            fontFamily={fontFamily}
+            fontSize={fontSize}
+            colorClass={currentColors.text}
+          />
+        ) : (
+          <div
+            ref={textRef}
+            className={cn(currentColors.text, 'text-center leading-tight select-none')}
+            style={{
+              fontSize: `${fontSize}px`,
+              fontFamily: FONT_FAMILY_STACK[fontFamily]
+            }}
+            title="Double-click to edit"
+          >
+            {renderFormattedText(text)}
+          </div>
+        )}
+      </div>
     </div>
   );
 };
+
+interface CodeBlockRenderProps {
+  code: string;
+  language: string;
+  fontFamily: TextBannerFontFamily;
+  fontSize: number;
+  colorClass: string;
+}
+
+const CodeBlockRender = React.forwardRef<HTMLDivElement, CodeBlockRenderProps>(
+  ({ code, language, fontSize }, ref) => {
+    const [highlighted, setHighlighted] = useState<HighlightedCode | null>(null);
+
+    useEffect(() => {
+      let cancelled = false;
+      highlightCode(code, language)
+        .then((result) => {
+          if (!cancelled) setHighlighted(result);
+        })
+        .catch(() => {
+          if (!cancelled) setHighlighted({ html: escapeHtml(code), language: 'plaintext' });
+        });
+      return () => {
+        cancelled = true;
+      };
+    }, [code, language]);
+
+    // Use a smaller font for code so it fits more easily
+    const codeFontSize = Math.max(12, Math.round(fontSize * 0.7));
+
+    return (
+      <div
+        ref={ref}
+        className="w-full max-w-full"
+        style={{ fontSize: `${codeFontSize}px` }}
+      >
+        <pre className="text-banner-code">
+          <code
+            dangerouslySetInnerHTML={{
+              __html: highlighted?.html ?? escapeHtml(code)
+            }}
+          />
+        </pre>
+      </div>
+    );
+  }
+);
+CodeBlockRender.displayName = 'CodeBlockRender';
+
+const escapeHtml = (input: string) =>
+  input
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
 
 export default TextBanner;

--- a/packages/teacher/src/features/widgets/textBanner/textBanner.tsx
+++ b/packages/teacher/src/features/widgets/textBanner/textBanner.tsx
@@ -233,6 +233,12 @@ const TextBanner: React.FC<TextBannerProps> = ({ savedState, onStateChange }) =>
     e.stopPropagation();
   };
 
+  // Prevent the textarea from losing focus when the toolbar is clicked.
+  const preventToolbarBlur = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+  };
+
   const adjustFontCap = (delta: number) => {
     const next = Math.min(MAX_FONT_SIZE_CAP, Math.max(MIN_FONT_SIZE_CAP, fontSizeCap + delta));
     updateState({ fontSizeCap: next });
@@ -251,7 +257,7 @@ const TextBanner: React.FC<TextBannerProps> = ({ savedState, onStateChange }) =>
       {controlsVisible && (
         <div
           className="flex-shrink-0 m-2 z-20 flex items-center gap-1.5 px-2 py-1.5 rounded-full bg-warm-gray-900/85 dark:bg-black/80 text-soft-white backdrop-blur-sm shadow-lg text-xs select-none self-center max-w-[calc(100%-1rem)] flex-wrap justify-center"
-          onMouseDown={stopAll}
+          onMouseDown={preventToolbarBlur}
           onClick={stopAll}
           onDoubleClick={stopAll}
         >

--- a/packages/teacher/src/features/widgets/textBanner/textBanner.tsx
+++ b/packages/teacher/src/features/widgets/textBanner/textBanner.tsx
@@ -50,14 +50,6 @@ const normaliseText = (value: string) => (value.length > 0 ? value : PLACEHOLDER
 const SMART_PUNCT_RE = /[‘’‚‛“”„‟–—…]/;
 const hasCodeFence = (value: string) => /```/.test(value);
 
-const normaliseCodePunctuation = (value: string) =>
-  value
-    .replace(/[‘’‚‛]/g, "'")
-    .replace(/[“”„‟]/g, '"')
-    .replace(/–/g, '-')
-    .replace(/—/g, '--')
-    .replace(/…/g, '...');
-
 const formatInlineText = (line: string) => {
   const tokens = line.split(/(\*_[^_]+_\*|\*[^*]+\*|_[^_]+_|~[^~]+~|`[^`]+`)/g);
   return tokens.map((token, index) => {
@@ -197,14 +189,14 @@ const TextBanner: React.FC<TextBannerProps> = ({ savedState, onStateChange }) =>
   }, [controlsVisible, isEditing]);
 
   const commitText = useCallback((nextText: string) => {
-    const value = hasCodeFence(nextText) ? normaliseCodePunctuation(nextText) : nextText;
+    const value = hasCodeFence(nextText) ? normaliseCode(nextText) : nextText;
     updateState({ text: normaliseText(value) });
   }, [updateState]);
 
   const handleEditChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     const raw = e.target.value;
     const value = hasCodeFence(raw) && SMART_PUNCT_RE.test(raw)
-      ? normaliseCodePunctuation(raw)
+      ? normaliseCode(raw)
       : raw;
     if (value !== raw) {
       const ta = e.target;
@@ -212,7 +204,7 @@ const TextBanner: React.FC<TextBannerProps> = ({ savedState, onStateChange }) =>
       // by normalising the prefix up to the original cursor so it lands at the
       // same logical position rather than mid-insertion.
       const rawCursor = ta.selectionStart;
-      const adjustedCursor = normaliseCodePunctuation(raw.slice(0, rawCursor)).length;
+      const adjustedCursor = normaliseCode(raw.slice(0, rawCursor)).length;
       setEditText(value);
       requestAnimationFrame(() => {
         if (ta.isConnected) {
@@ -301,6 +293,24 @@ const TextBanner: React.FC<TextBannerProps> = ({ savedState, onStateChange }) =>
   const adjustFontCap = (delta: number) => {
     const next = Math.min(MAX_FONT_SIZE_CAP, Math.max(MIN_FONT_SIZE_CAP, fontSizeCap + delta));
     updateState({ fontSizeCap: next });
+  };
+
+  const adjustColumnHeight = (delta: number) => {
+    if (!isColumnLayout) return;
+    const current = columnHeight ?? widgetRef.current?.offsetHeight ?? DEFAULT_COLUMN_HEIGHT;
+    const next = Math.min(MAX_COLUMN_HEIGHT, Math.max(MIN_COLUMN_HEIGHT, current + delta));
+    updateState({ columnHeight: next });
+  };
+
+  const handleResizeKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    const step = e.shiftKey ? 32 : 8;
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      adjustColumnHeight(step);
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      adjustColumnHeight(-step);
+    }
   };
 
   const pendingHeightRef = useRef<number | null>(null);
@@ -526,9 +536,7 @@ const TextBanner: React.FC<TextBannerProps> = ({ savedState, onStateChange }) =>
             ref={textRef}
             code={codeBlock.code}
             language={codeBlock.language}
-            fontFamily={fontFamily}
             fontSize={fontSize}
-            colorClass={currentColors.text}
           />
         ) : (
           <div
@@ -549,11 +557,13 @@ const TextBanner: React.FC<TextBannerProps> = ({ savedState, onStateChange }) =>
         <div
           role="separator"
           aria-orientation="horizontal"
-          aria-label="Resize banner height"
+          aria-label="Resize banner height (use arrow keys)"
+          tabIndex={0}
           onMouseDown={handleResizeMouseDown}
+          onKeyDown={handleResizeKeyDown}
           className={cn(
             'absolute bottom-0 left-0 right-0 h-2 flex items-center justify-center cursor-ns-resize select-none',
-            'opacity-0 group-hover/banner:opacity-100 transition-opacity',
+            'opacity-0 group-hover/banner:opacity-100 focus-visible:opacity-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-soft-white/70 transition-opacity',
             pendingHeight !== null && 'opacity-100'
           )}
         >
@@ -567,9 +577,7 @@ const TextBanner: React.FC<TextBannerProps> = ({ savedState, onStateChange }) =>
 interface CodeBlockRenderProps {
   code: string;
   language: string;
-  fontFamily: TextBannerFontFamily;
   fontSize: number;
-  colorClass: string;
 }
 
 const CodeBlockRender = React.forwardRef<HTMLDivElement, CodeBlockRenderProps>(
@@ -601,7 +609,7 @@ const CodeBlockRender = React.forwardRef<HTMLDivElement, CodeBlockRenderProps>(
         <pre className="text-banner-code">
           <code
             dangerouslySetInnerHTML={{
-              __html: highlighted?.html ?? escapeHtml(code)
+              __html: highlighted?.html ?? escapeHtml(normalised)
             }}
           />
         </pre>

--- a/packages/teacher/src/features/widgets/textBanner/textBanner.tsx
+++ b/packages/teacher/src/features/widgets/textBanner/textBanner.tsx
@@ -261,9 +261,8 @@ const TextBanner: React.FC<TextBannerProps> = ({ savedState, onStateChange }) =>
           onClick={stopAll}
           onDoubleClick={stopAll}
         >
-          {/* Row 1: colours + lock | fonts | dismiss */}
+          {/* Row 1: colours + lock | dismiss */}
           <div className="flex items-center gap-1.5 flex-wrap justify-center">
-            {/* Colour swatches + click-to-recolour lock */}
             <div className="flex items-center gap-1">
               {colorCombinations.map((combo, idx) => (
                 <button
@@ -294,7 +293,19 @@ const TextBanner: React.FC<TextBannerProps> = ({ savedState, onStateChange }) =>
 
             <span className="w-px h-5 bg-warm-gray-500/60 mx-0.5" aria-hidden />
 
-            {/* Font family */}
+            <button
+              type="button"
+              onClick={() => setControlsVisible(false)}
+              className="w-7 h-7 flex items-center justify-center rounded-full hover:bg-warm-gray-700/60"
+              aria-label="Hide controls"
+              title="Hide controls"
+            >
+              <FaXmark className="w-3 h-3" />
+            </button>
+          </div>
+
+          {/* Row 2: font family | font size */}
+          <div className="flex items-center gap-1.5 flex-wrap justify-center">
             <div className="flex items-center gap-1">
               {FONT_FAMILY_ORDER.map((family) => (
                 <button
@@ -318,41 +329,29 @@ const TextBanner: React.FC<TextBannerProps> = ({ savedState, onStateChange }) =>
 
             <span className="w-px h-5 bg-warm-gray-500/60 mx-0.5" aria-hidden />
 
-            {/* Dismiss */}
-            <button
-              type="button"
-              onClick={() => setControlsVisible(false)}
-              className="w-7 h-7 flex items-center justify-center rounded-full hover:bg-warm-gray-700/60"
-              aria-label="Hide controls"
-              title="Hide controls"
-            >
-              <FaXmark className="w-3 h-3" />
-            </button>
-          </div>
-
-          {/* Row 2: font size */}
-          <div className="flex items-center gap-1.5">
-            <button
-              type="button"
-              onClick={() => adjustFontCap(-FONT_SIZE_STEP)}
-              disabled={fontSizeCap <= MIN_FONT_SIZE_CAP}
-              className="w-7 h-7 flex items-center justify-center rounded-full hover:bg-warm-gray-700/60 disabled:opacity-40"
-              aria-label="Decrease maximum font size"
-              title="Decrease size"
-            >
-              <FaMinus className="w-3 h-3" />
-            </button>
-            <span className="text-[10px] tabular-nums w-8 text-center opacity-80">{fontSizeCap}px</span>
-            <button
-              type="button"
-              onClick={() => adjustFontCap(FONT_SIZE_STEP)}
-              disabled={fontSizeCap >= MAX_FONT_SIZE_CAP}
-              className="w-7 h-7 flex items-center justify-center rounded-full hover:bg-warm-gray-700/60 disabled:opacity-40"
-              aria-label="Increase maximum font size"
-              title="Increase size"
-            >
-              <FaPlus className="w-3 h-3" />
-            </button>
+            <div className="flex items-center gap-1">
+              <button
+                type="button"
+                onClick={() => adjustFontCap(-FONT_SIZE_STEP)}
+                disabled={fontSizeCap <= MIN_FONT_SIZE_CAP}
+                className="w-7 h-7 flex items-center justify-center rounded-full hover:bg-warm-gray-700/60 disabled:opacity-40"
+                aria-label="Decrease maximum font size"
+                title="Decrease size"
+              >
+                <FaMinus className="w-3 h-3" />
+              </button>
+              <span className="text-[10px] tabular-nums w-8 text-center opacity-80">{fontSizeCap}px</span>
+              <button
+                type="button"
+                onClick={() => adjustFontCap(FONT_SIZE_STEP)}
+                disabled={fontSizeCap >= MAX_FONT_SIZE_CAP}
+                className="w-7 h-7 flex items-center justify-center rounded-full hover:bg-warm-gray-700/60 disabled:opacity-40"
+                aria-label="Increase maximum font size"
+                title="Increase size"
+              >
+                <FaPlus className="w-3 h-3" />
+              </button>
+            </div>
           </div>
         </div>
       )}

--- a/packages/teacher/src/features/widgets/textBanner/textBanner.tsx
+++ b/packages/teacher/src/features/widgets/textBanner/textBanner.tsx
@@ -50,7 +50,9 @@ const normaliseText = (value: string) => (value.length > 0 ? value : PLACEHOLDER
 const SMART_PUNCT_RE = /[‘’‚‛“”„‟–—…]/;
 const hasCodeFence = (value: string) => /```/.test(value);
 
-// Returns true when the caret is between an opening and closing ``` fence.
+// Returns true when there is an odd number of ``` fences before the caret,
+// i.e. the caret sits after an open fence whose closing fence hasn't appeared
+// yet (whether it's been typed or not).
 const isCursorInsideFence = (text: string, cursor: number) => {
   let count = 0;
   let i = 0;
@@ -267,13 +269,18 @@ const TextBanner: React.FC<TextBannerProps> = ({ savedState, onStateChange }) =>
   const handleTextAreaClick = (e: React.MouseEvent) => {
     if (isEditing || e.detail !== 1 || wasDrag(e)) return;
     if (!clickToRecolour) return;
-    if (clickTimerRef.current) {
-      window.clearTimeout(clickTimerRef.current);
-    }
+    cancelPendingColorCycle();
     clickTimerRef.current = window.setTimeout(() => {
       updateState({ colorIndex: (colorIndex + 1) % colorCombinations.length });
       clickTimerRef.current = null;
     }, 500);
+  };
+
+  const cancelPendingColorCycle = () => {
+    if (clickTimerRef.current) {
+      window.clearTimeout(clickTimerRef.current);
+      clickTimerRef.current = null;
+    }
   };
 
   const enterEditMode = () => {
@@ -406,23 +413,31 @@ const TextBanner: React.FC<TextBannerProps> = ({ savedState, onStateChange }) =>
                 <button
                   key={combo.swatch}
                   type="button"
-                  onClick={() => updateState({ colorIndex: idx })}
+                  onClick={() => {
+                    cancelPendingColorCycle();
+                    updateState({ colorIndex: idx });
+                  }}
                   className={cn(
                     'w-5 h-5 rounded-full border transition-transform hover:scale-110',
                     idx === colorIndex ? 'border-soft-white ring-2 ring-soft-white/40' : 'border-warm-gray-500'
                   )}
                   style={{ backgroundColor: combo.swatch }}
                   aria-label={`Use colour ${idx + 1}`}
+                  aria-pressed={idx === colorIndex}
                 />
               ))}
               <button
                 type="button"
-                onClick={() => updateState({ clickToRecolour: !clickToRecolour })}
+                onClick={() => {
+                  cancelPendingColorCycle();
+                  updateState({ clickToRecolour: !clickToRecolour });
+                }}
                 className={cn(
                   'w-7 h-7 ml-1 flex items-center justify-center rounded-full transition-colors',
                   clickToRecolour ? 'hover:bg-warm-gray-700/60' : 'bg-soft-white text-warm-gray-900'
                 )}
                 aria-label={clickToRecolour ? 'Disable click-to-recolour' : 'Enable click-to-recolour'}
+                aria-pressed={!clickToRecolour}
                 title={clickToRecolour ? 'Click cycles colour — click to lock' : 'Colour locked — click to unlock'}
               >
                 {clickToRecolour ? <FaLockOpen className="w-3 h-3" /> : <FaLock className="w-3 h-3" />}
@@ -459,6 +474,7 @@ const TextBanner: React.FC<TextBannerProps> = ({ savedState, onStateChange }) =>
                   style={{ fontFamily: FONT_FAMILY_STACK[family] }}
                   title={FONT_FAMILY_LABEL[family]}
                   aria-label={`Use ${FONT_FAMILY_LABEL[family]} font`}
+                  aria-pressed={fontFamily === family}
                 >
                   Aa
                 </button>

--- a/packages/teacher/src/features/widgets/textBanner/textBanner.tsx
+++ b/packages/teacher/src/features/widgets/textBanner/textBanner.tsx
@@ -518,6 +518,7 @@ const TextBanner: React.FC<TextBannerProps> = ({ savedState, onStateChange }) =>
               onBlur={handleBlur}
               onMouseDown={(e) => e.stopPropagation()}
               onClick={(e) => e.stopPropagation()}
+              onDoubleClick={(e) => e.stopPropagation()}
               spellCheck={!hasCodeFence(editText)}
               autoCorrect="off"
               autoCapitalize="off"

--- a/packages/teacher/src/features/widgets/textBanner/textBanner.tsx
+++ b/packages/teacher/src/features/widgets/textBanner/textBanner.tsx
@@ -7,7 +7,7 @@ import {
   FONT_FAMILY_ORDER,
   TextBannerFontFamily
 } from './fonts';
-import { findCodeBlock, highlightCode, type HighlightedCode } from './highlight';
+import { findCodeBlock, highlightCode, normaliseCode, type HighlightedCode } from './highlight';
 import { cn, widgetContainer } from '@shared/utils/styles';
 import { useWidgetState } from '@shared/hooks/useWidgetState';
 import { useWorkspaceStore } from '../../../store/workspaceStore.simple';
@@ -46,6 +46,17 @@ const MAX_FONT_SIZE_CAP = 220;
 const FONT_SIZE_STEP = 16;
 
 const normaliseText = (value: string) => (value.length > 0 ? value : PLACEHOLDER_TEXT);
+
+const SMART_PUNCT_RE = /[‘’‚‛“”„‟–—…]/;
+const hasCodeFence = (value: string) => /```/.test(value);
+
+const normaliseCodePunctuation = (value: string) =>
+  value
+    .replace(/[‘’‚‛]/g, "'")
+    .replace(/[“”„‟]/g, '"')
+    .replace(/–/g, '-')
+    .replace(/—/g, '--')
+    .replace(/…/g, '...');
 
 const formatInlineText = (line: string) => {
   const tokens = line.split(/(\*_[^_]+_\*|\*[^*]+\*|_[^_]+_|~[^~]+~|`[^`]+`)/g);
@@ -185,8 +196,28 @@ const TextBanner: React.FC<TextBannerProps> = ({ savedState, onStateChange }) =>
   }, [controlsVisible, isEditing]);
 
   const commitText = useCallback((nextText: string) => {
-    updateState({ text: normaliseText(nextText) });
+    const value = hasCodeFence(nextText) ? normaliseCodePunctuation(nextText) : nextText;
+    updateState({ text: normaliseText(value) });
   }, [updateState]);
+
+  const handleEditChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const raw = e.target.value;
+    const value = hasCodeFence(raw) && SMART_PUNCT_RE.test(raw)
+      ? normaliseCodePunctuation(raw)
+      : raw;
+    if (value !== raw) {
+      const ta = e.target;
+      const cursor = ta.selectionStart;
+      setEditText(value);
+      requestAnimationFrame(() => {
+        if (ta.isConnected) {
+          ta.selectionStart = ta.selectionEnd = cursor;
+        }
+      });
+    } else {
+      setEditText(value);
+    }
+  };
 
   const handleBlur = () => {
     commitText(editText);
@@ -199,6 +230,20 @@ const TextBanner: React.FC<TextBannerProps> = ({ savedState, onStateChange }) =>
       commitText(editText);
       setIsEditing(false);
       setControlsVisible(false);
+      return;
+    }
+    if (e.key === 'Tab' && hasCodeFence(editText)) {
+      e.preventDefault();
+      const ta = e.currentTarget;
+      const start = ta.selectionStart;
+      const end = ta.selectionEnd;
+      const next = editText.slice(0, start) + '  ' + editText.slice(end);
+      setEditText(next);
+      requestAnimationFrame(() => {
+        if (ta.isConnected) {
+          ta.selectionStart = ta.selectionEnd = start + 2;
+        }
+      });
     }
   };
 
@@ -421,12 +466,20 @@ const TextBanner: React.FC<TextBannerProps> = ({ savedState, onStateChange }) =>
           <textarea
             ref={textareaRef}
             value={editText}
-            onChange={(e) => setEditText(e.target.value)}
+            onChange={handleEditChange}
             onKeyDown={handleKeyDown}
             onBlur={handleBlur}
             onMouseDown={(e) => e.stopPropagation()}
             onClick={(e) => e.stopPropagation()}
-            style={{ fontFamily: FONT_FAMILY_STACK[fontFamily] }}
+            spellCheck={!hasCodeFence(editText)}
+            autoCorrect="off"
+            autoCapitalize="off"
+            autoComplete="off"
+            data-gramm="false"
+            data-enable-grammarly="false"
+            style={{
+              fontFamily: hasCodeFence(editText) ? FONT_FAMILY_STACK.mono : FONT_FAMILY_STACK[fontFamily]
+            }}
             className="w-full h-full p-4 text-base bg-soft-white dark:bg-warm-gray-700 text-warm-gray-800 dark:text-warm-gray-200 rounded-md resize-none focus:outline-none focus:ring-2 focus:ring-terracotta-600 dark:focus:ring-terracotta-500"
             placeholder="Enter your message... (use ```language for code blocks)"
             autoFocus
@@ -486,28 +539,27 @@ const CodeBlockRender = React.forwardRef<HTMLDivElement, CodeBlockRenderProps>(
   ({ code, language, fontSize }, ref) => {
     const [highlighted, setHighlighted] = useState<HighlightedCode | null>(null);
 
+    const normalised = useMemo(() => normaliseCode(code), [code]);
+
     useEffect(() => {
       let cancelled = false;
-      highlightCode(code, language)
+      highlightCode(normalised, language)
         .then((result) => {
           if (!cancelled) setHighlighted(result);
         })
         .catch(() => {
-          if (!cancelled) setHighlighted({ html: escapeHtml(code), language: 'plaintext' });
+          if (!cancelled) setHighlighted({ html: escapeHtml(normalised), language: 'plaintext' });
         });
       return () => {
         cancelled = true;
       };
-    }, [code, language]);
-
-    // Use a smaller font for code so it fits more easily
-    const codeFontSize = Math.max(12, Math.round(fontSize * 0.7));
+    }, [normalised, language]);
 
     return (
       <div
         ref={ref}
-        className="w-full max-w-full"
-        style={{ fontSize: `${codeFontSize}px` }}
+        className="max-w-full"
+        style={{ fontSize: `${fontSize}px` }}
       >
         <pre className="text-banner-code">
           <code

--- a/packages/teacher/src/features/widgets/textBanner/textBanner.tsx
+++ b/packages/teacher/src/features/widgets/textBanner/textBanner.tsx
@@ -208,11 +208,15 @@ const TextBanner: React.FC<TextBannerProps> = ({ savedState, onStateChange }) =>
       : raw;
     if (value !== raw) {
       const ta = e.target;
-      const cursor = ta.selectionStart;
+      // Some replacements change length (— → --, … → ...). Adjust the cursor
+      // by normalising the prefix up to the original cursor so it lands at the
+      // same logical position rather than mid-insertion.
+      const rawCursor = ta.selectionStart;
+      const adjustedCursor = normaliseCodePunctuation(raw.slice(0, rawCursor)).length;
       setEditText(value);
       requestAnimationFrame(() => {
         if (ta.isConnected) {
-          ta.selectionStart = ta.selectionEnd = cursor;
+          ta.selectionStart = ta.selectionEnd = adjustedCursor;
         }
       });
     } else {

--- a/packages/teacher/src/features/widgets/textBanner/textBanner.tsx
+++ b/packages/teacher/src/features/widgets/textBanner/textBanner.tsx
@@ -18,7 +18,12 @@ interface TextBannerState {
   fontFamily: TextBannerFontFamily;
   fontSizeCap: number;
   clickToRecolour: boolean;
+  columnHeight?: number;
 }
+
+const DEFAULT_COLUMN_HEIGHT = 160;
+const MIN_COLUMN_HEIGHT = 60;
+const MAX_COLUMN_HEIGHT = 1200;
 
 interface TextBannerProps {
   savedState?: Partial<TextBannerState> & { text: string };
@@ -111,7 +116,8 @@ const TextBanner: React.FC<TextBannerProps> = ({ savedState, onStateChange }) =>
         colorIndex: savedState.colorIndex ?? 0,
         fontFamily: savedState.fontFamily ?? 'sans',
         fontSizeCap: savedState.fontSizeCap ?? DEFAULT_FONT_SIZE_CAP,
-        clickToRecolour: savedState.clickToRecolour ?? true
+        clickToRecolour: savedState.clickToRecolour ?? true,
+        columnHeight: savedState.columnHeight
       }
     : undefined;
 
@@ -121,22 +127,25 @@ const TextBanner: React.FC<TextBannerProps> = ({ savedState, onStateChange }) =>
     onStateChange
   });
 
-  const { text, colorIndex, fontFamily, fontSizeCap, clickToRecolour } = state;
+  const { text, colorIndex, fontFamily, fontSizeCap, clickToRecolour, columnHeight } = state;
 
   const [isEditing, setIsEditing] = useState(false);
   const [editText, setEditText] = useState(text);
   const [controlsVisible, setControlsVisible] = useState(() => !savedState);
+  const [pendingHeight, setPendingHeight] = useState<number | null>(null);
 
   const widgetRef = useRef<HTMLDivElement>(null);
   const textAreaContainerRef = useRef<HTMLDivElement>(null);
   const textRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const resizeStartRef = useRef<{ y: number; startHeight: number } | null>(null);
   const clickTimerRef = useRef<number | null>(null);
   const mouseDownPosRef = useRef<{ x: number; y: number } | null>(null);
 
   const codeBlock = useMemo(() => findCodeBlock(text), [text]);
   const isCodeBlockOnly = codeBlock?.match.trim() === text.trim();
 
+  const hasManualColumnHeight = isColumnLayout && columnHeight !== undefined;
   const fontSize = useAutoFontSize({
     text,
     containerRef: textAreaContainerRef,
@@ -144,7 +153,7 @@ const TextBanner: React.FC<TextBannerProps> = ({ savedState, onStateChange }) =>
     maxSize: fontSizeCap,
     minSize: isColumnLayout ? 18 : 12,
     padding: 32,
-    widthOnly: isColumnLayout
+    widthOnly: isColumnLayout && !hasManualColumnHeight
   });
 
   useEffect(() => {
@@ -244,14 +253,55 @@ const TextBanner: React.FC<TextBannerProps> = ({ savedState, onStateChange }) =>
     updateState({ fontSizeCap: next });
   };
 
+  const pendingHeightRef = useRef<number | null>(null);
+
+  const handleResizeMouseDown = (e: React.MouseEvent) => {
+    if (!isColumnLayout) return;
+    e.preventDefault();
+    e.stopPropagation();
+    const startHeight = widgetRef.current?.offsetHeight ?? columnHeight ?? DEFAULT_COLUMN_HEIGHT;
+    resizeStartRef.current = { y: e.clientY, startHeight };
+    pendingHeightRef.current = startHeight;
+    setPendingHeight(startHeight);
+
+    const handleMove = (ev: MouseEvent) => {
+      if (!resizeStartRef.current) return;
+      const delta = ev.clientY - resizeStartRef.current.y;
+      const next = Math.min(
+        MAX_COLUMN_HEIGHT,
+        Math.max(MIN_COLUMN_HEIGHT, resizeStartRef.current.startHeight + delta)
+      );
+      pendingHeightRef.current = next;
+      setPendingHeight(next);
+    };
+
+    const handleUp = () => {
+      document.removeEventListener('mousemove', handleMove);
+      document.removeEventListener('mouseup', handleUp);
+      const final = pendingHeightRef.current;
+      resizeStartRef.current = null;
+      pendingHeightRef.current = null;
+      setPendingHeight(null);
+      if (final !== null) {
+        updateState({ columnHeight: final });
+      }
+    };
+
+    document.addEventListener('mousemove', handleMove);
+    document.addEventListener('mouseup', handleUp);
+  };
+
+  const effectiveColumnHeight = pendingHeight ?? columnHeight;
+
   return (
     <div
       ref={widgetRef}
       className={cn(
         widgetContainer,
         currentColors.bg,
-        'relative overflow-hidden transition-colors duration-300 flex flex-col'
+        'relative overflow-hidden transition-colors duration-300 flex flex-col group/banner'
       )}
+      style={isColumnLayout && effectiveColumnHeight ? { height: `${effectiveColumnHeight}px` } : undefined}
       onDoubleClick={handleDoubleClick}
     >
       {controlsVisible && (
@@ -359,7 +409,7 @@ const TextBanner: React.FC<TextBannerProps> = ({ savedState, onStateChange }) =>
       <div
         ref={textAreaContainerRef}
         className={cn(
-          'flex-1 flex items-center justify-center p-4 relative',
+          'flex-1 min-h-0 flex items-center justify-center p-4 relative overflow-hidden',
           clickToRecolour && !isEditing ? 'cursor-pointer' : ''
         )}
         onMouseDown={(e) => {
@@ -404,6 +454,22 @@ const TextBanner: React.FC<TextBannerProps> = ({ savedState, onStateChange }) =>
           </div>
         )}
       </div>
+
+      {isColumnLayout && (
+        <div
+          role="separator"
+          aria-orientation="horizontal"
+          aria-label="Resize banner height"
+          onMouseDown={handleResizeMouseDown}
+          className={cn(
+            'absolute bottom-0 left-0 right-0 h-2 flex items-center justify-center cursor-ns-resize select-none',
+            'opacity-0 group-hover/banner:opacity-100 transition-opacity',
+            pendingHeight !== null && 'opacity-100'
+          )}
+        >
+          <div className="w-10 h-1 rounded-full bg-soft-white/60" />
+        </div>
+      )}
     </div>
   );
 };

--- a/packages/teacher/src/features/widgets/textBanner/textBanner.tsx
+++ b/packages/teacher/src/features/widgets/textBanner/textBanner.tsx
@@ -164,7 +164,8 @@ const TextBanner: React.FC<TextBannerProps> = ({ savedState, onStateChange }) =>
     maxSize: fontSizeCap,
     minSize: isColumnLayout ? 18 : 12,
     padding: 32,
-    widthOnly: isColumnLayout && !hasManualColumnHeight
+    widthOnly: isColumnLayout && !hasManualColumnHeight,
+    fontFamily
   });
 
   useEffect(() => {
@@ -299,6 +300,15 @@ const TextBanner: React.FC<TextBannerProps> = ({ savedState, onStateChange }) =>
   };
 
   const pendingHeightRef = useRef<number | null>(null);
+  const resizeCleanupRef = useRef<(() => void) | null>(null);
+
+  // Make sure any in-progress drag listeners are torn down on unmount.
+  useEffect(() => {
+    return () => {
+      resizeCleanupRef.current?.();
+      resizeCleanupRef.current = null;
+    };
+  }, []);
 
   const handleResizeMouseDown = (e: React.MouseEvent) => {
     if (!isColumnLayout) return;
@@ -320,9 +330,14 @@ const TextBanner: React.FC<TextBannerProps> = ({ savedState, onStateChange }) =>
       setPendingHeight(next);
     };
 
-    const handleUp = () => {
+    const detach = () => {
       document.removeEventListener('mousemove', handleMove);
       document.removeEventListener('mouseup', handleUp);
+      resizeCleanupRef.current = null;
+    };
+
+    const handleUp = () => {
+      detach();
       const final = pendingHeightRef.current;
       resizeStartRef.current = null;
       pendingHeightRef.current = null;
@@ -332,6 +347,7 @@ const TextBanner: React.FC<TextBannerProps> = ({ savedState, onStateChange }) =>
       }
     };
 
+    resizeCleanupRef.current = detach;
     document.addEventListener('mousemove', handleMove);
     document.addEventListener('mouseup', handleUp);
   };
@@ -351,7 +367,7 @@ const TextBanner: React.FC<TextBannerProps> = ({ savedState, onStateChange }) =>
     >
       {controlsVisible && (
         <div
-          className="flex-shrink-0 m-2 z-20 flex flex-col items-center gap-1 px-2 py-1.5 rounded-2xl bg-warm-gray-900/85 dark:bg-black/80 text-soft-white backdrop-blur-sm shadow-lg text-xs select-none self-center max-w-[calc(100%-1rem)]"
+          className="flex-shrink-0 z-20 flex flex-col items-center gap-1.5 px-3 py-2 bg-warm-gray-900/85 dark:bg-black/80 text-soft-white backdrop-blur-sm text-xs select-none"
           onMouseDown={preventToolbarBlur}
           onClick={stopAll}
           onDoubleClick={stopAll}
@@ -454,7 +470,10 @@ const TextBanner: React.FC<TextBannerProps> = ({ savedState, onStateChange }) =>
       <div
         ref={textAreaContainerRef}
         className={cn(
-          'flex-1 min-h-0 flex items-center justify-center p-4 relative overflow-hidden',
+          'flex-1 flex items-center justify-center p-4 relative',
+          // Only constrain the content pane when the widget itself has a bounded height
+          // (canvas mode is always bounded via react-rnd; column mode only when columnHeight is set).
+          (!isColumnLayout || hasManualColumnHeight) && 'min-h-0 overflow-hidden',
           clickToRecolour && !isEditing ? 'cursor-pointer' : ''
         )}
         onMouseDown={(e) => {

--- a/packages/teacher/src/features/widgets/textBanner/textBanner.tsx
+++ b/packages/teacher/src/features/widgets/textBanner/textBanner.tsx
@@ -463,27 +463,41 @@ const TextBanner: React.FC<TextBannerProps> = ({ savedState, onStateChange }) =>
         onClick={handleTextAreaClick}
       >
         {isEditing ? (
-          <textarea
-            ref={textareaRef}
-            value={editText}
-            onChange={handleEditChange}
-            onKeyDown={handleKeyDown}
-            onBlur={handleBlur}
-            onMouseDown={(e) => e.stopPropagation()}
-            onClick={(e) => e.stopPropagation()}
-            spellCheck={!hasCodeFence(editText)}
-            autoCorrect="off"
-            autoCapitalize="off"
-            autoComplete="off"
-            data-gramm="false"
-            data-enable-grammarly="false"
-            style={{
-              fontFamily: hasCodeFence(editText) ? FONT_FAMILY_STACK.mono : FONT_FAMILY_STACK[fontFamily]
-            }}
-            className="w-full h-full p-4 text-base bg-soft-white dark:bg-warm-gray-700 text-warm-gray-800 dark:text-warm-gray-200 rounded-md resize-none focus:outline-none focus:ring-2 focus:ring-terracotta-600 dark:focus:ring-terracotta-500"
-            placeholder="Enter your message... (use ```language for code blocks)"
-            autoFocus
-          />
+          <div className="flex flex-col w-full h-full gap-1">
+            <textarea
+              ref={textareaRef}
+              value={editText}
+              onChange={handleEditChange}
+              onKeyDown={handleKeyDown}
+              onBlur={handleBlur}
+              onMouseDown={(e) => e.stopPropagation()}
+              onClick={(e) => e.stopPropagation()}
+              spellCheck={!hasCodeFence(editText)}
+              autoCorrect="off"
+              autoCapitalize="off"
+              autoComplete="off"
+              data-gramm="false"
+              data-enable-grammarly="false"
+              style={{
+                fontFamily: hasCodeFence(editText) ? FONT_FAMILY_STACK.mono : FONT_FAMILY_STACK[fontFamily]
+              }}
+              className="flex-1 min-h-0 w-full p-4 text-base bg-soft-white dark:bg-warm-gray-700 text-warm-gray-800 dark:text-warm-gray-200 rounded-md resize-none focus:outline-none focus:ring-2 focus:ring-terracotta-600 dark:focus:ring-terracotta-500"
+              placeholder="Enter your message... (use ```language for code blocks)"
+              autoFocus
+            />
+            <div className={cn('text-[11px] text-center opacity-70 select-none', currentColors.text)}>
+              <a
+                href="https://commonmark.org/help/"
+                target="_blank"
+                rel="noopener noreferrer"
+                onMouseDown={(e) => e.preventDefault()}
+                className="underline hover:opacity-100"
+              >
+                Markdown
+              </a>{' '}
+              supported (subset)
+            </div>
+          </div>
         ) : isCodeBlockOnly && codeBlock ? (
           <CodeBlockRender
             ref={textRef}


### PR DESCRIPTION
## Summary

Substantial upgrade to the Text Banner widget plus a small Add Widget launchpad responsiveness fix that landed alongside it.

- **Edit-mode toolbar** appears on creation and when editing (full-width flush bar at the top, dismissed on outside click). Row 1 picks colours (six swatches + a lock to disable single-click-to-recolour). Row 2 picks font family (Poppins / Lora / Roboto Slab / JetBrains Mono via Google Fonts) and font-size cap.
- **Smarter auto-fit**: lower default cap (96px), constrains by both width and height when the widget is height-bounded, recalculates on cap / family / size changes.
- **Column-mode vertical resize handle** for content-height banners. Canvas mode keeps its existing react-rnd 4-way resize.
- **Code blocks**: paste ` ``` ` fenced content and `highlight.js` is lazy-loaded with a palette-friendly stylesheet. Smart quotes are normalised (input + render) and the textarea switches to monospace inside a fence; Tab inserts two spaces inside code.
- **Markdown hint** below the textarea linking to https://commonmark.org/help/.
- **Add Widget modal** is now responsive at narrow widths (`packages/teacher/src/features/hud/components/BottomBar.tsx`, `WidgetLaunchpad.tsx`).

## Review

Multi-round Codex review surfaced four real issues (P1 + three P2s) — all addressed in the final commit:
- `fontSizeCap` changes didn't re-run auto-fit
- Column-resize document listeners could leak on unmount
- `fontFamily` changes didn't re-run auto-fit
- `flex-1 min-h-0` regressed content-driven height in column 'content' mode

## Test plan

- [ ] Add a Text Banner (column mode) — controls appear; edit, type, dismiss; controls hide.
- [ ] Switch font family during edit; verify text resizes to fit.
- [ ] Click +/-; verify the rendered text actually grows/shrinks.
- [ ] Drag the bottom handle in column mode; verify smooth resize and font auto-fit.
- [ ] Type a ```` ```python … ``` ```` block; verify highlight, straight quotes, Tab insertion.
- [ ] Switch to canvas layout; verify 4-way Rnd resize works including diagonal.
- [ ] Open the Add Widget modal at narrow widths; verify layout doesn't clip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)