### PR TITLE
fix: hide macOS dashboard window when inactive

### DIFF
--- a/packages/macos-dashboard/Sources/ClassroomWidgetsDashboard/DashboardWindowController.swift
+++ b/packages/macos-dashboard/Sources/ClassroomWidgetsDashboard/DashboardWindowController.swift
@@ -9,6 +9,7 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate 
     private var localMouseMonitor: Any?
     private var globalMouseMonitor: Any?
     private var pendingWidgetLauncherOpen = false
+    private var widgetLauncherOpenAttemptInFlight = false
     var isDashboardVisible: Bool { dashboardVisible }
 
     init() {
@@ -78,7 +79,7 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate 
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
         setWebDashboardVisible(dashboardVisible)
 
-        if pendingWidgetLauncherOpen {
+        if pendingWidgetLauncherOpen && !widgetLauncherOpenAttemptInFlight {
             openWidgetLauncher()
         }
     }
@@ -107,7 +108,10 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate 
     func showWidgetLauncher() {
         pendingWidgetLauncherOpen = true
         showDashboard()
-        openWidgetLauncher()
+
+        if !webView.isLoading {
+            openWidgetLauncher()
+        }
     }
 
     func applySettings() {
@@ -233,6 +237,11 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate 
     }
 
     private func openWidgetLauncher(retriesRemaining: Int = 5) {
+        guard pendingWidgetLauncherOpen, !widgetLauncherOpenAttemptInFlight else {
+            return
+        }
+
+        widgetLauncherOpenAttemptInFlight = true
         let expression = """
         (() => {
           if (window.openClassroomWidgetLauncher) {
@@ -243,15 +252,22 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate 
         })()
         """
         webView.evaluateJavaScript(expression) { [weak self] result, _ in
+            guard let self else { return }
+
+            self.widgetLauncherOpenAttemptInFlight = false
+
             if result as? Bool == true {
-                self?.pendingWidgetLauncherOpen = false
+                self.pendingWidgetLauncherOpen = false
                 return
             }
 
-            guard retriesRemaining > 0 else { return }
+            guard retriesRemaining > 0 else {
+                self.pendingWidgetLauncherOpen = false
+                return
+            }
 
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
-                self?.openWidgetLauncher(retriesRemaining: retriesRemaining - 1)
+                self.openWidgetLauncher(retriesRemaining: retriesRemaining - 1)
             }
         }
     }

--- a/packages/macos-dashboard/Sources/ClassroomWidgetsDashboard/DashboardWindowController.swift
+++ b/packages/macos-dashboard/Sources/ClassroomWidgetsDashboard/DashboardWindowController.swift
@@ -1,13 +1,14 @@
 import AppKit
 import WebKit
 
