### PR TITLE
Add macOS dashboard distribution build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ packages/macos-dashboard/.build/
 .env.production.local
 .env.staging
 .env.staging.local
+.env.release.local
 
 # Only .example files should be committed
 # .env.example ✓ (committed)

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -24,6 +24,7 @@ Avoid `any` in widget state callbacks. Declare explicit shapes for saved state a
 Keep networked widgets on the shared patterns (`useNetworkedWidget`, `useNetworkedWidgetState`, `useSocketEvents`).
 Keep commits atomic and add files explicitly.
 Use `tmux` for long-running commands and `trash` instead of `rm` for deletions.
+For macOS app work, use `npm run macos:run -- --verify` for local verification and `npm run macos:dmg -- --distribution --notarise` for public-downloadable DMGs. The app should be installed and launched from `/Applications/Classroom Widgets Dashboard.app` after successful local or release builds so macOS camera permission stays tied to the canonical app location.
 
 ---
 
@@ -55,6 +56,8 @@ npm test           # Run tests with Vitest
 # Building
 npm run build      # Build teacher app (auto-generates voice types)
 npm run build:all  # Build all applications (teacher + student)
+npm run macos:run -- --verify  # Build, install to /Applications, launch, and verify the macOS dashboard
+npm run macos:dmg -- --distribution --notarise  # Build a Developer ID signed, notarised DMG
 
 # Setup
 npm run install:all  # Install dependencies for all workspaces

--- a/docs/MACOS_DISTRIBUTION.md
+++ b/docs/MACOS_DISTRIBUTION.md
@@ -1,0 +1,63 @@
+# macOS distribution
+
+The macOS dashboard app is built locally from the teacher production build and the SwiftPM package in `packages/macos-dashboard`.
+
+## Local run
+
+```bash
+npm run macos:run -- --verify
+```
+
+This writes `dist/Classroom Widgets Dashboard.app`, opens it, and verifies that `ClassroomWidgetsDashboard` is running.
+
+## Local DMG
+
+```bash
+npm run macos:dmg
+```
+
+This creates an ad hoc signed local DMG at:
+
+```text
+dist/ClassroomWidgetsDashboard-v<version>-macos.dmg
+```
+
+Use this only for local packaging checks. It is not suitable for public download.
+
+## Developer ID DMG
+
+Create a local `.env.release.local` with machine-specific credentials:
+
+```bash
+APPLE_SIGNING_IDENTITY="Developer ID Application: Tinkertanker (TEAMID)"
+APPLE_TEAM_ID="TEAMID"
+APPLE_API_KEY_PATH="/path/to/AuthKey_KEYID.p8"
+APPLE_API_KEY_ID="KEYID"
+APPLE_API_KEY_ISSUER_ID="ISSUER-UUID"
+```
+
+Build a signed DMG:
+
+```bash
+npm run macos:dmg -- --distribution
+```
+
+Build, notarise, and staple a public-downloadable DMG:
+
+```bash
+npm run macos:dmg -- --distribution --notarise
+```
+
+The distribution signature uses hardened runtime and `script/macos-distribution-entitlements.plist`, which includes camera access for the Visualiser widget.
+
+## Validation
+
+Useful checks:
+
+```bash
+codesign -dvvv --entitlements :- "dist/Classroom Widgets Dashboard.app"
+codesign --verify --deep --strict --verbose=2 "dist/Classroom Widgets Dashboard.app"
+codesign --verify --strict --verbose=2 "dist/ClassroomWidgetsDashboard-v<version>-macos.dmg"
+xcrun stapler validate "dist/ClassroomWidgetsDashboard-v<version>-macos.dmg"
+spctl -a -vv -t open --context context:primary-signature "dist/ClassroomWidgetsDashboard-v<version>-macos.dmg"
+```

--- a/docs/MACOS_DISTRIBUTION.md
+++ b/docs/MACOS_DISTRIBUTION.md
@@ -9,6 +9,7 @@ npm run macos:run -- --verify
 ```
 
 This writes `dist/Classroom Widgets Dashboard.app`, opens it, and verifies that `ClassroomWidgetsDashboard` is running.
+The app is installed and launched from `/Applications/Classroom Widgets Dashboard.app` after each successful local run build so macOS camera permission remains tied to the canonical app location.
 
 ## Local DMG
 
@@ -23,6 +24,7 @@ dist/ClassroomWidgetsDashboard-v<version>-macos.dmg
 ```
 
 Use this only for local packaging checks. It is not suitable for public download.
+The built app is also installed to `/Applications/Classroom Widgets Dashboard.app`.
 
 ## Developer ID DMG
 
