### PR TITLE
fix: macOS dashboard overlay — widgets unclickable (zero interactive regions)

### DIFF
--- a/packages/teacher/src/features/desktop/useDesktopDashboardMode.ts
+++ b/packages/teacher/src/features/desktop/useDesktopDashboardMode.ts
@@ -50,6 +50,14 @@ function isEditableTarget(target: EventTarget | null) {
 }
 
 function isElementInteractable(element: Element) {
+  // pointer-events is inherited and can be re-enabled by descendants
+  // (e.g. .toolbar-container and .toolbar-content disable it, the buttons
+  // inside restore it), so only the element's own computed value is
+  // meaningful — an ancestor's 'none' must not disqualify the element.
+  if (window.getComputedStyle(element).pointerEvents === 'none') {
+    return false;
+  }
+
   let current: Element | null = element;
 
   while (current && current !== document.documentElement) {
@@ -57,7 +65,6 @@ function isElementInteractable(element: Element) {
     if (
       style.display === 'none' ||
       style.visibility === 'hidden' ||
-      style.pointerEvents === 'none' ||
       Number(style.opacity) === 0
     ) {
       return false;
@@ -129,9 +136,16 @@ export function useDesktopDashboardMode() {
         }));
     };
 
+    let lastPublishedKey: string | null = null;
+
     const publishRegions = () => {
       frame = 0;
       const regions = collectRegions();
+      const key = regions
+        .map((region) => `${region.x},${region.y},${region.width},${region.height}`)
+        .join(';');
+      if (key === lastPublishedKey) return;
+      lastPublishedKey = key;
       setInteractiveRegions(regions);
       window.webkit?.messageHandlers?.classroomDashboard?.postMessage({
         type: 'interactive-regions-changed',


### PR DESCRIPTION
## Summary

The macOS dashboard overlay toggles `NSWindow.ignoresMouseEvents` based on interactive regions reported by the web app. `isElementInteractable()` rejected any element with an ancestor styled `pointer-events: none` — but `.toolbar-container`, `.toolbar-content` and the modal backdrop all deliberately use that pattern, with descendants re-enabling pointer events. Since `pointer-events` is an inherited property, the element's own computed value already accounts for ancestors, so the ancestor walk filtered out every toolbar button and dialog. The overlay reported **zero regions**, the native window ignored the mouse everywhere, and widgets/HUD were unclickable — the root cause behind the long "can click desktop XOR can click widgets" saga. The single full-screen window + `ignoresMouseEvents` toggle architecture is sound once regions are reported correctly.

## Changes
- Check `pointer-events` only on the element's own computed style; keep the ancestor walk for `display`/`visibility`/`opacity` (opacity is compositional, not inherited)
- Skip republishing regions over the native bridge when unchanged (the toolbar clock's blinking colon triggered a publish every 500 ms)

## Testing
- Verified end to end on the installed app (`npm run macos:run -- --verify`) with simulated clicks (cliclick) + screenshots + os_log: regions now report (count=8 with toolbar visible), MORE opens the launchpad, launchpad/dialog clicks work, widget Start/Restart and dragging work, clicks and focus on empty areas pass through to underlying apps, and rapid widget↔desktop alternation shows no stale capture states
- Teacher test suite: 85 passed, 0 failed
- `tsc --noEmit`: only pre-existing errors in unrelated files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tinkertanker/classroom-widgets/pull/58" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->