-final class DashboardWindowController: NSWindowController {
+final class DashboardWindowController: NSWindowController, WKNavigationDelegate {
     private let webView: WKWebView
     private let scriptMessageHandler: DashboardScriptMessageHandler
     private var dashboardVisible: Bool
     private var interactiveRegions: [CGRect] = []
     private var localMouseMonitor: Any?
     private var globalMouseMonitor: Any?
+    private var pendingWidgetLauncherOpen = false
     var isDashboardVisible: Bool { dashboardVisible }
 
     init() {
@@ -42,13 +43,14 @@ final class DashboardWindowController: NSWindowController {
         window.contentView = webView
 
         super.init(window: window)
+        webView.navigationDelegate = self
         applySettings()
         installMouseMonitors()
 
         scriptMessageHandler.onVisibilityChanged = { [weak self] visible in
             guard let self else { return }
             self.dashboardVisible = visible
-            self.updateMousePassthrough()
+            self.syncWindowVisibility()
         }
         scriptMessageHandler.onInteractiveRegionsChanged = { [weak self] regions in
             guard let self else { return }
@@ -73,14 +75,20 @@ final class DashboardWindowController: NSWindowController {
         webView.configuration.userContentController.removeScriptMessageHandler(forName: "classroomDashboard")
     }
 
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        setWebDashboardVisible(dashboardVisible)
+
+        if pendingWidgetLauncherOpen {
+            openWidgetLauncher()
+        }
+    }
+
     func showDashboard() {
         dashboardVisible = true
         let frame = Self.combinedVisibleFrame()
         window?.setFrame(frame, display: true)
         applySettings()
-        window?.makeKeyAndOrderFront(nil)
-        window?.orderFrontRegardless()
-        updateMousePassthrough()
+        syncWindowVisibility(activateApp: true)
         NSApp.activate(ignoringOtherApps: true)
         setWebDashboardVisible(true)
     }
@@ -91,23 +99,15 @@ final class DashboardWindowController: NSWindowController {
 
         if dashboardVisible {
             window?.setFrame(Self.combinedVisibleFrame(), display: true)
-            window?.makeKeyAndOrderFront(nil)
-            window?.orderFrontRegardless()
-            updateMousePassthrough()
-            NSApp.activate(ignoringOtherApps: true)
-        } else {
-            window?.ignoresMouseEvents = true
         }
+
+        syncWindowVisibility(activateApp: dashboardVisible)
     }
 
     func showWidgetLauncher() {
+        pendingWidgetLauncherOpen = true
         showDashboard()
-        let expression = """
-        requestAnimationFrame(() => {
-          document.querySelector('[title*="More widgets"]')?.click()
-        })
-        """
-        webView.evaluateJavaScript(expression)
+        openWidgetLauncher()
     }
 
     func applySettings() {
@@ -122,12 +122,27 @@ final class DashboardWindowController: NSWindowController {
         }
         window.collectionBehavior = behavior
 
-        if !dashboardVisible {
+        syncWindowVisibility()
+    }
+
+    private func syncWindowVisibility(activateApp: Bool = false) {
+        guard let window else { return }
+
+        guard dashboardVisible else {
             window.ignoresMouseEvents = true
+            window.orderOut(nil)
             return
         }
 
+        if !window.isVisible {
+            window.makeKeyAndOrderFront(nil)
+        }
+        window.orderFrontRegardless()
         updateMousePassthrough()
+
+        if activateApp {
+            NSApp.activate(ignoringOtherApps: true)
+        }
     }
 
     private func installMouseMonitors() {
@@ -195,9 +210,50 @@ final class DashboardWindowController: NSWindowController {
         webView.load(URLRequest(url: url))
     }
 
-    private func setWebDashboardVisible(_ visible: Bool) {
-        let expression = "window.classroomDashboard?.setVisible(\(visible ? "true" : "false"))"
-        webView.evaluateJavaScript(expression)
+    private func setWebDashboardVisible(_ visible: Bool, retriesRemaining: Int = 3) {
+        let expression = """
+        (() => {
+          if (window.classroomDashboard?.setVisible) {
+            window.classroomDashboard.setVisible(\(visible ? "true" : "false"));
+            return true;
+          }
+          return false;
+        })()
+        """
+        webView.evaluateJavaScript(expression) { [weak self] result, _ in
+            guard
+                result as? Bool != true,
+                retriesRemaining > 0
+            else { return }
+
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
+                self?.setWebDashboardVisible(visible, retriesRemaining: retriesRemaining - 1)
+            }
+        }
+    }
+
+    private func openWidgetLauncher(retriesRemaining: Int = 5) {
+        let expression = """
+        (() => {
+          if (window.openClassroomWidgetLauncher) {
+            window.openClassroomWidgetLauncher();
+            return true;
+          }
+          return false;
+        })()
+        """
+        webView.evaluateJavaScript(expression) { [weak self] result, _ in
+            if result as? Bool == true {
+                self?.pendingWidgetLauncherOpen = false
+                return
+            }
+
+            guard retriesRemaining > 0 else { return }
+
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
+                self?.openWidgetLauncher(retriesRemaining: retriesRemaining - 1)
+            }
+        }
     }
 
     private static func combinedVisibleFrame() -> NSRect {

--- a/packages/teacher/src/app/App.tsx
+++ b/packages/teacher/src/app/App.tsx
@@ -167,11 +167,7 @@ function App() {
       // Open widget launcher with Cmd/Ctrl + K (handle this first to avoid triggering voice control)
       if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
         e.preventDefault();
-        // Trigger the LaunchpadDialog by clicking the More button
-        const moreButton = document.querySelector('[title*="More widgets"]') as HTMLButtonElement;
-        if (moreButton) {
-          moreButton.click();
-        }
+        window.openClassroomWidgetLauncher?.();
         return;
       }
 

--- a/packages/teacher/src/features/hud/components/BottomBar.tsx
+++ b/packages/teacher/src/features/hud/components/BottomBar.tsx
@@ -100,11 +100,15 @@ const BottomBar: React.FC<BottomBarProps> = ({ onToggleLayout }) => {
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-  const handleAddWidget = (type: WidgetType) => {
+  const handleAddWidget = React.useCallback((type: WidgetType) => {
     createWidget(type);
-  };
+  }, [createWidget]);
 
-  const handleShowMoreWidgets = () => {
+  const handleShowMoreWidgets = React.useCallback(() => {
+    if (stickerMode) {
+      return;
+    }
+
     showModal({
       title: 'Add Widget',
       content: (
@@ -118,7 +122,7 @@ const BottomBar: React.FC<BottomBarProps> = ({ onToggleLayout }) => {
       className: 'w-[calc(100%-2rem)] max-w-4xl bg-soft-white dark:bg-warm-gray-800 rounded-lg shadow-xl',
       noPadding: true
     });
-  };
+  }, [handleAddWidget, hideModal, showModal, stickerMode]);
 
   useEffect(() => {
     window.openClassroomWidgetLauncher = handleShowMoreWidgets;

--- a/packages/teacher/src/features/hud/components/BottomBar.tsx
+++ b/packages/teacher/src/features/hud/components/BottomBar.tsx
@@ -21,6 +21,12 @@ import { useHudProximityContext } from '@shared/hooks/useHudProximity';
 import { hudProximity } from '@shared/utils/styles';
 import { STICKER_MODE_CHANGE_EVENT } from '@shared/constants/events';
 
+declare global {
+  interface Window {
+    openClassroomWidgetLauncher?: () => void;
+  }
+}
+
 // Default recent widgets if none are set
 const defaultRecentWidgets = [
   WidgetType.RANDOMISER,
@@ -113,6 +119,16 @@ const BottomBar: React.FC<BottomBarProps> = ({ onToggleLayout }) => {
       noPadding: true
     });
   };
+
+  useEffect(() => {
+    window.openClassroomWidgetLauncher = handleShowMoreWidgets;
+
+    return () => {
+      if (window.openClassroomWidgetLauncher === handleShowMoreWidgets) {
+        delete window.openClassroomWidgetLauncher;
+      }
+    };
+  }, [handleShowMoreWidgets]);
 
   const handleShowStickers = () => {
     showModal({


### PR DESCRIPTION
## Summary
- order the macOS dashboard window out when hidden so the transparent overlay does not sit above other apps
- keep dashboard visibility synced after WebKit finishes loading
- expose a real widget launcher bridge instead of clicking the hidden bottom bar button

## Verification
- `rtk npm run build -w @classroom-widgets/teacher`
- `rtk swift build --package-path packages/macos-dashboard -c debug`
- `rtk ./script/build_and_run.sh --verify`
- menu-bar Show/Hide Dashboard transitions `windows=0 -> 1 -> 0`
- menu-bar Open Widget Launcher opens a dashboard window, then Hide returns to `windows=0`

## Handoff
Ready for Devin to babysit review/CI.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tinkertanker/classroom-widgets/pull/53" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->