@@ -49,6 +51,7 @@ npm run macos:dmg -- --distribution --notarise
 ```
 
 The distribution signature uses hardened runtime and `script/macos-distribution-entitlements.plist`, which includes camera access for the Visualiser widget.
+Successful release builds also install the signed app to `/Applications/Classroom Widgets Dashboard.app` before packaging the DMG.
 
 ## Validation
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "test:build-config": "node scripts/check-root-build-config.cjs",
     "generate:voice-types": "node scripts/generateVoiceCommandTypes.cjs",
     "prebuild": "npm run generate:voice-types",
+    "macos:run": "./script/build_and_run.sh",
+    "macos:dmg": "./script/build_macos_release.sh",
     "server": "npm run start -w @classroom-widgets/server",
     "install:all": "npm install",
     "clean": "node scripts/clean-workspaces.cjs"

--- a/packages/macos-dashboard/Sources/ClassroomWidgetsDashboard/DashboardHotKey.swift
+++ b/packages/macos-dashboard/Sources/ClassroomWidgetsDashboard/DashboardHotKey.swift
@@ -37,7 +37,7 @@ final class DashboardHotKey {
                   hotKeyID.signature == DashboardHotKey.signature,
                   hotKeyID.id == instance.id
             else {
-                return noErr
+                return OSStatus(eventNotHandledErr)
             }
 
             instance.handler()

--- a/packages/macos-dashboard/Sources/ClassroomWidgetsDashboard/DashboardSettings.swift
+++ b/packages/macos-dashboard/Sources/ClassroomWidgetsDashboard/DashboardSettings.swift
@@ -24,8 +24,8 @@ enum DashboardDefaults {
             DashboardSettingKeys.toggleShortcutModifiers: shortcutModifiers,
             DashboardSettingKeys.launcherShortcutKeyCode: launcherShortcutKeyCode,
             DashboardSettingKeys.launcherShortcutModifiers: shortcutModifiers,
-            DashboardSettingKeys.showDashboardAtLaunch: true,
-            DashboardSettingKeys.clickThroughEmptyAreas: true,
+            DashboardSettingKeys.showDashboardAtLaunch: false,
+            DashboardSettingKeys.clickThroughEmptyAreas: false,
             DashboardSettingKeys.keepOnAllSpaces: true,
             DashboardSettingKeys.floatingOverlay: true
         ])
@@ -73,8 +73,7 @@ struct DashboardSettingsView: View {
     @AppStorage(DashboardSettingKeys.toggleShortcutModifiers) private var toggleShortcutModifiers = DashboardDefaults.shortcutModifiers
     @AppStorage(DashboardSettingKeys.launcherShortcutKeyCode) private var launcherShortcutKeyCode = DashboardDefaults.launcherShortcutKeyCode
     @AppStorage(DashboardSettingKeys.launcherShortcutModifiers) private var launcherShortcutModifiers = DashboardDefaults.shortcutModifiers
-    @AppStorage(DashboardSettingKeys.showDashboardAtLaunch) private var showDashboardAtLaunch = true
-    @AppStorage(DashboardSettingKeys.clickThroughEmptyAreas) private var clickThroughEmptyAreas = true
+    @AppStorage(DashboardSettingKeys.showDashboardAtLaunch) private var showDashboardAtLaunch = false
     @AppStorage(DashboardSettingKeys.keepOnAllSpaces) private var keepOnAllSpaces = true
     @AppStorage(DashboardSettingKeys.floatingOverlay) private var floatingOverlay = true
 
@@ -97,9 +96,7 @@ struct DashboardSettingsView: View {
                     }
                 }
 
-                Section("Overlay") {
-                    Toggle("Click through empty dashboard areas", isOn: $clickThroughEmptyAreas)
-
+                Section("Dashboard Layer") {
                     Toggle("Show on all Spaces", isOn: $keepOnAllSpaces)
 
                     Toggle("Float above other windows", isOn: $floatingOverlay)
@@ -163,7 +160,6 @@ struct DashboardSettingsView: View {
 
     private var windowBehaviorSignature: String {
         [
-            clickThroughEmptyAreas,
             keepOnAllSpaces,
             floatingOverlay
         ].map(String.init).joined(separator: ":")

--- a/packages/macos-dashboard/Sources/ClassroomWidgetsDashboard/DashboardSettings.swift
+++ b/packages/macos-dashboard/Sources/ClassroomWidgetsDashboard/DashboardSettings.swift
@@ -25,7 +25,7 @@ enum DashboardDefaults {
             DashboardSettingKeys.launcherShortcutKeyCode: launcherShortcutKeyCode,
             DashboardSettingKeys.launcherShortcutModifiers: shortcutModifiers,
             DashboardSettingKeys.showDashboardAtLaunch: false,
-            DashboardSettingKeys.clickThroughEmptyAreas: false,
+            DashboardSettingKeys.clickThroughEmptyAreas: true,
             DashboardSettingKeys.keepOnAllSpaces: true,
             DashboardSettingKeys.floatingOverlay: true
         ])
@@ -74,6 +74,7 @@ struct DashboardSettingsView: View {
     @AppStorage(DashboardSettingKeys.launcherShortcutKeyCode) private var launcherShortcutKeyCode = DashboardDefaults.launcherShortcutKeyCode
     @AppStorage(DashboardSettingKeys.launcherShortcutModifiers) private var launcherShortcutModifiers = DashboardDefaults.shortcutModifiers
     @AppStorage(DashboardSettingKeys.showDashboardAtLaunch) private var showDashboardAtLaunch = false
+    @AppStorage(DashboardSettingKeys.clickThroughEmptyAreas) private var clickThroughEmptyAreas = true
     @AppStorage(DashboardSettingKeys.keepOnAllSpaces) private var keepOnAllSpaces = true
     @AppStorage(DashboardSettingKeys.floatingOverlay) private var floatingOverlay = true
 
@@ -100,6 +101,8 @@ struct DashboardSettingsView: View {
                     Toggle("Show on all Spaces", isOn: $keepOnAllSpaces)
 
                     Toggle("Float above other windows", isOn: $floatingOverlay)
+
+                    Toggle("Click through empty dashboard areas", isOn: $clickThroughEmptyAreas)
                 }
             }
             .formStyle(.grouped)
@@ -160,6 +163,7 @@ struct DashboardSettingsView: View {
 
     private var windowBehaviorSignature: String {
         [
+            clickThroughEmptyAreas,
             keepOnAllSpaces,
             floatingOverlay
         ].map(String.init).joined(separator: ":")

--- a/packages/macos-dashboard/Sources/ClassroomWidgetsDashboard/DashboardWindowController.swift
+++ b/packages/macos-dashboard/Sources/ClassroomWidgetsDashboard/DashboardWindowController.swift
@@ -200,7 +200,7 @@ final class DashboardWindowController: NSWindowController {
     }
 
     private static func combinedVisibleFrame() -> NSRect {
-        NSScreen.screens.reduce(NSRect.zero) { partial, screen in
+        NSScreen.screens.reduce(NSRect.null) { partial, screen in
             partial.union(screen.visibleFrame)
         }
     }

--- a/packages/macos-dashboard/Sources/ClassroomWidgetsDashboard/DashboardWindowController.swift
+++ b/packages/macos-dashboard/Sources/ClassroomWidgetsDashboard/DashboardWindowController.swift
@@ -5,6 +5,9 @@ final class DashboardWindowController: NSWindowController {
     private let webView: WKWebView
     private let scriptMessageHandler: DashboardScriptMessageHandler
     private var dashboardVisible: Bool
+    private var interactiveRegions: [CGRect] = []
+    private var localMouseMonitor: Any?
+    private var globalMouseMonitor: Any?
     var isDashboardVisible: Bool { dashboardVisible }
 
     init() {
@@ -40,10 +43,17 @@ final class DashboardWindowController: NSWindowController {
 
         super.init(window: window)
         applySettings()
+        installMouseMonitors()
 
         scriptMessageHandler.onVisibilityChanged = { [weak self] visible in
-            self?.dashboardVisible = visible
-            self?.window?.ignoresMouseEvents = !visible
+            guard let self else { return }
+            self.dashboardVisible = visible
+            self.updateMousePassthrough()
+        }
+        scriptMessageHandler.onInteractiveRegionsChanged = { [weak self] regions in
+            guard let self else { return }
+            self.interactiveRegions = regions
+            self.updateMousePassthrough()
         }
         webView.configuration.userContentController.add(scriptMessageHandler, name: "classroomDashboard")
         loadDashboard()
@@ -54,6 +64,12 @@ final class DashboardWindowController: NSWindowController {
     }
 
     deinit {
+        if let localMouseMonitor {
+            NSEvent.removeMonitor(localMouseMonitor)
+        }
+        if let globalMouseMonitor {
+            NSEvent.removeMonitor(globalMouseMonitor)
+        }
         webView.configuration.userContentController.removeScriptMessageHandler(forName: "classroomDashboard")
     }
 
@@ -64,7 +80,7 @@ final class DashboardWindowController: NSWindowController {
         applySettings()
         window?.makeKeyAndOrderFront(nil)
         window?.orderFrontRegardless()
-        window?.ignoresMouseEvents = false
+        updateMousePassthrough()
         NSApp.activate(ignoringOtherApps: true)
         setWebDashboardVisible(true)
     }
@@ -76,7 +92,7 @@ final class DashboardWindowController: NSWindowController {
         if dashboardVisible {
             window?.makeKeyAndOrderFront(nil)
             window?.orderFrontRegardless()
-            window?.ignoresMouseEvents = false
+            updateMousePassthrough()
             NSApp.activate(ignoringOtherApps: true)
         } else {
             window?.ignoresMouseEvents = true
@@ -110,7 +126,58 @@ final class DashboardWindowController: NSWindowController {
             return
         }
 
-        window.ignoresMouseEvents = false
+        updateMousePassthrough()
+    }
+
+    private func installMouseMonitors() {
+        localMouseMonitor = NSEvent.addLocalMonitorForEvents(matching: [
+            .mouseMoved,
+            .leftMouseDragged,
+            .rightMouseDragged,
+            .otherMouseDragged,
+            .leftMouseDown,
+            .rightMouseDown,
+            .otherMouseDown
+        ]) { [weak self] event in
+            self?.updateMousePassthrough()
+            return event
+        }
+
+        globalMouseMonitor = NSEvent.addGlobalMonitorForEvents(matching: [
+            .mouseMoved,
+            .leftMouseDragged,
+            .rightMouseDragged,
+            .otherMouseDragged,
+            .leftMouseDown,
+            .rightMouseDown,
+            .otherMouseDown
+        ]) { [weak self] _ in
+            self?.updateMousePassthrough()
+        }
+    }
+
+    private func updateMousePassthrough() {
+        guard let window else { return }
+
+        guard dashboardVisible else {
+            window.ignoresMouseEvents = true
+            return
+        }
+
+        guard UserDefaults.standard.bool(forKey: DashboardSettingKeys.clickThroughEmptyAreas) else {
+            window.ignoresMouseEvents = false
+            return
+        }
+
+        let screenPoint = NSEvent.mouseLocation
+        guard window.frame.contains(screenPoint) else {
+            window.ignoresMouseEvents = true
+            return
+        }
+
+        let pointInWindow = window.convertPoint(fromScreen: screenPoint)
+        let webPoint = CGPoint(x: pointInWindow.x, y: webView.bounds.height - pointInWindow.y)
+        window.ignoresMouseEvents = !interactiveRegions.contains { $0.contains(webPoint) }
     }
 
     private func loadDashboard() {

--- a/packages/macos-dashboard/Sources/ClassroomWidgetsDashboard/DashboardWindowController.swift
+++ b/packages/macos-dashboard/Sources/ClassroomWidgetsDashboard/DashboardWindowController.swift
@@ -117,6 +117,7 @@ final class DashboardWindowController: NSWindowController {
         var components = URLComponents()
         components.scheme = dashboardURLScheme
         components.host = "app"
+        components.path = "/"
         components.queryItems = [
             URLQueryItem(name: "dashboard", value: "1"),
             URLQueryItem(name: "visible", value: dashboardVisible ? "1" : "0")

--- a/packages/macos-dashboard/Sources/ClassroomWidgetsDashboard/DashboardWindowController.swift
+++ b/packages/macos-dashboard/Sources/ClassroomWidgetsDashboard/DashboardWindowController.swift
@@ -4,13 +4,12 @@ import WebKit
 final class DashboardWindowController: NSWindowController {
     private let webView: WKWebView
     private let scriptMessageHandler: DashboardScriptMessageHandler
-    private var localMouseMonitor: Any?
-    private var globalMouseMonitor: Any?
-    private var interactiveRegions: [CGRect] = []
-    private var dashboardVisible = true
+    private var dashboardVisible: Bool
     var isDashboardVisible: Bool { dashboardVisible }
 
     init() {
+        dashboardVisible = UserDefaults.standard.bool(forKey: DashboardSettingKeys.showDashboardAtLaunch)
+
         let configuration = WKWebViewConfiguration()
         configuration.setURLSchemeHandler(
             StaticFileSchemeHandler(webRoot: WebRootResolver.resolve()),
@@ -27,7 +26,7 @@ final class DashboardWindowController: NSWindowController {
         webView.setValue(false, forKey: "drawsBackground")
 
         let window = DashboardWindow(
-            contentRect: Self.combinedScreenFrame(),
+            contentRect: Self.combinedVisibleFrame(),
             styleMask: [.borderless],
             backing: .buffered,
             defer: false
@@ -36,7 +35,7 @@ final class DashboardWindowController: NSWindowController {
         window.isOpaque = false
         window.hasShadow = false
         window.level = .floating
-        window.ignoresMouseEvents = false
+        window.ignoresMouseEvents = !dashboardVisible
         window.contentView = webView
 
         super.init(window: window)
@@ -44,17 +43,10 @@ final class DashboardWindowController: NSWindowController {
 
         scriptMessageHandler.onVisibilityChanged = { [weak self] visible in
             self?.dashboardVisible = visible
-            if !visible {
-                self?.window?.ignoresMouseEvents = true
-            }
-        }
-        scriptMessageHandler.onInteractiveRegionsChanged = { [weak self] regions in
-            self?.interactiveRegions = regions
-            self?.updateMousePassthrough()
+            self?.window?.ignoresMouseEvents = !visible
         }
         webView.configuration.userContentController.add(scriptMessageHandler, name: "classroomDashboard")
         loadDashboard()
-        installMouseMonitors()
     }
 
     required init?(coder: NSCoder) {
@@ -62,21 +54,18 @@ final class DashboardWindowController: NSWindowController {
     }
 
     deinit {
-        if let localMouseMonitor {
-            NSEvent.removeMonitor(localMouseMonitor)
-        }
-        if let globalMouseMonitor {
-            NSEvent.removeMonitor(globalMouseMonitor)
-        }
         webView.configuration.userContentController.removeScriptMessageHandler(forName: "classroomDashboard")
     }
 
     func showDashboard() {
         dashboardVisible = true
-        window?.setFrame(Self.combinedScreenFrame(), display: true)
+        let frame = Self.combinedVisibleFrame()
+        window?.setFrame(frame, display: true)
         applySettings()
+        window?.makeKeyAndOrderFront(nil)
         window?.orderFrontRegardless()
         window?.ignoresMouseEvents = false
+        NSApp.activate(ignoringOtherApps: true)
         setWebDashboardVisible(true)
     }
 
@@ -85,9 +74,10 @@ final class DashboardWindowController: NSWindowController {
         setWebDashboardVisible(dashboardVisible)
 
         if dashboardVisible {
+            window?.makeKeyAndOrderFront(nil)
             window?.orderFrontRegardless()
             window?.ignoresMouseEvents = false
-            updateMousePassthrough()
+            NSApp.activate(ignoringOtherApps: true)
         } else {
             window?.ignoresMouseEvents = true
         }
@@ -115,13 +105,24 @@ final class DashboardWindowController: NSWindowController {
         }
         window.collectionBehavior = behavior
 
-        if !UserDefaults.standard.bool(forKey: DashboardSettingKeys.clickThroughEmptyAreas) {
-            window.ignoresMouseEvents = false
+        if !dashboardVisible {
+            window.ignoresMouseEvents = true
+            return
         }
+
+        window.ignoresMouseEvents = false
     }
 
     private func loadDashboard() {
-        let url = URL(string: "\(dashboardURLScheme)://app/?dashboard=1")!
+        var components = URLComponents()
+        components.scheme = dashboardURLScheme
+        components.host = "app"
+        components.queryItems = [
+            URLQueryItem(name: "dashboard", value: "1"),
+            URLQueryItem(name: "visible", value: dashboardVisible ? "1" : "0")
+        ]
+
+        guard let url = components.url else { return }
         webView.load(URLRequest(url: url))
     }
 
@@ -130,45 +131,9 @@ final class DashboardWindowController: NSWindowController {
         webView.evaluateJavaScript(expression)
     }
 
-    private func installMouseMonitors() {
-        localMouseMonitor = NSEvent.addLocalMonitorForEvents(matching: [.mouseMoved, .leftMouseDragged, .rightMouseDragged, .otherMouseDragged]) { [weak self] event in
-            self?.updateMousePassthrough()
-            return event
-        }
-
-        globalMouseMonitor = NSEvent.addGlobalMonitorForEvents(matching: [.mouseMoved, .leftMouseDragged, .rightMouseDragged, .otherMouseDragged]) { [weak self] _ in
-            self?.updateMousePassthrough()
-        }
-    }
-
-    private func updateMousePassthrough() {
-        guard UserDefaults.standard.bool(forKey: DashboardSettingKeys.clickThroughEmptyAreas) else {
-            window?.ignoresMouseEvents = false
-            return
-        }
-
-        guard dashboardVisible, let window else {
-            window?.ignoresMouseEvents = true
-            return
-        }
-
-        let screenPoint = NSEvent.mouseLocation
-        guard window.frame.contains(screenPoint) else {
-            window.ignoresMouseEvents = true
-            return
-        }
-
-        let pointInWindow = window.convertPoint(fromScreen: screenPoint)
-        let webPoint = CGPoint(
-            x: pointInWindow.x,
-            y: webView.bounds.height - pointInWindow.y
-        )
-        window.ignoresMouseEvents = !interactiveRegions.contains { $0.contains(webPoint) }
-    }
-
-    private static func combinedScreenFrame() -> NSRect {
+    private static func combinedVisibleFrame() -> NSRect {
         NSScreen.screens.reduce(NSRect.zero) { partial, screen in
-            partial.union(screen.frame)
+            partial.union(screen.visibleFrame)
         }
     }
 }

--- a/packages/macos-dashboard/Sources/ClassroomWidgetsDashboard/DashboardWindowController.swift
+++ b/packages/macos-dashboard/Sources/ClassroomWidgetsDashboard/DashboardWindowController.swift
@@ -90,6 +90,7 @@ final class DashboardWindowController: NSWindowController {
         setWebDashboardVisible(dashboardVisible)
 
         if dashboardVisible {
+            window?.setFrame(Self.combinedVisibleFrame(), display: true)
             window?.makeKeyAndOrderFront(nil)
             window?.orderFrontRegardless()
             updateMousePassthrough()

--- a/packages/macos-dashboard/Sources/ClassroomWidgetsDashboard/WebRootResolver.swift
+++ b/packages/macos-dashboard/Sources/ClassroomWidgetsDashboard/WebRootResolver.swift
@@ -11,14 +11,37 @@ enum WebRootResolver {
             return bundledWebRoot
         }
 
-        let bundleURL = Bundle.main.bundleURL
-        let repoRoot = bundleURL
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
+        if let repoBuildRoot = findTeacherBuildRoot(from: Bundle.main.bundleURL) {
+            return repoBuildRoot
+        }
 
-        return repoRoot
+        return URL(fileURLWithPath: FileManager.default.currentDirectoryPath, isDirectory: true)
             .appendingPathComponent("packages")
             .appendingPathComponent("teacher")
             .appendingPathComponent("build")
+    }
+
+    private static func findTeacherBuildRoot(from startURL: URL) -> URL? {
+        let fileManager = FileManager.default
+        var current = startURL
+
+        for _ in 0..<10 {
+            let candidate = current
+                .appendingPathComponent("packages")
+                .appendingPathComponent("teacher")
+                .appendingPathComponent("build", isDirectory: true)
+
+            if fileManager.fileExists(atPath: candidate.appendingPathComponent("index.html").path) {
+                return candidate
+            }
+
+            let parent = current.deletingLastPathComponent()
+            if parent.path == current.path {
+                break
+            }
+            current = parent
+        }
+
+        return nil
     }
 }

--- a/packages/macos-dashboard/Sources/ClassroomWidgetsDashboard/main.swift
+++ b/packages/macos-dashboard/Sources/ClassroomWidgetsDashboard/main.swift
@@ -1,10 +1,12 @@
 import AppKit
 
 let dashboardURLScheme = "classroom-widgets"
+@MainActor private var appDelegate: AppDelegate?
 
 MainActor.assumeIsolated {
     let app = NSApplication.shared
     let delegate = AppDelegate()
+    appDelegate = delegate
     app.delegate = delegate
     app.run()
 }

--- a/packages/teacher/src/app/App.css
+++ b/packages/teacher/src/app/App.css
@@ -141,7 +141,7 @@ html.desktop-dashboard-mode .widget-wrapper {
   filter: drop-shadow(0 24px 42px rgba(0, 0, 0, 0.22));
 }
 
-html.desktop-dashboard-mode .widget-wrapper > div {
+html.desktop-dashboard-mode .widget-wrapper > .widget-surface {
   animation: desktop-widget-depth-in 360ms cubic-bezier(0.16, 1, 0.3, 1) both;
 }
 
@@ -152,7 +152,7 @@ html.desktop-dashboard-hidden [role="dialog"] {
   pointer-events: none !important;
 }
 
-html.desktop-dashboard-hidden .widget-wrapper > div,
+html.desktop-dashboard-hidden .widget-wrapper > .widget-surface,
 html.desktop-dashboard-hidden [role="dialog"] {
   transform: translateY(28px) scale(0.92) rotateX(10deg);
 }
@@ -207,7 +207,7 @@ html.dark.desktop-dashboard-mode [role="dialog"] {
   opacity: 0.9;
 }
 
-html.desktop-dashboard-mode .widget-wrapper > div {
+html.desktop-dashboard-mode .widget-wrapper > .widget-surface[data-dashboard-glass="true"] {
   overflow: hidden;
   border-radius: 14px;
   backdrop-filter: blur(18px) saturate(1.35);

--- a/packages/teacher/src/app/App.tsx
+++ b/packages/teacher/src/app/App.tsx
@@ -597,7 +597,7 @@ function App() {
           <div className="h-full relative overflow-hidden">
             {layoutFormat === 'column' ? (
               <ColumnBoard>
-                <ColumnWidgetList />
+                <ColumnWidgetList dashboardVisible={isDashboardVisible} />
               </ColumnBoard>
             ) : (
               <Board onBoardClick={handleBoardClick} stickerMode={stickerMode}>

--- a/packages/teacher/src/features/board/components/ColumnWidgetList.tsx
+++ b/packages/teacher/src/features/board/components/ColumnWidgetList.tsx
@@ -4,7 +4,11 @@ import { useWorkspaceStore } from '../../../store/workspaceStore.simple';
 import { WidgetType } from '@shared/types';
 import ColumnWidgetRenderer from './ColumnWidgetRenderer';
 
-const ColumnWidgetList: React.FC = () => {
+interface ColumnWidgetListProps {
+  dashboardVisible?: boolean;
+}
+
+const ColumnWidgetList: React.FC<ColumnWidgetListProps> = ({ dashboardVisible }) => {
   const widgetIds = useWorkspaceStore(
     useShallow((state) => state.widgets
       .filter(w => w.type !== WidgetType.STAMP)
@@ -14,7 +18,7 @@ const ColumnWidgetList: React.FC = () => {
   return (
     <>
       {widgetIds.map((widgetId) => (
-        <ColumnWidgetRenderer key={widgetId} widgetId={widgetId} />
+        <ColumnWidgetRenderer key={widgetId} widgetId={widgetId} dashboardVisible={dashboardVisible} />
       ))}
     </>
   );

--- a/packages/teacher/src/features/board/components/ColumnWidgetRenderer.tsx
+++ b/packages/teacher/src/features/board/components/ColumnWidgetRenderer.tsx
@@ -8,6 +8,7 @@ import { useWorkspaceStore } from '../../../store/workspaceStore.simple';
 
 interface ColumnWidgetRendererProps {
   widgetId: string;
+  dashboardVisible?: boolean;
 }
 
 const WidgetLoader: React.FC = () => (
@@ -19,7 +20,7 @@ const WidgetLoader: React.FC = () => (
   </Card>
 );
 
-const ColumnWidgetRenderer: React.FC<ColumnWidgetRendererProps> = ({ widgetId }) => {
+const ColumnWidgetRenderer: React.FC<ColumnWidgetRendererProps> = ({ widgetId, dashboardVisible }) => {
   const { widget, state, setState } = useWidget(widgetId);
   const isActive = useWorkspaceStore((state) => state.focusedWidgetId === widgetId);
 
@@ -42,7 +43,7 @@ const ColumnWidgetRenderer: React.FC<ColumnWidgetRendererProps> = ({ widgetId })
   };
 
   return (
-    <ColumnWidgetWrapper widgetId={widgetId}>
+    <ColumnWidgetWrapper widgetId={widgetId} dashboardVisible={dashboardVisible}>
       <ErrorBoundary widgetName={widgetName}>
         <Suspense fallback={<WidgetLoader />}>
           <Component {...widgetProps} />

--- a/packages/teacher/src/features/desktop/useDesktopDashboardMode.ts
+++ b/packages/teacher/src/features/desktop/useDesktopDashboardMode.ts
@@ -35,6 +35,7 @@ const DASHBOARD_INTERACTIVE_SELECTOR = [
   '.toolbar-container input',
   '.toolbar-container select',
   '.toolbar-container textarea',
+  '.dashboard-widget-chrome',
   '[data-dashboard-interactive="true"]',
   '[role="dialog"]',
   '.delete-button'
@@ -72,7 +73,11 @@ export function useDesktopDashboardMode() {
     if (typeof window === 'undefined') return false;
     return isDesktopDashboardMode();
   }, []);
-  const [isDashboardVisible, setDashboardVisible] = useState(isDashboardMode);
+  const [isDashboardVisible, setDashboardVisible] = useState(() => {
+    if (!isDashboardMode || typeof window === 'undefined') return false;
+
+    return new URLSearchParams(window.location.search).get('visible') !== '0';
+  });
   const [interactiveRegions, setInteractiveRegions] = useState<DashboardInteractiveRegion[]>([]);
 
   const setVisible = useCallback((visible: boolean) => {

--- a/packages/teacher/src/features/widgets/shared/ColumnWidgetWrapper.tsx
+++ b/packages/teacher/src/features/widgets/shared/ColumnWidgetWrapper.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useState, useRef, useEffect, memo } from 'react';
-import { FaTrash } from 'react-icons/fa6';
+import { FaTrash, FaXmark } from 'react-icons/fa6';
 import { useWidget } from '@shared/hooks/useWidget';
 import { widgetRegistry } from '../../../services/WidgetRegistry';
 import { useWorkspaceStore } from '../../../store/workspaceStore.simple';
@@ -74,7 +74,8 @@ const ColumnWidgetWrapper: React.FC<ColumnWidgetWrapperProps> = ({ widgetId, chi
   const config = widgetRegistry.get(widget.type);
   if (!config) return null;
   const isTransparent = config.features?.isTransparent || false;
-  const showDashboardOverlay = isDesktopDashboardMode() && dashboardVisible && !isTransparent && widget.type !== WidgetType.TIMER;
+  const isDashboardMode = isDesktopDashboardMode();
+  const showDashboardOverlay = isDashboardMode && dashboardVisible && !isTransparent && widget.type !== WidgetType.TIMER;
 
   // Height strategy is driven by the widget's columnSizing declaration
   const columnSizing = config.columnSizing ?? 'fixed';
@@ -112,25 +113,47 @@ const ColumnWidgetWrapper: React.FC<ColumnWidgetWrapperProps> = ({ widgetId, chi
         >
           {children}
           <LiquidGlassOverlay active={showDashboardOverlay} />
+          {isDashboardMode ? (
+            <div
+              className={`dashboard-widget-chrome absolute top-2 right-2 flex items-center gap-1 transition-all duration-200 ${
+                isDeleteVisible ? 'opacity-100' : 'opacity-0 pointer-events-none'
+              }`}
+              data-dashboard-interactive="true"
+              style={{ zIndex: 9999 }}
+            >
+              <button
+                type="button"
+                onClick={handleDeleteClick}
+                tabIndex={isDeleteVisible ? 0 : -1}
+                aria-label="Close widget"
+                className="delete-button w-7 h-7 rounded-full bg-white/90 dark:bg-warm-gray-800/90 text-warm-gray-600 dark:text-warm-gray-200 border border-warm-gray-200/80 dark:border-warm-gray-600/80 shadow-lg flex items-center justify-center hover:bg-dusty-rose-500 hover:text-white transition-colors"
+                title="Close widget"
+              >
+                <FaXmark className="w-3.5 h-3.5" aria-hidden="true" />
+              </button>
+            </div>
+          ) : null}
         </div>
       </div>
       {/* Delete button - appears on hover below widget (outside bounds), always visible on touch devices */}
-      <button
-        type="button"
-        onClick={handleDeleteClick}
-        tabIndex={isDeleteVisible ? 0 : -1}
-        aria-label="Delete widget"
-        className={`delete-button absolute -bottom-8 left-1/2 transform -translate-x-1/2
-                   bg-warm-gray-200 dark:bg-warm-gray-600 hover:bg-dusty-rose-500 dark:hover:bg-dusty-rose-500
-                   text-warm-gray-500 dark:text-warm-gray-400 hover:text-white p-2 rounded-full
-                   shadow-lg transition-all duration-300 ${
-                     isDeleteVisible ? 'opacity-100' : 'opacity-0 pointer-events-none'
-                   }`}
-        style={{ zIndex: 9999 }}
-        title="Delete widget"
-      >
-        <FaTrash className="w-3 h-3" aria-hidden="true" />
-      </button>
+      {!isDashboardMode ? (
+        <button
+          type="button"
+          onClick={handleDeleteClick}
+          tabIndex={isDeleteVisible ? 0 : -1}
+          aria-label="Delete widget"
+          className={`delete-button absolute -bottom-8 left-1/2 transform -translate-x-1/2
+                     bg-warm-gray-200 dark:bg-warm-gray-600 hover:bg-dusty-rose-500 dark:hover:bg-dusty-rose-500
+                     text-warm-gray-500 dark:text-warm-gray-400 hover:text-white p-2 rounded-full
+                     shadow-lg transition-all duration-300 ${
+                       isDeleteVisible ? 'opacity-100' : 'opacity-0 pointer-events-none'
+                     }`}
+          style={{ zIndex: 9999 }}
+          title="Delete widget"
+        >
+          <FaTrash className="w-3 h-3" aria-hidden="true" />
+        </button>
+      ) : null}
     </div>
   );
 };

--- a/packages/teacher/src/features/widgets/shared/ColumnWidgetWrapper.tsx
+++ b/packages/teacher/src/features/widgets/shared/ColumnWidgetWrapper.tsx
@@ -4,6 +4,7 @@ import { useWidget } from '@shared/hooks/useWidget';
 import { widgetRegistry } from '../../../services/WidgetRegistry';
 import { useWorkspaceStore } from '../../../store/workspaceStore.simple';
 import { isDesktopDashboardMode } from '@shared/utils/dashboardMode';
+import { WidgetType } from '@shared/types';
 import LiquidGlassOverlay from '../../desktop/LiquidGlassOverlay';
 
 interface ColumnWidgetWrapperProps {
@@ -73,7 +74,7 @@ const ColumnWidgetWrapper: React.FC<ColumnWidgetWrapperProps> = ({ widgetId, chi
   const config = widgetRegistry.get(widget.type);
   if (!config) return null;
   const isTransparent = config.features?.isTransparent || false;
-  const showDashboardOverlay = isDesktopDashboardMode() && dashboardVisible && !isTransparent;
+  const showDashboardOverlay = isDesktopDashboardMode() && dashboardVisible && !isTransparent && widget.type !== WidgetType.TIMER;
 
   // Height strategy is driven by the widget's columnSizing declaration
   const columnSizing = config.columnSizing ?? 'fixed';

--- a/packages/teacher/src/features/widgets/shared/ColumnWidgetWrapper.tsx
+++ b/packages/teacher/src/features/widgets/shared/ColumnWidgetWrapper.tsx
@@ -105,8 +105,13 @@ const ColumnWidgetWrapper: React.FC<ColumnWidgetWrapperProps> = ({ widgetId, chi
       style={style}
     >
       <div className="widget-wrapper w-full h-full relative">
-        {children}
-        <LiquidGlassOverlay active={showDashboardOverlay} />
+        <div
+          className="widget-surface w-full h-full relative"
+          data-dashboard-glass={showDashboardOverlay ? 'true' : 'false'}
+        >
+          {children}
+          <LiquidGlassOverlay active={showDashboardOverlay} />
+        </div>
       </div>
       {/* Delete button - appears on hover below widget (outside bounds), always visible on touch devices */}
       <button

--- a/packages/teacher/src/features/widgets/shared/ColumnWidgetWrapper.tsx
+++ b/packages/teacher/src/features/widgets/shared/ColumnWidgetWrapper.tsx
@@ -3,13 +3,16 @@ import { FaTrash } from 'react-icons/fa6';
 import { useWidget } from '@shared/hooks/useWidget';
 import { widgetRegistry } from '../../../services/WidgetRegistry';
 import { useWorkspaceStore } from '../../../store/workspaceStore.simple';
+import { isDesktopDashboardMode } from '@shared/utils/dashboardMode';
+import LiquidGlassOverlay from '../../desktop/LiquidGlassOverlay';
 
 interface ColumnWidgetWrapperProps {
   widgetId: string;
   children: React.ReactNode;
+  dashboardVisible?: boolean;
 }
 
-const ColumnWidgetWrapper: React.FC<ColumnWidgetWrapperProps> = ({ widgetId, children }) => {
+const ColumnWidgetWrapper: React.FC<ColumnWidgetWrapperProps> = ({ widgetId, children, dashboardVisible = true }) => {
   const { widget, remove } = useWidget(widgetId);
   const setFocusedWidget = useWorkspaceStore((state) => state.setFocusedWidget);
   // Use a boolean selector to avoid re-rendering all widgets on every focus change
@@ -69,6 +72,8 @@ const ColumnWidgetWrapper: React.FC<ColumnWidgetWrapperProps> = ({ widgetId, chi
 
   const config = widgetRegistry.get(widget.type);
   if (!config) return null;
+  const isTransparent = config.features?.isTransparent || false;
+  const showDashboardOverlay = isDesktopDashboardMode() && dashboardVisible && !isTransparent;
 
   // Height strategy is driven by the widget's columnSizing declaration
   const columnSizing = config.columnSizing ?? 'fixed';
@@ -99,8 +104,9 @@ const ColumnWidgetWrapper: React.FC<ColumnWidgetWrapperProps> = ({ widgetId, chi
       onMouseLeave={handleMouseLeave}
       style={style}
     >
-      <div className="widget-wrapper w-full h-full">
+      <div className="widget-wrapper w-full h-full relative">
         {children}
+        <LiquidGlassOverlay active={showDashboardOverlay} />
       </div>
       {/* Delete button - appears on hover below widget (outside bounds), always visible on touch devices */}
       <button

--- a/packages/teacher/src/features/widgets/shared/WidgetWrapper.tsx
+++ b/packages/teacher/src/features/widgets/shared/WidgetWrapper.tsx
@@ -114,7 +114,6 @@ const WidgetWrapper: React.FC<WidgetWrapperProps> = ({ widgetId, children, dashb
   }, [isResizing, isBeingDragged, stopDrag]);
 
   const isTransparent = config?.features?.isTransparent || false;
-  const shouldUseDashboardGlass = isDashboardMode && dashboardVisible && !isTransparent && widget.type !== WidgetType.TIMER;
   
   const wrapperClasses = clsx(
     'widget-wrapper',
@@ -144,6 +143,7 @@ const WidgetWrapper: React.FC<WidgetWrapperProps> = ({ widgetId, children, dashb
 
   if (!widget) return null;
   if (!config) return null;
+  const shouldUseDashboardGlass = isDashboardMode && dashboardVisible && !isTransparent && widget.type !== WidgetType.TIMER;
 
   return (
     <div 

--- a/packages/teacher/src/features/widgets/shared/WidgetWrapper.tsx
+++ b/packages/teacher/src/features/widgets/shared/WidgetWrapper.tsx
@@ -3,11 +3,11 @@
 import React, { useCallback, useRef, useEffect, useState, memo } from 'react';
 import { Rnd } from 'react-rnd';
 import { clsx } from 'clsx';
-import { FaTrash } from 'react-icons/fa6';
+import { FaTrash, FaXmark } from 'react-icons/fa6';
 import { useWidget, useWidgetDrag } from '@shared/hooks/useWidget';
 import { useWorkspace } from '@shared/hooks/useWorkspace';
 import { widgetRegistry } from '../../../services/WidgetRegistry';
-import { Position, Size } from '@shared/types';
+import { Position, Size, WidgetType } from '@shared/types';
 import { debug } from '@shared/utils/debug';
 import { isDesktopDashboardMode } from '@shared/utils/dashboardMode';
 import { useWorkspaceStore } from '../../../store/workspaceStore.simple';
@@ -114,6 +114,7 @@ const WidgetWrapper: React.FC<WidgetWrapperProps> = ({ widgetId, children, dashb
   }, [isResizing, isBeingDragged, stopDrag]);
 
   const isTransparent = config?.features?.isTransparent || false;
+  const shouldUseDashboardGlass = isDashboardMode && dashboardVisible && !isTransparent && widget.type !== WidgetType.TIMER;
   
   const wrapperClasses = clsx(
     'widget-wrapper',
@@ -200,23 +201,45 @@ const WidgetWrapper: React.FC<WidgetWrapperProps> = ({ widgetId, children, dashb
           topLeft: true
         }}
       >
-        <div className="w-full h-full relative" onClick={handleWidgetClick}>
+        <div
+          className="widget-surface w-full h-full relative"
+          data-dashboard-glass={shouldUseDashboardGlass ? 'true' : 'false'}
+          onClick={handleWidgetClick}
+        >
           {children}
-          <LiquidGlassOverlay active={isDashboardMode && dashboardVisible && !isTransparent} />
-          {/* Hover trash icon */}
-          <button
-            onClick={handleDeleteClick}
-            className={`delete-button absolute -bottom-8 left-1/2 transform -translate-x-1/2 
-                       bg-warm-gray-200 dark:bg-warm-gray-600 hover:bg-dusty-rose-500 dark:hover:bg-dusty-rose-500 
-                       text-warm-gray-500 dark:text-warm-gray-400 hover:text-white p-2 rounded-full 
-                       shadow-lg transition-all duration-300 ${
-                         showTrash && !isBeingDragged ? 'opacity-100' : 'opacity-0 pointer-events-none'
-                       }`}
-            style={{ zIndex: 9999 }}
-            title="Delete widget"
-          >
-            <FaTrash className="w-3 h-3" />
-          </button>
+          <LiquidGlassOverlay active={shouldUseDashboardGlass} />
+          {isDashboardMode ? (
+            <div
+              className={`dashboard-widget-chrome no-drag absolute top-2 right-2 flex items-center gap-1 transition-all duration-200 ${
+                showTrash && !isBeingDragged ? 'opacity-100' : 'opacity-0 pointer-events-none'
+              }`}
+              data-dashboard-interactive="true"
+              style={{ zIndex: 9999 }}
+            >
+              <button
+                onClick={handleDeleteClick}
+                className="delete-button no-drag w-7 h-7 rounded-full bg-white/90 dark:bg-warm-gray-800/90 text-warm-gray-600 dark:text-warm-gray-200 border border-warm-gray-200/80 dark:border-warm-gray-600/80 shadow-lg flex items-center justify-center hover:bg-dusty-rose-500 hover:text-white transition-colors"
+                title="Close widget"
+                aria-label="Close widget"
+              >
+                <FaXmark className="w-3.5 h-3.5" />
+              </button>
+            </div>
+          ) : (
+            <button
+              onClick={handleDeleteClick}
+              className={`delete-button absolute -bottom-8 left-1/2 transform -translate-x-1/2
+                         bg-warm-gray-200 dark:bg-warm-gray-600 hover:bg-dusty-rose-500 dark:hover:bg-dusty-rose-500
+                         text-warm-gray-500 dark:text-warm-gray-400 hover:text-white p-2 rounded-full
+                         shadow-lg transition-all duration-300 ${
+                           showTrash && !isBeingDragged ? 'opacity-100' : 'opacity-0 pointer-events-none'
+                         }`}
+              style={{ zIndex: 9999 }}
+              title="Delete widget"
+            >
+              <FaTrash className="w-3 h-3" />
+            </button>
+          )}
         </div>
       </Rnd>
     </div>

--- a/script/build_and_run.sh
+++ b/script/build_and_run.sh
@@ -2,6 +2,16 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+RELEASE_ENV_FILE="${RELEASE_ENV_FILE:-.env.release.local}"
+if [ -f "$RELEASE_ENV_FILE" ]; then
+  set -a
+  # shellcheck disable=SC1090
+  . "$RELEASE_ENV_FILE"
+  set +a
+fi
+
 APP_NAME="Classroom Widgets Dashboard"
 PRODUCT_NAME="ClassroomWidgetsDashboard"
 BUNDLE_ID="com.classroomwidgets.dashboard"
@@ -10,6 +20,9 @@ APP_CONTENTS="$APP_BUNDLE/Contents"
 APP_MACOS="$APP_CONTENTS/MacOS"
 APP_RESOURCES="$APP_CONTENTS/Resources"
 MACOS_DIR="$ROOT_DIR/packages/macos-dashboard"
+INSTALL_APP_BUNDLE="/Applications/$APP_NAME.app"
+ENTITLEMENTS_PATH="$ROOT_DIR/script/macos-distribution-entitlements.plist"
+SIGNING_IDENTITY="${APPLE_SIGNING_IDENTITY:-}"
 MODE="${1:-run}"
 
 case "$MODE" in
@@ -22,12 +35,36 @@ esac
 
 pkill -x "$PRODUCT_NAME" 2>/dev/null || true
 
+trash_path() {
+  local path="$1"
+  if [ ! -e "$path" ]; then
+    return
+  fi
+
+  if command -v trash >/dev/null 2>&1; then
+    trash "$path"
+    return
+  fi
+
+  local fallback_dir="${TMPDIR:-/tmp}/classroom-widgets-trash"
+  mkdir -p "$fallback_dir"
+  mv "$path" "$fallback_dir/$(basename "$path").$(date +%s)"
+}
+
+detect_signing_identity() {
+  if [ -n "$SIGNING_IDENTITY" ]; then
+    return
+  fi
+
+  SIGNING_IDENTITY="$(security find-identity -p codesigning -v 2>/dev/null | awk -F'\"' '/Developer ID Application:/{ print $2; exit }')"
+}
+
 npm run build -w @classroom-widgets/teacher
 
 swift build --package-path "$MACOS_DIR" -c debug
 
 EXECUTABLE="$MACOS_DIR/.build/debug/$PRODUCT_NAME"
-rm -rf "$APP_BUNDLE"
+trash_path "$APP_BUNDLE"
 mkdir -p "$APP_MACOS" "$APP_RESOURCES/Web"
 cp "$EXECUTABLE" "$APP_MACOS/$PRODUCT_NAME"
 chmod +x "$APP_MACOS/$PRODUCT_NAME"
@@ -58,8 +95,23 @@ cat > "$APP_CONTENTS/Info.plist" <<PLIST
 </plist>
 PLIST
 
+detect_signing_identity
+if [ -n "$SIGNING_IDENTITY" ]; then
+  codesign --force --options runtime --timestamp --entitlements "$ENTITLEMENTS_PATH" --sign "$SIGNING_IDENTITY" "$APP_BUNDLE"
+else
+  codesign --force --deep --sign - "$APP_BUNDLE"
+fi
+
+codesign --verify --deep --strict --verbose=2 "$APP_BUNDLE"
+
+install_app() {
+  trash_path "$INSTALL_APP_BUNDLE"
+  cp -R "$APP_BUNDLE" "$INSTALL_APP_BUNDLE"
+}
+
 open_app() {
-  /usr/bin/open -n "$APP_BUNDLE"
+  install_app
+  /usr/bin/open -n "$INSTALL_APP_BUNDLE"
 }
 
 case "$MODE" in
@@ -81,6 +133,6 @@ case "$MODE" in
     open_app
     sleep 2
     pgrep -x "$PRODUCT_NAME" >/dev/null
-    echo "$PRODUCT_NAME is running"
+    echo "$PRODUCT_NAME is running from $INSTALL_APP_BUNDLE"
     ;;
 esac

--- a/script/build_macos_release.sh
+++ b/script/build_macos_release.sh
@@ -26,7 +26,7 @@ STAGING_DIR="${ROOT_DIR}/dist/macos-dmg-staging"
 ENTITLEMENTS_PATH="${ROOT_DIR}/script/macos-distribution-entitlements.plist"
 VERSION="$(node -p "require('./package.json').version")"
 BUILD_NUMBER="${BUILD_NUMBER:-$(date +%Y%m%d%H%M)}"
-DMG_PATH="${ROOT_DIR}/dist/${PRODUCT_NAME}-v${VERSION}-macos.dmg"
+DMG_PATH="${DMG_PATH:-}"
 SIGNING_IDENTITY="${APPLE_SIGNING_IDENTITY:-}"
 DEVELOPMENT_TEAM="${APPLE_TEAM_ID:-}"
 API_KEY_PATH="${APPLE_API_KEY_PATH:-}"
@@ -138,6 +138,8 @@ while [[ $# -gt 0 ]]; do
       ;;
   esac
 done
+
+DMG_PATH="${DMG_PATH:-${ROOT_DIR}/dist/${PRODUCT_NAME}-v${VERSION}-macos.dmg}"
 
 if ! command -v create-dmg >/dev/null 2>&1; then
   echo "create-dmg not found. Install it with: brew install create-dmg" >&2

--- a/script/build_macos_release.sh
+++ b/script/build_macos_release.sh
@@ -280,7 +280,6 @@ if [ "${USE_NOTARISATION}" = "true" ]; then
     xcrun notarytool submit "${DMG_PATH}"
     --key "${API_KEY_PATH}"
     --key-id "${API_KEY_ID}"
-    --team-id "${DEVELOPMENT_TEAM}"
     --wait
   )
 

--- a/script/build_macos_release.sh
+++ b/script/build_macos_release.sh
@@ -1,0 +1,296 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${ROOT_DIR}"
+
+RELEASE_ENV_FILE="${RELEASE_ENV_FILE:-.env.release.local}"
+if [ -f "${RELEASE_ENV_FILE}" ]; then
+  set -a
+  # shellcheck disable=SC1090
+  . "${RELEASE_ENV_FILE}"
+  set +a
+fi
+
+APP_NAME="Classroom Widgets Dashboard"
+PRODUCT_NAME="ClassroomWidgetsDashboard"
+BUNDLE_ID="com.classroomwidgets.dashboard"
+MACOS_DIR="${ROOT_DIR}/packages/macos-dashboard"
+APP_BUNDLE="${ROOT_DIR}/dist/${APP_NAME}.app"
+APP_CONTENTS="${APP_BUNDLE}/Contents"
+APP_MACOS="${APP_CONTENTS}/MacOS"
+APP_RESOURCES="${APP_CONTENTS}/Resources"
+WEB_RESOURCES="${APP_RESOURCES}/Web"
+STAGING_DIR="${ROOT_DIR}/dist/macos-dmg-staging"
+ENTITLEMENTS_PATH="${ROOT_DIR}/script/macos-distribution-entitlements.plist"
+VERSION="$(node -p "require('./package.json').version")"
+BUILD_NUMBER="${BUILD_NUMBER:-$(date +%Y%m%d%H%M)}"
+DMG_PATH="${ROOT_DIR}/dist/${PRODUCT_NAME}-v${VERSION}-macos.dmg"
+SIGNING_IDENTITY="${APPLE_SIGNING_IDENTITY:-}"
+DEVELOPMENT_TEAM="${APPLE_TEAM_ID:-}"
+API_KEY_PATH="${APPLE_API_KEY_PATH:-}"
+API_KEY_ID="${APPLE_API_KEY_ID:-}"
+API_ISSUER_ID="${APPLE_API_KEY_ISSUER_ID:-}"
+USE_DISTRIBUTION_SIGNING="${USE_DISTRIBUTION_SIGNING:-false}"
+USE_NOTARISATION="${USE_NOTARISATION:-false}"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  ./script/build_macos_release.sh [options]
+
+Options:
+  --version <version>   Artifact/app version suffix (default: package.json version)
+  --build <number>      CFBundleVersion value (default: timestamp)
+  --output <path>       DMG output path
+  --distribution        Sign app and DMG with a Developer ID Application identity
+  --notarise            Submit the signed DMG for notarisation and staple it
+  --notarize            Alias for --notarise
+  --identity <name>     Developer ID Application identity
+  --team <id>           Apple Developer Team ID
+  --api-key <path>      App Store Connect API key (.p8) path
+  --api-key-id <id>     App Store Connect API key ID
+  --api-issuer <id>     App Store Connect issuer ID (omit for Individual keys)
+
+Environment:
+  .env.release.local is loaded automatically when present. Supported keys:
+  APPLE_SIGNING_IDENTITY, APPLE_TEAM_ID, APPLE_API_KEY_PATH,
+  APPLE_API_KEY_ID, APPLE_API_KEY_ISSUER_ID.
+EOF
+}
+
+trash_path() {
+  local path="$1"
+  if [ ! -e "${path}" ]; then
+    return
+  fi
+
+  if command -v trash >/dev/null 2>&1; then
+    trash "${path}"
+    return
+  fi
+
+  local fallback_dir="${TMPDIR:-/tmp}/classroom-widgets-trash"
+  mkdir -p "${fallback_dir}"
+  mv "${path}" "${fallback_dir}/$(basename "${path}").$(date +%s)"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --version)
+      [[ -n "${2:-}" ]] || { echo "--version requires a value" >&2; usage; exit 1; }
+      VERSION="${2#v}"
+      shift 2
+      ;;
+    --build)
+      [[ -n "${2:-}" ]] || { echo "--build requires a value" >&2; usage; exit 1; }
+      BUILD_NUMBER="$2"
+      shift 2
+      ;;
+    --output)
+      [[ -n "${2:-}" ]] || { echo "--output requires a value" >&2; usage; exit 1; }
+      DMG_PATH="$2"
+      shift 2
+      ;;
+    --distribution|--release|--sign)
+      USE_DISTRIBUTION_SIGNING="true"
+      shift
+      ;;
+    --notarise|--notarize)
+      USE_NOTARISATION="true"
+      USE_DISTRIBUTION_SIGNING="true"
+      shift
+      ;;
+    --identity)
+      [[ -n "${2:-}" ]] || { echo "--identity requires a value" >&2; usage; exit 1; }
+      SIGNING_IDENTITY="$2"
+      shift 2
+      ;;
+    --team)
+      [[ -n "${2:-}" ]] || { echo "--team requires a value" >&2; usage; exit 1; }
+      DEVELOPMENT_TEAM="$2"
+      shift 2
+      ;;
+    --api-key)
+      [[ -n "${2:-}" ]] || { echo "--api-key requires a value" >&2; usage; exit 1; }
+      API_KEY_PATH="$2"
+      shift 2
+      ;;
+    --api-key-id)
+      [[ -n "${2:-}" ]] || { echo "--api-key-id requires a value" >&2; usage; exit 1; }
+      API_KEY_ID="$2"
+      shift 2
+      ;;
+    --api-issuer)
+      [[ -n "${2:-}" ]] || { echo "--api-issuer requires a value" >&2; usage; exit 1; }
+      API_ISSUER_ID="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if ! command -v create-dmg >/dev/null 2>&1; then
+  echo "create-dmg not found. Install it with: brew install create-dmg" >&2
+  exit 1
+fi
+
+if [ "${USE_DISTRIBUTION_SIGNING}" = "true" ]; then
+  if [ -z "${SIGNING_IDENTITY}" ] || [ -z "${DEVELOPMENT_TEAM}" ]; then
+    echo "Distribution signing requested, but identity/team are missing." >&2
+    usage
+    exit 1
+  fi
+
+  if ! security find-identity -p codesigning -v | grep -F "${SIGNING_IDENTITY}" >/dev/null; then
+    echo "Signing identity not found in the keychain: ${SIGNING_IDENTITY}" >&2
+    exit 1
+  fi
+fi
+
+if [ "${USE_NOTARISATION}" = "true" ]; then
+  if [ -z "${API_KEY_PATH}" ] || [ -z "${API_KEY_ID}" ]; then
+    echo "Notarisation requested, but App Store Connect API key details are missing." >&2
+    usage
+    exit 1
+  fi
+
+  if [ ! -f "${API_KEY_PATH}" ]; then
+    echo "App Store Connect API key not found at: ${API_KEY_PATH}" >&2
+    exit 1
+  fi
+fi
+
+mkdir -p "${ROOT_DIR}/dist"
+trash_path "${APP_BUNDLE}"
+trash_path "${STAGING_DIR}"
+trash_path "${DMG_PATH}"
+
+echo "Building teacher web assets"
+npm run build -w @classroom-widgets/teacher
+
+echo "Building macOS executable"
+swift build --package-path "${MACOS_DIR}" -c release
+
+EXECUTABLE="${MACOS_DIR}/.build/release/${PRODUCT_NAME}"
+mkdir -p "${APP_MACOS}" "${WEB_RESOURCES}"
+cp "${EXECUTABLE}" "${APP_MACOS}/${PRODUCT_NAME}"
+chmod +x "${APP_MACOS}/${PRODUCT_NAME}"
+cp -R "${ROOT_DIR}/packages/teacher/build/." "${WEB_RESOURCES}/"
+
+cat > "${APP_CONTENTS}/Info.plist" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleDisplayName</key>
+  <string>${APP_NAME}</string>
+  <key>CFBundleExecutable</key>
+  <string>${PRODUCT_NAME}</string>
+  <key>CFBundleIdentifier</key>
+  <string>${BUNDLE_ID}</string>
+  <key>CFBundleName</key>
+  <string>${APP_NAME}</string>
+  <key>CFBundlePackageType</key>
+  <string>APPL</string>
+  <key>CFBundleShortVersionString</key>
+  <string>${VERSION}</string>
+  <key>CFBundleVersion</key>
+  <string>${BUILD_NUMBER}</string>
+  <key>LSApplicationCategoryType</key>
+  <string>public.app-category.education</string>
+  <key>LSMinimumSystemVersion</key>
+  <string>13.0</string>
+  <key>LSUIElement</key>
+  <true/>
+  <key>NSCameraUsageDescription</key>
+  <string>Classroom Widgets uses the camera for the Visualiser widget.</string>
+  <key>NSHighResolutionCapable</key>
+  <true/>
+  <key>NSPrincipalClass</key>
+  <string>NSApplication</string>
+</dict>
+</plist>
+PLIST
+
+if [ "${USE_DISTRIBUTION_SIGNING}" = "true" ]; then
+  echo "Signing app with ${SIGNING_IDENTITY}"
+  codesign --force --options runtime --timestamp --entitlements "${ENTITLEMENTS_PATH}" --sign "${SIGNING_IDENTITY}" "${APP_BUNDLE}"
+  codesign --verify --deep --strict --verbose=2 "${APP_BUNDLE}"
+else
+  echo "Applying ad hoc app signature for local packaging"
+  codesign --force --deep --sign - "${APP_BUNDLE}"
+  codesign --verify --deep --strict --verbose=2 "${APP_BUNDLE}"
+fi
+
+mkdir -p "${STAGING_DIR}"
+cp -R "${APP_BUNDLE}" "${STAGING_DIR}/"
+
+echo "Creating DMG at ${DMG_PATH}"
+if ! create-dmg \
+  --volname "${APP_NAME}" \
+  --window-pos 200 120 \
+  --window-size 560 360 \
+  --icon-size 120 \
+  --text-size 12 \
+  --icon "${APP_NAME}.app" 160 190 \
+  --app-drop-link 390 190 \
+  --hide-extension "${APP_NAME}.app" \
+  --no-internet-enable \
+  "${DMG_PATH}" \
+  "${STAGING_DIR}/"; then
+  echo "create-dmg failed; retrying without Finder AppleScript prettifying." >&2
+  trash_path "${DMG_PATH}"
+  create-dmg \
+    --skip-jenkins \
+    --volname "${APP_NAME}" \
+    --window-pos 200 120 \
+    --window-size 560 360 \
+    --icon-size 120 \
+    --text-size 12 \
+    --icon "${APP_NAME}.app" 160 190 \
+    --app-drop-link 390 190 \
+    --hide-extension "${APP_NAME}.app" \
+    --no-internet-enable \
+    "${DMG_PATH}" \
+    "${STAGING_DIR}/"
+fi
+
+if [ "${USE_DISTRIBUTION_SIGNING}" = "true" ]; then
+  echo "Signing DMG with ${SIGNING_IDENTITY}"
+  codesign --force --options runtime --timestamp --sign "${SIGNING_IDENTITY}" "${DMG_PATH}"
+  codesign --verify --strict --verbose=2 "${DMG_PATH}"
+fi
+
+if [ "${USE_NOTARISATION}" = "true" ]; then
+  NOTARY_CMD=(
+    xcrun notarytool submit "${DMG_PATH}"
+    --key "${API_KEY_PATH}"
+    --key-id "${API_KEY_ID}"
+    --team-id "${DEVELOPMENT_TEAM}"
+    --wait
+  )
+
+  if [ -n "${API_ISSUER_ID}" ]; then
+    NOTARY_CMD+=(--issuer "${API_ISSUER_ID}")
+  fi
+
+  echo "Submitting DMG for notarisation"
+  "${NOTARY_CMD[@]}"
+  xcrun stapler staple "${DMG_PATH}"
+  xcrun stapler validate "${DMG_PATH}"
+fi
+
+trash_path "${STAGING_DIR}"
+
+echo "Built:"
+echo "  - ${APP_BUNDLE}"
+echo "  - ${DMG_PATH}"

--- a/script/build_macos_release.sh
+++ b/script/build_macos_release.sh
@@ -17,6 +17,7 @@ PRODUCT_NAME="ClassroomWidgetsDashboard"
 BUNDLE_ID="com.classroomwidgets.dashboard"
 MACOS_DIR="${ROOT_DIR}/packages/macos-dashboard"
 APP_BUNDLE="${ROOT_DIR}/dist/${APP_NAME}.app"
+INSTALL_APP_BUNDLE="/Applications/${APP_NAME}.app"
 APP_CONTENTS="${APP_BUNDLE}/Contents"
 APP_MACOS="${APP_CONTENTS}/MacOS"
 APP_RESOURCES="${APP_CONTENTS}/Resources"
@@ -231,6 +232,10 @@ else
   codesign --verify --deep --strict --verbose=2 "${APP_BUNDLE}"
 fi
 
+echo "Installing app to ${INSTALL_APP_BUNDLE}"
+trash_path "${INSTALL_APP_BUNDLE}"
+cp -R "${APP_BUNDLE}" "${INSTALL_APP_BUNDLE}"
+
 mkdir -p "${STAGING_DIR}"
 cp -R "${APP_BUNDLE}" "${STAGING_DIR}/"
 
@@ -293,4 +298,5 @@ trash_path "${STAGING_DIR}"
 
 echo "Built:"
 echo "  - ${APP_BUNDLE}"
+echo "  - ${INSTALL_APP_BUNDLE}"
 echo "  - ${DMG_PATH}"

--- a/script/macos-distribution-entitlements.plist
+++ b/script/macos-distribution-entitlements.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.device.camera</key>
+  <true/>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
- add the SwiftPM macOS dashboard overlay app and desktop dashboard mode integration
- add local macOS run and DMG build scripts with Developer ID signing, hardened runtime, camera entitlement, notarisation, and stapling support
- install successful macOS builds to /Applications/Classroom Widgets Dashboard.app so macOS camera permission stays tied to the canonical app location

## Validation
- npm run macos:run -- --verify
- npm run macos:dmg -- --distribution --notarise --identity "Developer ID Application: Tinkertanker (PQ6U5ESLN2)" --team PQ6U5ESLN2 --api-key /Users/yingjie/Developer/personal-projects/JustNow/.release-credentials/AuthKey_C56Y5MW7VN.p8 --api-key-id C56Y5MW7VN --api-issuer 69a6de74-75f2-47e3-e053-5b8c7c11a4d1
- xcrun stapler validate dist/ClassroomWidgetsDashboard-v0.10.10-macos.dmg
- spctl -a -vv -t open --context context:primary-signature dist/ClassroomWidgetsDashboard-v0.10.10-macos.dmg
- hdiutil verify dist/ClassroomWidgetsDashboard-v0.10.10-macos.dmg
- npm run test -w @classroom-widgets/teacher -- --run src/features/widgets/visualiser/visualiser.test.tsx
- npm run test:unit -w @classroom-widgets/server
- swift build --package-path packages/macos-dashboard -c release

Apple notarisation accepted submission b400dea5-aa31-4110-ab44-0d255eeac40e. The local notarised DMG is dist/ClassroomWidgetsDashboard-v0.10.10-macos.dmg.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tinkertanker/classroom-widgets/pull/52" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->