### PR TITLE
[codex] Expand macOS dashboard settings

### DIFF
--- a/packages/macos-dashboard/Sources/ClassroomWidgetsDashboard/AppDelegate.swift
+++ b/packages/macos-dashboard/Sources/ClassroomWidgetsDashboard/AppDelegate.swift
@@ -7,13 +7,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var controller: DashboardWindowController?
     private var hotKeys: [DashboardHotKey] = []
     private var statusItem: NSStatusItem?
+    private let launchAtLoginManager = LaunchAtLoginManager()
     private lazy var settingsContext = DashboardSettingsContext(
+        launchAtLoginManager: launchAtLoginManager,
         onShortcutsChanged: { [weak self] in
             self?.registerHotKeys()
             self?.updateStatusMenu()
         },
         onWindowBehaviorChanged: { [weak self] in
             self?.controller?.applySettings()
+        },
+        onMenuBarIconChanged: { [weak self] in
+            self?.syncStatusItemVisibility()
         },
         onShowDashboard: { [weak self] in
             self?.controller?.showDashboard()
@@ -49,11 +54,34 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func setupStatusItem() {
+        guard UserDefaults.standard.bool(forKey: DashboardSettingKeys.showMenuBarIcon) else {
+            statusItem = nil
+            return
+        }
+
         let statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)
         statusItem.button?.image = menuBarIcon()
         statusItem.button?.imagePosition = .imageOnly
         self.statusItem = statusItem
         updateStatusMenu()
+    }
+
+    private func syncStatusItemVisibility() {
+        let shouldShow = UserDefaults.standard.bool(forKey: DashboardSettingKeys.showMenuBarIcon)
+
+        if shouldShow {
+            if statusItem == nil {
+                setupStatusItem()
+            } else {
+                updateStatusMenu()
+            }
+            return
+        }
+
+        if let statusItem {
+            NSStatusBar.system.removeStatusItem(statusItem)
+        }
+        statusItem = nil
     }
 
     private func menuBarIcon() -> NSImage? {
@@ -80,24 +108,31 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let toggleTitle = controller?.isDashboardVisible == true ? "Hide Dashboard" : "Show Dashboard"
         let toggleItem = NSMenuItem(title: toggleTitle, action: #selector(toggleDashboard), keyEquivalent: "")
         toggleItem.target = self
-        toggleItem.attributedTitle = menuTitle(toggleTitle, shortcut: DashboardShortcutFormatter.title(
+        applyShortcut(
+            to: toggleItem,
             keyCode: shortcutKeyCode(for: DashboardSettingKeys.toggleShortcutKeyCode, fallback: DashboardDefaults.toggleShortcutKeyCode),
             modifiers: shortcutModifiers(for: DashboardSettingKeys.toggleShortcutModifiers)
-        ))
+        )
         menu.addItem(toggleItem)
 
         let launcherItem = NSMenuItem(title: "Open Widget Launcher", action: #selector(showWidgetLauncher), keyEquivalent: "")
         launcherItem.target = self
-        launcherItem.attributedTitle = menuTitle("Open Widget Launcher", shortcut: DashboardShortcutFormatter.title(
+        applyShortcut(
+            to: launcherItem,
             keyCode: shortcutKeyCode(for: DashboardSettingKeys.launcherShortcutKeyCode, fallback: DashboardDefaults.launcherShortcutKeyCode),
             modifiers: shortcutModifiers(for: DashboardSettingKeys.launcherShortcutModifiers)
-        ))
+        )
         menu.addItem(launcherItem)
 
         menu.addItem(NSMenuItem.separator())
 
-        let settingsItem = NSMenuItem(title: "Settings...", action: #selector(showSettings), keyEquivalent: ",")
+        let settingsItem = NSMenuItem(title: "Settings...", action: #selector(showSettings), keyEquivalent: "")
         settingsItem.target = self
+        applyShortcut(
+            to: settingsItem,
+            keyCode: shortcutKeyCode(for: DashboardSettingKeys.settingsShortcutKeyCode, fallback: DashboardDefaults.settingsShortcutKeyCode),
+            modifiers: shortcutModifiers(for: DashboardSettingKeys.settingsShortcutModifiers)
+        )
         menu.addItem(settingsItem)
 
         menu.addItem(NSMenuItem.separator())
@@ -109,29 +144,76 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         statusItem?.menu = menu
     }
 
+    private func applyShortcut(to item: NSMenuItem, keyCode: Int, modifiers: Int) {
+        guard let keyEquivalent = DashboardShortcutFormatter.keyEquivalent(for: keyCode) else {
+            item.keyEquivalent = ""
+            item.keyEquivalentModifierMask = []
+            return
+        }
+
+        item.keyEquivalent = keyEquivalent
+        item.keyEquivalentModifierMask = DashboardShortcutFormatter.modifierFlags(from: modifiers)
+    }
+
     private func registerHotKeys() {
         hotKeys.removeAll()
 
         let toggleKeyCode = shortcutKeyCode(for: DashboardSettingKeys.toggleShortcutKeyCode, fallback: DashboardDefaults.toggleShortcutKeyCode)
-        if toggleKeyCode != -1, let modifiers = carbonModifiers(from: shortcutModifiers(for: DashboardSettingKeys.toggleShortcutModifiers)) {
-            registerHotKey(id: 1, keyCode: toggleKeyCode, modifiers: modifiers) { [weak self] in
-                self?.controller?.toggleDashboard()
-                self?.updateStatusMenu()
-            }
+        let toggleModifiers = shortcutModifiers(for: DashboardSettingKeys.toggleShortcutModifiers)
+        registerGlobalShortcut(
+            id: 1,
+            keyCode: toggleKeyCode,
+            rawModifiers: toggleModifiers,
+            reservedShortcuts: []
+        ) { [weak self] in
+            self?.controller?.toggleDashboard()
+            self?.updateStatusMenu()
         }
 
         let launcherKeyCode = shortcutKeyCode(for: DashboardSettingKeys.launcherShortcutKeyCode, fallback: DashboardDefaults.launcherShortcutKeyCode)
         let launcherModifiers = shortcutModifiers(for: DashboardSettingKeys.launcherShortcutModifiers)
-        let conflictsWithToggle = launcherKeyCode == toggleKeyCode &&
-            launcherModifiers == shortcutModifiers(for: DashboardSettingKeys.toggleShortcutModifiers)
+        registerGlobalShortcut(
+            id: 2,
+            keyCode: launcherKeyCode,
+            rawModifiers: launcherModifiers,
+            reservedShortcuts: [(toggleKeyCode, toggleModifiers)]
+        ) { [weak self] in
+            self?.controller?.showWidgetLauncher()
+            self?.updateStatusMenu()
+        }
 
-        if !conflictsWithToggle,
-           launcherKeyCode != -1,
-           let modifiers = carbonModifiers(from: launcherModifiers) {
-            registerHotKey(id: 2, keyCode: launcherKeyCode, modifiers: modifiers) { [weak self] in
-                self?.controller?.showWidgetLauncher()
-                self?.updateStatusMenu()
-            }
+        let settingsKeyCode = shortcutKeyCode(for: DashboardSettingKeys.settingsShortcutKeyCode, fallback: DashboardDefaults.settingsShortcutKeyCode)
+        let settingsModifiers = shortcutModifiers(for: DashboardSettingKeys.settingsShortcutModifiers)
+        registerGlobalShortcut(
+            id: 3,
+            keyCode: settingsKeyCode,
+            rawModifiers: settingsModifiers,
+            reservedShortcuts: [
+                (toggleKeyCode, toggleModifiers),
+                (launcherKeyCode, launcherModifiers)
+            ]
+        ) { [weak self] in
+            self?.settingsWindowCoordinator.show()
+            self?.updateStatusMenu()
+        }
+    }
+
+    private func registerGlobalShortcut(
+        id: UInt32,
+        keyCode: Int,
+        rawModifiers: Int,
+        reservedShortcuts: [(keyCode: Int, modifiers: Int)],
+        handler: @escaping () -> Void
+    ) {
+        guard keyCode != -1 else { return }
+
+        let conflictsWithReservedShortcut = reservedShortcuts.contains { reservedShortcut in
+            reservedShortcut.keyCode == keyCode && reservedShortcut.modifiers == rawModifiers
+        }
+        guard !conflictsWithReservedShortcut else { return }
+
+        if let modifiers = carbonModifiers(from: rawModifiers) {
+            registerHotKey(id: id, keyCode: keyCode, modifiers: modifiers, handler: handler)
         }
     }
 
@@ -142,6 +224,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         } catch {
             NSLog("Unable to register dashboard hotkey \(id): \(error)")
         }
+    }
+
+    func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
+        showSettings()
+        return true
     }
 
     @objc private func toggleDashboard() {
@@ -191,17 +278,4 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         return carbonModifiers == 0 ? nil : carbonModifiers
     }
 
-    private func menuTitle(_ title: String, shortcut: String?) -> NSAttributedString {
-        guard let shortcut else {
-            return NSAttributedString(string: title)
-        }
-
-        let attributed = NSMutableAttributedString(string: title)
-        let shortcutString = NSAttributedString(
-            string: "    \(shortcut)",
-            attributes: [.foregroundColor: NSColor.secondaryLabelColor]
-        )
-        attributed.append(shortcutString)
-        return attributed
-    }
 }

--- a/packages/macos-dashboard/Sources/ClassroomWidgetsDashboard/AppDelegate.swift
+++ b/packages/macos-dashboard/Sources/ClassroomWidgetsDashboard/AppDelegate.swift
@@ -47,6 +47,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         if UserDefaults.standard.bool(forKey: DashboardSettingKeys.showDashboardAtLaunch) {
             controller.showDashboard()
         }
+
+        if !UserDefaults.standard.bool(forKey: DashboardSettingKeys.showMenuBarIcon) {
+            showSettings()
+        }
     }
 
     func applicationWillTerminate(_ notification: Notification) {

--- a/packages/macos-dashboard/Sources/ClassroomWidgetsDashboard/DashboardSettings.swift
+++ b/packages/macos-dashboard/Sources/ClassroomWidgetsDashboard/DashboardSettings.swift
@@ -7,15 +7,20 @@ enum DashboardSettingKeys {
     static let toggleShortcutModifiers = "dashboardToggleShortcutModifiers"
     static let launcherShortcutKeyCode = "dashboardLauncherShortcutKeyCode"
     static let launcherShortcutModifiers = "dashboardLauncherShortcutModifiers"
+    static let settingsShortcutKeyCode = "dashboardSettingsShortcutKeyCode"
+    static let settingsShortcutModifiers = "dashboardSettingsShortcutModifiers"
     static let showDashboardAtLaunch = "showDashboardAtLaunch"
     static let clickThroughEmptyAreas = "clickThroughEmptyAreas"
     static let keepOnAllSpaces = "keepOnAllSpaces"
     static let floatingOverlay = "floatingOverlay"
+    static let showMenuBarIcon = "showMenuBarIcon"
+    static let hasSeenMenuBarHideInfo = "hasSeenMenuBarHideInfo"
 }
 
 enum DashboardDefaults {
     static let toggleShortcutKeyCode = Int(kVK_Space)
     static let launcherShortcutKeyCode = Int(kVK_ANSI_K)
+    static let settingsShortcutKeyCode = Int(kVK_ANSI_Comma)
     static let shortcutModifiers = Int(NSEvent.ModifierFlags([.command, .option]).rawValue)
 
     static func register() {
@@ -24,31 +29,53 @@ enum DashboardDefaults {
             DashboardSettingKeys.toggleShortcutModifiers: shortcutModifiers,
             DashboardSettingKeys.launcherShortcutKeyCode: launcherShortcutKeyCode,
             DashboardSettingKeys.launcherShortcutModifiers: shortcutModifiers,
+            DashboardSettingKeys.settingsShortcutKeyCode: settingsShortcutKeyCode,
+            DashboardSettingKeys.settingsShortcutModifiers: shortcutModifiers,
             DashboardSettingKeys.showDashboardAtLaunch: false,
             DashboardSettingKeys.clickThroughEmptyAreas: true,
             DashboardSettingKeys.keepOnAllSpaces: true,
-            DashboardSettingKeys.floatingOverlay: true
+            DashboardSettingKeys.floatingOverlay: true,
+            DashboardSettingKeys.showMenuBarIcon: true,
+            DashboardSettingKeys.hasSeenMenuBarHideInfo: false
         ])
     }
 }
 
 @MainActor
 final class DashboardSettingsContext {
+    private let launchAtLoginManager: LaunchAtLoginManager
     private let onShortcutsChanged: @MainActor () -> Void
     private let onWindowBehaviorChanged: @MainActor () -> Void
+    private let onMenuBarIconChanged: @MainActor () -> Void
     private let onShowDashboard: @MainActor () -> Void
     private let onShowWidgetLauncher: @MainActor () -> Void
 
     init(
+        launchAtLoginManager: LaunchAtLoginManager,
         onShortcutsChanged: @escaping @MainActor () -> Void,
         onWindowBehaviorChanged: @escaping @MainActor () -> Void,
+        onMenuBarIconChanged: @escaping @MainActor () -> Void,
         onShowDashboard: @escaping @MainActor () -> Void,
         onShowWidgetLauncher: @escaping @MainActor () -> Void
     ) {
+        self.launchAtLoginManager = launchAtLoginManager
         self.onShortcutsChanged = onShortcutsChanged
         self.onWindowBehaviorChanged = onWindowBehaviorChanged
+        self.onMenuBarIconChanged = onMenuBarIconChanged
         self.onShowDashboard = onShowDashboard
         self.onShowWidgetLauncher = onShowWidgetLauncher
+    }
+
+    var canConfigureLaunchAtLogin: Bool {
+        launchAtLoginManager.canConfigure
+    }
+
+    func launchAtLoginEnabled() -> Bool {
+        launchAtLoginManager.isEnabled
+    }
+
+    func setLaunchAtLoginEnabled(_ isEnabled: Bool) throws -> LaunchAtLoginManager.ChangeResult {
+        try launchAtLoginManager.setEnabled(isEnabled)
     }
 
     func shortcutsChanged() {
@@ -57,6 +84,10 @@ final class DashboardSettingsContext {
 
     func windowBehaviorChanged() {
         onWindowBehaviorChanged()
+    }
+
+    func menuBarIconChanged() {
+        onMenuBarIconChanged()
     }
 
     func showDashboard() {
@@ -73,19 +104,53 @@ struct DashboardSettingsView: View {
     @AppStorage(DashboardSettingKeys.toggleShortcutModifiers) private var toggleShortcutModifiers = DashboardDefaults.shortcutModifiers
     @AppStorage(DashboardSettingKeys.launcherShortcutKeyCode) private var launcherShortcutKeyCode = DashboardDefaults.launcherShortcutKeyCode
     @AppStorage(DashboardSettingKeys.launcherShortcutModifiers) private var launcherShortcutModifiers = DashboardDefaults.shortcutModifiers
+    @AppStorage(DashboardSettingKeys.settingsShortcutKeyCode) private var settingsShortcutKeyCode = DashboardDefaults.settingsShortcutKeyCode
+    @AppStorage(DashboardSettingKeys.settingsShortcutModifiers) private var settingsShortcutModifiers = DashboardDefaults.shortcutModifiers
     @AppStorage(DashboardSettingKeys.showDashboardAtLaunch) private var showDashboardAtLaunch = false
     @AppStorage(DashboardSettingKeys.clickThroughEmptyAreas) private var clickThroughEmptyAreas = true
     @AppStorage(DashboardSettingKeys.keepOnAllSpaces) private var keepOnAllSpaces = true
     @AppStorage(DashboardSettingKeys.floatingOverlay) private var floatingOverlay = true
+    @AppStorage(DashboardSettingKeys.showMenuBarIcon) private var showMenuBarIcon = true
+    @AppStorage(DashboardSettingKeys.hasSeenMenuBarHideInfo) private var hasSeenMenuBarHideInfo = false
+    @State private var launchAtLoginEnabled = false
+    @State private var launchAtLoginAlertMessage: String?
+    @State private var showHideIconInfoAlert = false
 
     let context: DashboardSettingsContext
 
     var body: some View {
         TabView {
             Form {
-                Section("Launch") {
-                    Toggle("Show dashboard at launch", isOn: $showDashboardAtLaunch)
+                Section("Startup") {
+                    Toggle("Launch at login", isOn: launchAtLoginBinding)
+                        .disabled(!context.canConfigureLaunchAtLogin)
 
+                    Text("If macOS asks for approval, enable Classroom Widgets Dashboard in System Settings > General > Login Items.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+
+                    Toggle("Show dashboard at launch", isOn: $showDashboardAtLaunch)
+                }
+
+                Section("Menu Bar") {
+                    Toggle("Show menu bar icon", isOn: $showMenuBarIcon)
+                        .onChange(of: showMenuBarIcon) { newValue in
+                            context.menuBarIconChanged()
+
+                            if !newValue && !hasSeenMenuBarHideInfo {
+                                showHideIconInfoAlert = true
+                                hasSeenMenuBarHideInfo = true
+                            }
+                        }
+
+                    Text("If the icon is hidden, use the Settings shortcut or relaunch the app to reopen Settings.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                Section("Actions") {
                     HStack {
                         Button("Show Dashboard") {
                             context.showDashboard()
@@ -112,7 +177,7 @@ struct DashboardSettingsView: View {
 
             Form {
                 Section("Keyboard Shortcuts") {
-                    LabeledContent("Show or hide dashboard") {
+                    shortcutRow("Show or hide dashboard") {
                         KeyboardShortcutRecorder(
                             keyCode: $toggleShortcutKeyCode,
                             modifiers: $toggleShortcutModifiers,
@@ -120,7 +185,7 @@ struct DashboardSettingsView: View {
                         )
                     }
 
-                    LabeledContent("Open widget launcher") {
+                    shortcutRow("Open widget launcher") {
                         KeyboardShortcutRecorder(
                             keyCode: $launcherShortcutKeyCode,
                             modifiers: $launcherShortcutModifiers,
@@ -128,10 +193,24 @@ struct DashboardSettingsView: View {
                         )
                     }
 
-                    if shortcutsConflict {
-                        Label("Both actions use the same shortcut. The dashboard toggle will take precedence.", systemImage: "exclamationmark.triangle")
-                            .foregroundStyle(.orange)
+                    shortcutRow("Open Settings") {
+                        KeyboardShortcutRecorder(
+                            keyCode: $settingsShortcutKeyCode,
+                            modifiers: $settingsShortcutModifiers,
+                            placeholder: "None"
+                        )
+                    }
+
+                    Text("These shortcuts work across macOS while Classroom Widgets Dashboard is running. Keep each action on a distinct shortcut.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+
+                    if let shortcutConflictMessage {
+                        Label(shortcutConflictMessage, systemImage: "exclamationmark.triangle")
                             .font(.caption)
+                            .foregroundStyle(.orange)
+                            .fixedSize(horizontal: false, vertical: true)
                     }
                 }
 
@@ -141,6 +220,8 @@ struct DashboardSettingsView: View {
                         toggleShortcutModifiers = DashboardDefaults.shortcutModifiers
                         launcherShortcutKeyCode = DashboardDefaults.launcherShortcutKeyCode
                         launcherShortcutModifiers = DashboardDefaults.shortcutModifiers
+                        settingsShortcutKeyCode = DashboardDefaults.settingsShortcutKeyCode
+                        settingsShortcutModifiers = DashboardDefaults.shortcutModifiers
                     }
                 }
             }
@@ -149,16 +230,97 @@ struct DashboardSettingsView: View {
                 Label("Shortcuts", systemImage: "keyboard")
             }
         }
-        .frame(width: 520, height: 330)
+        .frame(width: 540, height: 430)
         .padding(20)
+        .task {
+            syncLaunchAtLoginState()
+        }
         .onChange(of: windowBehaviorSignature) { _ in context.windowBehaviorChanged() }
         .onChange(of: shortcutsSignature) { _ in context.shortcutsChanged() }
+        .alert("Launch at login", isPresented: launchAtLoginAlertIsPresented) {
+            Button("OK", role: .cancel) {
+                launchAtLoginAlertMessage = nil
+            }
+        } message: {
+            Text(launchAtLoginAlertMessage ?? "")
+        }
+        .alert("Menu bar icon hidden", isPresented: $showHideIconInfoAlert) {
+            Button("Got it", role: .cancel) { }
+        } message: {
+            Text("Use the Settings shortcut or relaunch Classroom Widgets Dashboard to reopen Settings.")
+        }
     }
 
-    private var shortcutsConflict: Bool {
-        toggleShortcutKeyCode != -1 &&
-            toggleShortcutKeyCode == launcherShortcutKeyCode &&
-            toggleShortcutModifiers == launcherShortcutModifiers
+    @ViewBuilder
+    private func shortcutRow<Content: View>(_ title: String, @ViewBuilder content: () -> Content) -> some View {
+        LabeledContent {
+            content()
+                .frame(width: 210, alignment: .trailing)
+        } label: {
+            Text(title)
+        }
+    }
+
+    private var shortcutConflictMessage: String? {
+        let shortcuts: [(label: String, keyCode: Int, modifiers: Int)] = [
+            ("Show or hide dashboard", toggleShortcutKeyCode, toggleShortcutModifiers),
+            ("Open widget launcher", launcherShortcutKeyCode, launcherShortcutModifiers),
+            ("Open Settings", settingsShortcutKeyCode, settingsShortcutModifiers)
+        ]
+
+        for index in shortcuts.indices {
+            let current = shortcuts[index]
+            guard current.keyCode != -1 else { continue }
+            guard index + 1 < shortcuts.count else { continue }
+
+            for comparisonIndex in (index + 1)..<shortcuts.count {
+                let comparison = shortcuts[comparisonIndex]
+                guard comparison.keyCode != -1 else { continue }
+
+                if current.keyCode == comparison.keyCode && current.modifiers == comparison.modifiers {
+                    return "\(current.label) and \(comparison.label) should not share the same shortcut."
+                }
+            }
+        }
+
+        return nil
+    }
+
+    private func syncLaunchAtLoginState() {
+        launchAtLoginEnabled = context.launchAtLoginEnabled()
+    }
+
+    private var launchAtLoginBinding: Binding<Bool> {
+        Binding(
+            get: { launchAtLoginEnabled },
+            set: { newValue in
+                let previousValue = launchAtLoginEnabled
+                launchAtLoginEnabled = newValue
+
+                do {
+                    let result = try context.setLaunchAtLoginEnabled(newValue)
+                    syncLaunchAtLoginState()
+
+                    if result == .requiresApproval {
+                        launchAtLoginAlertMessage = "macOS needs approval before Classroom Widgets Dashboard can launch at login. Enable it in System Settings > General > Login Items."
+                    }
+                } catch {
+                    launchAtLoginEnabled = previousValue
+                    launchAtLoginAlertMessage = error.localizedDescription
+                }
+            }
+        )
+    }
+
+    private var launchAtLoginAlertIsPresented: Binding<Bool> {
+        Binding(
+            get: { launchAtLoginAlertMessage != nil },
+            set: { isPresented in
+                if !isPresented {
+                    launchAtLoginAlertMessage = nil
+                }
+            }
+        )
     }
 
     private var windowBehaviorSignature: String {
@@ -174,13 +336,17 @@ struct DashboardSettingsView: View {
             toggleShortcutKeyCode,
             toggleShortcutModifiers,
             launcherShortcutKeyCode,
-            launcherShortcutModifiers
+            launcherShortcutModifiers,
+            settingsShortcutKeyCode,
+            settingsShortcutModifiers
         ].map(String.init).joined(separator: ":")
     }
 }
 
 @MainActor
 final class SettingsWindowCoordinator: NSObject, NSWindowDelegate {
+    private static let defaultWindowSize = NSSize(width: 580, height: 470)
+
     private let makeContentView: @MainActor () -> NSView
     private(set) var window: NSWindow?
 
@@ -197,7 +363,7 @@ final class SettingsWindowCoordinator: NSObject, NSWindowDelegate {
         }
 
         let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 560, height: 380),
+            contentRect: NSRect(origin: .zero, size: Self.defaultWindowSize),
             styleMask: [.titled, .closable],
             backing: .buffered,
             defer: false
@@ -214,6 +380,10 @@ final class SettingsWindowCoordinator: NSObject, NSWindowDelegate {
     }
 
     func windowShouldClose(_ sender: NSWindow) -> Bool {
+        guard sender === window else {
+            return true
+        }
+
         sender.orderOut(nil)
         return false
     }

--- a/packages/macos-dashboard/Sources/ClassroomWidgetsDashboard/DashboardShortcutFormatter.swift
+++ b/packages/macos-dashboard/Sources/ClassroomWidgetsDashboard/DashboardShortcutFormatter.swift
@@ -11,6 +11,22 @@ enum DashboardShortcutFormatter {
         return modifierSymbols(from: flags) + keyTitle(for: keyCode)
     }
 
+    static func keyEquivalent(for keyCode: Int) -> String? {
+        guard keyCode != -1 else {
+            return nil
+        }
+
+        if let specialKey = specialMenuKeyEquivalents[keyCode] {
+            return specialKey
+        }
+
+        return keyCodeToUSKeyboardCharacter[keyCode]?.lowercased()
+    }
+
+    static func modifierFlags(from modifiers: Int) -> NSEvent.ModifierFlags {
+        NSEvent.ModifierFlags(rawValue: UInt(modifiers)).intersection(.deviceIndependentFlagsMask)
+    }
+
     static func modifierSymbols(from flags: NSEvent.ModifierFlags) -> String {
         var symbols = ""
         if flags.contains(.control) { symbols += "⌃" }
@@ -46,6 +62,35 @@ enum DashboardShortcutFormatter {
         kVK_F1: "F1", kVK_F2: "F2", kVK_F3: "F3", kVK_F4: "F4",
         kVK_F5: "F5", kVK_F6: "F6", kVK_F7: "F7", kVK_F8: "F8",
         kVK_F9: "F9", kVK_F10: "F10", kVK_F11: "F11", kVK_F12: "F12"
+    ]
+
+    private static let specialMenuKeyEquivalents: [Int: String] = [
+        kVK_Return: "\r",
+        kVK_Tab: "\t",
+        kVK_Space: " ",
+        kVK_Delete: "\u{8}",
+        kVK_Escape: "\u{1b}",
+        kVK_ForwardDelete: String(UnicodeScalar(NSDeleteFunctionKey)!),
+        kVK_LeftArrow: String(UnicodeScalar(NSLeftArrowFunctionKey)!),
+        kVK_RightArrow: String(UnicodeScalar(NSRightArrowFunctionKey)!),
+        kVK_UpArrow: String(UnicodeScalar(NSUpArrowFunctionKey)!),
+        kVK_DownArrow: String(UnicodeScalar(NSDownArrowFunctionKey)!),
+        kVK_Home: String(UnicodeScalar(NSHomeFunctionKey)!),
+        kVK_End: String(UnicodeScalar(NSEndFunctionKey)!),
+        kVK_PageUp: String(UnicodeScalar(NSPageUpFunctionKey)!),
+        kVK_PageDown: String(UnicodeScalar(NSPageDownFunctionKey)!),
+        kVK_F1: String(UnicodeScalar(NSF1FunctionKey)!),
+        kVK_F2: String(UnicodeScalar(NSF2FunctionKey)!),
+        kVK_F3: String(UnicodeScalar(NSF3FunctionKey)!),
+        kVK_F4: String(UnicodeScalar(NSF4FunctionKey)!),
+        kVK_F5: String(UnicodeScalar(NSF5FunctionKey)!),
+        kVK_F6: String(UnicodeScalar(NSF6FunctionKey)!),
+        kVK_F7: String(UnicodeScalar(NSF7FunctionKey)!),
+        kVK_F8: String(UnicodeScalar(NSF8FunctionKey)!),
+        kVK_F9: String(UnicodeScalar(NSF9FunctionKey)!),
+        kVK_F10: String(UnicodeScalar(NSF10FunctionKey)!),
+        kVK_F11: String(UnicodeScalar(NSF11FunctionKey)!),
+        kVK_F12: String(UnicodeScalar(NSF12FunctionKey)!)
     ]
 
     private static let keyCodeToUSKeyboardCharacter: [Int: String] = [

--- a/packages/macos-dashboard/Sources/ClassroomWidgetsDashboard/LaunchAtLoginManager.swift
+++ b/packages/macos-dashboard/Sources/ClassroomWidgetsDashboard/LaunchAtLoginManager.swift
@@ -1,0 +1,68 @@
+import ServiceManagement
+
+enum LaunchAtLoginError: LocalizedError {
+    case serviceUnavailable
+    case registrationFailed(underlying: any Error)
+
+    var errorDescription: String? {
+        switch self {
+        case .serviceUnavailable:
+            "Launch at login is not available in this build."
+        case .registrationFailed(let underlying):
+            "Could not toggle launch at login: \(underlying.localizedDescription). Try moving Classroom Widgets Dashboard to /Applications, or restart your Mac."
+        }
+    }
+}
+
+@MainActor
+final class LaunchAtLoginManager {
+    enum ChangeResult {
+        case updated
+        case requiresApproval
+    }
+
+    private let service: SMAppService
+
+    init(service: SMAppService = .mainApp) {
+        self.service = service
+    }
+
+    var isEnabled: Bool {
+        switch service.status {
+        case .enabled, .requiresApproval:
+            true
+        case .notRegistered, .notFound:
+            false
+        @unknown default:
+            false
+        }
+    }
+
+    var canConfigure: Bool {
+        true
+    }
+
+    func setEnabled(_ isEnabled: Bool) throws -> ChangeResult {
+        if isEnabled {
+            if service.status != .enabled {
+                do {
+                    try service.register()
+                } catch {
+                    throw LaunchAtLoginError.registrationFailed(underlying: error)
+                }
+            }
+
+            return service.status == .requiresApproval ? .requiresApproval : .updated
+        }
+
+        switch service.status {
+        case .enabled, .requiresApproval:
+            try service.unregister()
+            return .updated
+        case .notRegistered, .notFound:
+            return .updated
+        @unknown default:
+            throw LaunchAtLoginError.serviceUnavailable
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add launch-at-login support to the macOS dashboard settings
- add menu bar icon visibility control with a recovery warning
- add a configurable Settings shortcut and show menu shortcuts in AppKit's right-aligned shortcut column

## Validation
- swift build --package-path packages/macos-dashboard
- npm run macos:run -- --verify

## Notes
- npm ci was run to install missing local workspace dependencies before the full macOS verification. It reported existing audit issues, which this PR does not address.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tinkertanker/classroom-widgets/pull/54" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->