### PR TITLE
Teacher app: performance and stability fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7593,7 +7593,7 @@
         "jsdom": "^26.1.0",
         "postcss": "^8.5.6",
         "tailwindcss": "^3.4.17",
-        "typescript": "^5.4.5",
+        "typescript": "^5.7.2",
         "vite": "^7.0.4",
         "vite-tsconfig-paths": "^5.1.4",
         "vitest": "^3.2.4"

--- a/packages/shared/hooks/useWidget.ts
+++ b/packages/shared/hooks/useWidget.ts
@@ -100,14 +100,16 @@ export function useWidgetEvents(widgetId: string, handlers: {
 // Hook for creating a new widget
 export function useCreateWidget() {
   const addWidget = useWorkspaceStore((state) => state.addWidget);
-  const widgets = useWorkspaceStore(useShallow((state) => state.widgets));
-  const scale = useWorkspaceStore((state) => state.scale);
-  
+
   const createWidget = useCallback((type: WidgetType, position?: Position) => {
     // If position is provided, use it
     if (position) {
       return addWidget(type, position);
     }
+
+    // Read widgets/scale at call time rather than subscribing — callers like
+    // the toolbar would otherwise re-render on every widget move/focus change
+    const { widgets, scale } = useWorkspaceStore.getState();
     
     // Get widget default size from registry
     const widgetConfig = widgetRegistry.get(type);
@@ -167,8 +169,8 @@ export function useCreateWidget() {
     
     // Fallback to default position
     return addWidget(type);
-  }, [addWidget, widgets, scale]);
-  
+  }, [addWidget]);
+
   return createWidget;
 }
 

--- a/packages/shared/types/storage.ts
+++ b/packages/shared/types/storage.ts
@@ -125,6 +125,8 @@ export interface StoredBottomBarConfig {
 export interface GlobalSettings {
   theme: 'light' | 'dark';
   bottomBar: StoredBottomBarConfig;
+  /** Class end time shown by the toolbar clock (epoch ms), null when unset */
+  classEndTime?: number | null;
 }
 
 /**

--- a/packages/teacher/package.json
+++ b/packages/teacher/package.json
@@ -49,7 +49,7 @@
     "jsdom": "^26.1.0",
     "postcss": "^8.5.6",
     "tailwindcss": "^3.4.17",
-    "typescript": "^5.4.5",
+    "typescript": "^5.7.2",
     "vite": "^7.0.4",
     "vite-tsconfig-paths": "^5.1.4",
     "vitest": "^3.2.4"

--- a/packages/teacher/package.json
+++ b/packages/teacher/package.json
@@ -8,6 +8,7 @@
     "dev": "vite",
     "build": "vite build",
     "test": "vitest",
+    "typecheck": "tsc --noEmit",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/packages/teacher/src/contexts/SessionContext.tsx
+++ b/packages/teacher/src/contexts/SessionContext.tsx
@@ -253,13 +253,18 @@ export const SessionProvider: React.FC<SessionProviderProps> = ({ children }) =>
   // Helper function for delay with abort support
   const delay = (ms: number, signal?: AbortSignal): Promise<void> => {
     return new Promise((resolve, reject) => {
-      const timeout = setTimeout(resolve, ms);
-      if (signal) {
-        signal.addEventListener('abort', () => {
-          clearTimeout(timeout);
-          reject(new Error('Aborted'));
-        });
-      }
+      const onAbort = () => {
+        clearTimeout(timeout);
+        reject(new Error('Aborted'));
+      };
+      // Detach the abort listener once the delay completes — recovery retries
+      // reuse the same signal, so leaked listeners would accumulate and fire
+      // stale rejections on a later abort
+      const timeout = setTimeout(() => {
+        signal?.removeEventListener('abort', onAbort);
+        resolve();
+      }, ms);
+      signal?.addEventListener('abort', onAbort, { once: true });
     });
   };
 

--- a/packages/teacher/src/contexts/SessionContext.tsx
+++ b/packages/teacher/src/contexts/SessionContext.tsx
@@ -339,8 +339,10 @@ export const SessionProvider: React.FC<SessionProviderProps> = ({ children }) =>
 
         try {
           const response = await new Promise<any>((resolve, reject) => {
-            // Set up timeout for this attempt
+            // Set up timeout for this attempt; detach the abort listener on
+            // this path too — the signal is shared across retry attempts
             const timeoutId = setTimeout(() => {
+              signal.removeEventListener('abort', abortHandler);
               reject(new Error(`Recovery attempt ${attempt} timed out`));
             }, RECOVERY_TIMEOUT);
 
@@ -349,7 +351,7 @@ export const SessionProvider: React.FC<SessionProviderProps> = ({ children }) =>
               clearTimeout(timeoutId);
               reject(new Error('Aborted'));
             };
-            signal.addEventListener('abort', abortHandler);
+            signal.addEventListener('abort', abortHandler, { once: true });
 
             // Attempt to rejoin session
             socket.emit('session:create', { existingCode: sessionCode }, (result: any) => {

--- a/packages/teacher/src/features/board/components/Background.tsx
+++ b/packages/teacher/src/features/board/components/Background.tsx
@@ -239,4 +239,6 @@ const Background: React.FC<BackgroundProps> = ({ type }) => {
   }
 };
 
-export default Background;
+// Memoized: Board re-renders on every zoom/scale change, and the SVG/gradient
+// layers are expensive to reconcile when neither `type` nor dark mode changed
+export default React.memo(Background);

--- a/packages/teacher/src/features/hud/components/BottomBar.tsx
+++ b/packages/teacher/src/features/hud/components/BottomBar.tsx
@@ -201,11 +201,10 @@ const BottomBar: React.FC<BottomBarProps> = ({ onToggleLayout }) => {
       const x = MARGIN + col * (Math.max(size.width, 350) + SPACING);
       const y = currentY;
 
-      // Add the widget at the calculated position
-      // Use setTimeout to ensure unique timestamps even with the improved ID generation
-      setTimeout(() => {
-        addWidget(config.type, { x, y });
-      }, index * 10); // Small delay between each widget
+      // Add the widget at the calculated position. Widget IDs include a
+      // random suffix, so synchronous adds are safe — staggered timers would
+      // also pile up across repeated invocations and outlive unmount
+      addWidget(config.type, { x, y });
     });
 
     // Calculate total area needed
@@ -307,7 +306,7 @@ const BottomBar: React.FC<BottomBarProps> = ({ onToggleLayout }) => {
               <WidgetButton
                 key={config!.type}
                 config={config!}
-                onClick={() => handleAddWidget(config!.type)}
+                onSelect={handleAddWidget}
                 className={clsx(
                   stickerMode ? 'opacity-50 cursor-not-allowed' : '',
                   'flex-shrink-0'

--- a/packages/teacher/src/features/hud/components/Clock.tsx
+++ b/packages/teacher/src/features/hud/components/Clock.tsx
@@ -11,7 +11,6 @@ const URGENT_THRESHOLD = 5;
 
 const Clock: React.FC = () => {
   const [time, setTime] = useState(new Date());
-  const [showColon, setShowColon] = useState(true);
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const [selectedHour, setSelectedHour] = useState(12);
   const [selectedMinute, setSelectedMinute] = useState(0);
@@ -28,20 +27,20 @@ const Clock: React.FC = () => {
     return new Date(classEndTime);
   }, [classEndTime]);
 
-  // Update current time every second
+  // Check the time every second, but only re-render when the displayed
+  // minute changes (the colon blink is pure CSS, see .clock-colon-blink)
   useEffect(() => {
     const timer = setInterval(() => {
-      setTime(new Date());
+      setTime((prev) => {
+        const now = new Date();
+        const sameMinute =
+          prev.getMinutes() === now.getMinutes() &&
+          prev.getHours() === now.getHours() &&
+          prev.getDate() === now.getDate();
+        return sameMinute ? prev : now;
+      });
     }, 1000);
     return () => clearInterval(timer);
-  }, []);
-
-  // Blink colon every 500ms
-  useEffect(() => {
-    const colonTimer = setInterval(() => {
-      setShowColon(prev => !prev);
-    }, 500);
-    return () => clearInterval(colonTimer);
   }, []);
 
   // Close dropdown when clicking outside
@@ -127,7 +126,7 @@ const Clock: React.FC = () => {
     newEndTime.setHours(hours24, selectedMinute, 0, 0);
 
     // If the time is earlier than now, assume it's for tomorrow
-    if (newEndTime <= time) {
+    if (newEndTime <= new Date()) {
       newEndTime.setDate(newEndTime.getDate() + 1);
     }
 
@@ -219,7 +218,7 @@ const Clock: React.FC = () => {
         {/* Current Time */}
         <span className="text-sm font-medium">
           {displayHours}
-          <span className={showColon ? 'opacity-100' : 'opacity-0'}>:</span>
+          <span className="clock-colon-blink">:</span>
           {displayMinutes}
           <span className="ml-1 text-xs opacity-75">{ampm}</span>
         </span>
@@ -399,4 +398,4 @@ const Clock: React.FC = () => {
   );
 };
 
-export default Clock;
+export default React.memo(Clock);

--- a/packages/teacher/src/features/hud/components/WidgetButton.tsx
+++ b/packages/teacher/src/features/hud/components/WidgetButton.tsx
@@ -2,20 +2,20 @@
 
 import React from 'react';
 import { clsx } from 'clsx';
-import { WidgetConfig } from '@shared/types';
+import { WidgetConfig, WidgetType } from '@shared/types';
 
 interface WidgetButtonProps {
   config: WidgetConfig;
-  onClick: () => void;
+  onSelect: (type: WidgetType) => void;
   className?: string;
 }
 
-const WidgetButton: React.FC<WidgetButtonProps> = ({ config, onClick, className }) => {
+const WidgetButton: React.FC<WidgetButtonProps> = ({ config, onSelect, className }) => {
   const Icon = config.icon;
-  
+
   return (
     <button
-      onClick={onClick}
+      onClick={() => onSelect(config.type)}
       className={clsx(
         'px-3 py-2 max-[540px]:px-2 max-[540px]:py-1.5 rounded-lg text-warm-gray-700',
         'bg-white/50 dark:bg-warm-gray-700/50',
@@ -35,4 +35,6 @@ const WidgetButton: React.FC<WidgetButtonProps> = ({ config, onClick, className 
   );
 };
 
-export default WidgetButton;
+// Memoized: BottomBar re-renders on sticker mode and recent-widget changes;
+// onSelect takes the widget type so callers can pass one stable callback
+export default React.memo(WidgetButton);

--- a/packages/teacher/src/features/session/hooks/useSocketEvents.ts
+++ b/packages/teacher/src/features/session/hooks/useSocketEvents.ts
@@ -27,35 +27,45 @@ export function useSocketEvents({
   const { socket, isConnected } = useSession();
   const eventsRef = useRef(events);
 
-  // Store handler references so we can remove only our handlers on cleanup
-  const handlersRef = useRef<Map<string, (...args: any[]) => void>>(new Map());
-
   // Update events ref to avoid stale closures
   eventsRef.current = events;
+
+  // Re-subscribe only when the SET of event names changes, not when the
+  // events object identity changes — callers typically pass inline objects,
+  // which would otherwise tear down and re-register every listener on every
+  // render (and could drop events emitted in between)
+  const eventNamesKey = Object.keys(events)
+    .filter((name) => events[name as ServerEventName])
+    .sort()
+    .join(',');
 
   // Register/unregister event listeners
   useEffect(() => {
     if (!socket || !isActive) return;
 
-    // Clear previous handlers before registering new ones
-    handlersRef.current.clear();
+    // Register a stable wrapper per event that reads the latest handler at
+    // call time; cleanup removes only OUR wrappers, not all listeners for
+    // the event, so multiple widgets of the same type can coexist
+    const wrappers = new Map<string, (...args: any[]) => void>();
+    const eventNames = eventNamesKey ? eventNamesKey.split(',') : [];
 
-    // Register all event listeners and store handler references
-    Object.entries(events).forEach(([eventName, handler]) => {
-      if (handler) {
-        handlersRef.current.set(eventName, handler);
-        socket.on(eventName, handler);
-      }
+    eventNames.forEach((eventName) => {
+      const wrapper = (...args: any[]) => {
+        const handler = eventsRef.current[eventName as ServerEventName] as
+          | ((...handlerArgs: any[]) => void)
+          | undefined;
+        handler?.(...args);
+      };
+      wrappers.set(eventName, wrapper);
+      socket.on(eventName, wrapper);
     });
 
-    // Cleanup function - remove only OUR handlers, not all listeners for the event
     return () => {
-      handlersRef.current.forEach((handler, eventName) => {
-        socket.off(eventName, handler);
+      wrappers.forEach((wrapper, eventName) => {
+        socket.off(eventName, wrapper);
       });
-      handlersRef.current.clear();
     };
-  }, [socket, events, isActive]);
+  }, [socket, eventNamesKey, isActive]);
   
   // Emit function with type safety
   const emit = useCallback(<T extends ClientEventName>(event: T, data: ClientEventData<T>) => {

--- a/packages/teacher/src/features/voiceControl/services/VoiceCommandService.ts
+++ b/packages/teacher/src/features/voiceControl/services/VoiceCommandService.ts
@@ -1,6 +1,11 @@
 import { VoiceCommandRequest, VoiceCommandResponse, VoiceContext } from '../types/voiceControl';
 import { debug } from '@shared/utils/debug';
 
+// LLM fallback (Ollama) usually answers in under a second, but a wedged
+// backend would otherwise leave the voice UI waiting forever
+const COMMAND_TIMEOUT_MS = 15000;
+const HEALTH_CHECK_TIMEOUT_MS = 5000;
+
 export class VoiceCommandService {
   private baseUrl: string;
 
@@ -33,7 +38,8 @@ export class VoiceCommandService {
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify(request)
+        body: JSON.stringify(request),
+        signal: AbortSignal.timeout(COMMAND_TIMEOUT_MS)
       });
 
       if (!response.ok) {
@@ -89,7 +95,9 @@ export class VoiceCommandService {
    */
   async checkHealth(): Promise<boolean> {
     try {
-      const response = await fetch(`${this.baseUrl}/voice-command/health`);
+      const response = await fetch(`${this.baseUrl}/voice-command/health`, {
+        signal: AbortSignal.timeout(HEALTH_CHECK_TIMEOUT_MS)
+      });
       return response.ok;
     } catch (error) {
       debug.error('Voice command service health check failed:', error);

--- a/packages/teacher/src/features/voiceControl/services/VoiceCommandService.ts
+++ b/packages/teacher/src/features/voiceControl/services/VoiceCommandService.ts
@@ -66,7 +66,11 @@ export class VoiceCommandService {
           confidence: 0
         },
         feedback: {
-          message: error instanceof Error ? error.message : 'Failed to process voice command',
+          // A timed-out fetch rejects with a DOMException whose raw message
+          // ("signal timed out") would otherwise be shown to the teacher
+          message: error instanceof DOMException && error.name === 'TimeoutError'
+            ? 'Voice command timed out — is the server running?'
+            : error instanceof Error ? error.message : 'Failed to process voice command',
           type: 'error',
           shouldSpeak: false
         }

--- a/packages/teacher/src/features/voiceControl/services/VoiceCommandService.ts
+++ b/packages/teacher/src/features/voiceControl/services/VoiceCommandService.ts
@@ -6,6 +6,28 @@ import { debug } from '@shared/utils/debug';
 const COMMAND_TIMEOUT_MS = 15000;
 const HEALTH_CHECK_TIMEOUT_MS = 5000;
 
+// AbortSignal.timeout() is newer than the app's build target; fall back to a
+// manual controller so older runtimes still send the request un-bounded by
+// the missing API rather than failing before fetch starts
+function timeoutSignal(ms: number): AbortSignal | undefined {
+  if (typeof AbortSignal !== 'undefined' && typeof AbortSignal.timeout === 'function') {
+    return AbortSignal.timeout(ms);
+  }
+  if (typeof AbortController === 'undefined') {
+    return undefined;
+  }
+  const controller = new AbortController();
+  setTimeout(() => {
+    try {
+      controller.abort(new DOMException('The operation timed out', 'TimeoutError'));
+    } catch {
+      // Very old runtimes lack abort(reason)/DOMException constructor
+      controller.abort();
+    }
+  }, ms);
+  return controller.signal;
+}
+
 export class VoiceCommandService {
   private baseUrl: string;
 
@@ -39,7 +61,7 @@ export class VoiceCommandService {
           'Content-Type': 'application/json',
         },
         body: JSON.stringify(request),
-        signal: AbortSignal.timeout(COMMAND_TIMEOUT_MS)
+        signal: timeoutSignal(COMMAND_TIMEOUT_MS)
       });
 
       if (!response.ok) {
@@ -68,7 +90,7 @@ export class VoiceCommandService {
         feedback: {
           // A timed-out fetch rejects with a DOMException whose raw message
           // ("signal timed out") would otherwise be shown to the teacher
-          message: error instanceof DOMException && error.name === 'TimeoutError'
+          message: (error as { name?: string } | null)?.name === 'TimeoutError'
             ? 'Voice command timed out — is the server running?'
             : error instanceof Error ? error.message : 'Failed to process voice command',
           type: 'error',
@@ -100,7 +122,7 @@ export class VoiceCommandService {
   async checkHealth(): Promise<boolean> {
     try {
       const response = await fetch(`${this.baseUrl}/voice-command/health`, {
-        signal: AbortSignal.timeout(HEALTH_CHECK_TIMEOUT_MS)
+        signal: timeoutSignal(HEALTH_CHECK_TIMEOUT_MS)
       });
       return response.ok;
     } catch (error) {

--- a/packages/teacher/src/features/widgets/visualiser/visualiser.test.tsx
+++ b/packages/teacher/src/features/widgets/visualiser/visualiser.test.tsx
@@ -35,7 +35,7 @@ describe('Visualiser', () => {
     if (originalSrcObjectDescriptor) {
       Object.defineProperty(HTMLMediaElement.prototype, 'srcObject', originalSrcObjectDescriptor);
     } else {
-      delete (HTMLMediaElement.prototype as HTMLMediaElement & { srcObject?: MediaStream }).srcObject;
+      delete (HTMLMediaElement.prototype as { srcObject?: MediaStream }).srcObject;
     }
   });
 

--- a/packages/teacher/src/features/widgets/volumeLevel/hooks/useVolumeAnalyzer.ts
+++ b/packages/teacher/src/features/widgets/volumeLevel/hooks/useVolumeAnalyzer.ts
@@ -23,7 +23,7 @@ export function useVolumeAnalyzer({
 }: UseVolumeAnalyzerOptions) {
   const [volume, setVolume] = useState(0);
   const volumeHistoryRef = useRef<number[]>([]);
-  const dataArrayRef = useRef<Uint8Array | null>(null);
+  const dataArrayRef = useRef<Uint8Array<ArrayBuffer> | null>(null);
   const isCooldownRef = useRef(isInCooldown);
   const onThresholdExceededRef = useRef(onThresholdExceeded);
 

--- a/packages/teacher/src/index.css
+++ b/packages/teacher/src/index.css
@@ -33,6 +33,18 @@ code {
   animation: scale-in 0.1s ease-out;
 }
 
+/* Toolbar clock colon blink — pure CSS so the Clock component doesn't
+   need a 500ms re-render interval */
+@keyframes clock-colon-blink {
+  0% { opacity: 1; }
+  50% { opacity: 0; }
+  100% { opacity: 1; }
+}
+
+.clock-colon-blink {
+  animation: clock-colon-blink 1s step-end infinite;
+}
+
 /* Sticker button hover animations - fanning out effect */
 .group:hover .smile-sticker {
   transform: translateX(-4px) translateY(1px) rotate(-5deg) scale(1.02) !important;

--- a/packages/teacher/src/services/WidgetRegistry.ts
+++ b/packages/teacher/src/services/WidgetRegistry.ts
@@ -27,7 +27,7 @@ import {
 } from 'react-icons/fa6';
 import { GiSnake } from 'react-icons/gi';
 
-import { WidgetType, WidgetConfig, WidgetCategory, Size, ColumnSizing } from '@shared/types';
+import { WidgetType, WidgetConfig, WidgetCategory, WidgetFeatures, Size, ColumnSizing } from '@shared/types';
 import { WIDGET_TYPES } from '@shared/constants/widgetTypes';
 
 // Preload all widget chunks immediately so they're browser-cached
@@ -649,7 +649,7 @@ export class WidgetRegistry {
     return this.get(type)?.networked?.roomType;
   }
 
-  hasFeature(type: WidgetType, feature: keyof import('../shared/types').WidgetFeatures): boolean {
+  hasFeature(type: WidgetType, feature: keyof WidgetFeatures): boolean {
     return this.get(type)?.features?.[feature] || false;
   }
 
@@ -657,7 +657,7 @@ export class WidgetRegistry {
     return this.getByCategory(WidgetCategory.NETWORKED);
   }
 
-  getWidgetsByFeature(feature: keyof import('../shared/types').WidgetFeatures): WidgetConfig[] {
+  getWidgetsByFeature(feature: keyof WidgetFeatures): WidgetConfig[] {
     return this.getAll().filter(widget => widget.features?.[feature]);
   }
 

--- a/packages/teacher/src/store/workspaceStore.simple.ts
+++ b/packages/teacher/src/store/workspaceStore.simple.ts
@@ -287,8 +287,16 @@ function writeStorageValue(value: string, capturedWorkspaceId?: string | null): 
       // Update the workspace the value was captured for; fall back to the
       // pointer in storage when no id was captured (e.g. during startup)
       const currentWorkspaceId = capturedWorkspaceId || v2Data.currentWorkspaceId;
-      const currentWorkspace = v2Data.workspaces[currentWorkspaceId] ||
-        createDefaultWorkspace(currentWorkspaceId);
+      let currentWorkspace = v2Data.workspaces[currentWorkspaceId];
+      if (!currentWorkspace) {
+        if (capturedWorkspaceId) {
+          // The captured workspace was deleted (e.g. by another window)
+          // before the flush — drop the write rather than resurrect it
+          lastPersistedZustandValue = value;
+          return;
+        }
+        currentWorkspace = createDefaultWorkspace(currentWorkspaceId);
+      }
 
       v2Data.workspaces[currentWorkspaceId] = {
         ...currentWorkspace,

--- a/packages/teacher/src/store/workspaceStore.simple.ts
+++ b/packages/teacher/src/store/workspaceStore.simple.ts
@@ -179,6 +179,7 @@ const workspaceStorage: StateStorage = {
                 layoutFormat: currentWorkspace.layoutFormat || 'canvas',
                 theme: v2Data.globalSettings.theme,
                 bottomBar: (v2Data.globalSettings as any).bottomBar || (v2Data.globalSettings as any).toolbar,
+                classEndTime: v2Data.globalSettings.classEndTime ?? null,
                 sessionCode: v2Data.session.code,
                 sessionCreatedAt: v2Data.session.createdAt
               },
@@ -312,7 +313,8 @@ function writeStorageValue(value: string, capturedWorkspaceId?: string | null): 
       // Update global settings
       v2Data.globalSettings = {
         theme: state.theme || 'light',
-        bottomBar: state.bottomBar || defaultBottomBar
+        bottomBar: state.bottomBar || defaultBottomBar,
+        classEndTime: state.classEndTime ?? null
       };
 
       // Update session

--- a/packages/teacher/src/store/workspaceStore.simple.ts
+++ b/packages/teacher/src/store/workspaceStore.simple.ts
@@ -51,7 +51,7 @@ const defaultRecentWidgets = [
  * Get workspace metadata list from V2 storage
  */
 function getWorkspaceListFromStorage(): { currentId: string; list: WorkspaceMetadata[] } {
-  const v2Data = loadStorage();
+  const v2Data = loadStorageSynced();
   if (!v2Data) {
     return { currentId: '', list: [] };
   }
@@ -72,7 +72,7 @@ function getWorkspaceListFromStorage(): { currentId: string; list: WorkspaceMeta
  * Count existing workspaces with default naming pattern to generate next name
  */
 function getNextWorkspaceName(): string {
-  const v2Data = loadStorage();
+  const v2Data = loadStorageSynced();
   if (!v2Data) return 'Workspace 1';
 
   const workspaceCount = Object.keys(v2Data.workspaces).length;
@@ -101,6 +101,42 @@ const defaultBottomBar = {
 // =============================================================================
 
 let lastPersistedZustandValue: string | null = null;
+
+// Persisting is expensive (two JSON.parse calls plus a full re-stringify of the
+// V2 storage object, written to two localStorage keys), and Zustand's persist
+// middleware calls setItem on every store change — including focus changes and
+// drag stops. Batch rapid updates and write at most once per window.
+const PERSIST_DEBOUNCE_MS = 300;
+let pendingPersistValue: string | null = null;
+let persistTimeoutId: ReturnType<typeof setTimeout> | null = null;
+
+function flushPendingPersist(): void {
+  if (persistTimeoutId !== null) {
+    clearTimeout(persistTimeoutId);
+    persistTimeoutId = null;
+  }
+  if (pendingPersistValue !== null) {
+    const value = pendingPersistValue;
+    pendingPersistValue = null;
+    writeStorageValue(value);
+  }
+}
+
+// Several store actions read localStorage directly; they must see any
+// not-yet-flushed state or they would save a stale copy over it.
+function loadStorageSynced() {
+  flushPendingPersist();
+  return loadStorage();
+}
+
+if (typeof window !== 'undefined') {
+  window.addEventListener('pagehide', flushPendingPersist);
+  document.addEventListener('visibilitychange', () => {
+    if (document.visibilityState === 'hidden') {
+      flushPendingPersist();
+    }
+  });
+}
 
 /**
  * Custom storage adapter that handles the multi-workspace V2 format.
@@ -176,6 +212,36 @@ const workspaceStorage: StateStorage = {
   },
 
   setItem: (name: string, value: string): void => {
+    if (value === lastPersistedZustandValue && pendingPersistValue === null) {
+      return;
+    }
+
+    pendingPersistValue = value;
+    if (persistTimeoutId === null) {
+      persistTimeoutId = setTimeout(() => {
+        persistTimeoutId = null;
+        if (pendingPersistValue !== null) {
+          const pending = pendingPersistValue;
+          pendingPersistValue = null;
+          writeStorageValue(pending);
+        }
+      }, PERSIST_DEBOUNCE_MS);
+    }
+  },
+
+  removeItem: (name: string): void => {
+    if (persistTimeoutId !== null) {
+      clearTimeout(persistTimeoutId);
+      persistTimeoutId = null;
+    }
+    pendingPersistValue = null;
+    localStorage.removeItem(STORAGE_KEY);
+    localStorage.removeItem(LEGACY_STORAGE_KEY);
+    lastPersistedZustandValue = null;
+  }
+};
+
+function writeStorageValue(value: string): void {
     if (value === lastPersistedZustandValue) {
       return;
     }
@@ -241,14 +307,7 @@ const workspaceStorage: StateStorage = {
       localStorage.setItem(LEGACY_STORAGE_KEY, value);
       lastPersistedZustandValue = value;
     }
-  },
-
-  removeItem: (name: string): void => {
-    localStorage.removeItem(STORAGE_KEY);
-    localStorage.removeItem(LEGACY_STORAGE_KEY);
-    lastPersistedZustandValue = null;
-  }
-};
+}
 
 // =============================================================================
 // Store Creation
@@ -366,14 +425,21 @@ export const useWorkspaceStore = create<WorkspaceStore>()(
   },
   bringToFront: (widgetId) => {
     set((state) => {
-      const widgets = [...state.widgets];
-      const widgetIndex = widgets.findIndex(w => w.id === widgetId);
-      if (widgetIndex !== -1) {
-        const widget = widgets[widgetIndex];
-        widgets.splice(widgetIndex, 1);
-        widgets.push(widget);
-        widgets.forEach((w, i) => { w.zIndex = i; });
+      const widgetIndex = state.widgets.findIndex(w => w.id === widgetId);
+      if (widgetIndex === -1) {
+        return { focusedWidgetId: widgetId };
       }
+      // Already on top: skip the array rebuild (and the persist write it
+      // would trigger) — this runs on every click inside a widget
+      if (widgetIndex === state.widgets.length - 1) {
+        return state.focusedWidgetId === widgetId ? {} : { focusedWidgetId: widgetId };
+      }
+      const reordered = [...state.widgets];
+      const [moved] = reordered.splice(widgetIndex, 1);
+      reordered.push(moved);
+      // Replace only the widgets whose zIndex actually changed; mutating them
+      // in place would leave subscribers with stale references
+      const widgets = reordered.map((w, i) => (w.zIndex === i ? w : { ...w, zIndex: i }));
       return { widgets, focusedWidgetId: widgetId };
     });
   },
@@ -443,7 +509,7 @@ export const useWorkspaceStore = create<WorkspaceStore>()(
   },
 
   switchWorkspace: (workspaceId: string) => {
-    const v2Data = loadStorage();
+    const v2Data = loadStorageSynced();
     if (!v2Data || !v2Data.workspaces[workspaceId]) {
       console.warn('[WorkspaceStore] Cannot switch: workspace not found:', workspaceId);
       return;
@@ -471,7 +537,7 @@ export const useWorkspaceStore = create<WorkspaceStore>()(
   },
 
   createWorkspace: (name?: string) => {
-    const v2Data = loadStorage();
+    const v2Data = loadStorageSynced();
     if (!v2Data) {
       console.warn('[WorkspaceStore] Cannot create workspace: no storage found');
       return '';
@@ -504,7 +570,7 @@ export const useWorkspaceStore = create<WorkspaceStore>()(
   },
 
   deleteWorkspace: (workspaceId: string) => {
-    const v2Data = loadStorage();
+    const v2Data = loadStorageSynced();
     if (!v2Data) {
       console.warn('[WorkspaceStore] Cannot delete workspace: no storage found');
       return false;
@@ -543,7 +609,7 @@ export const useWorkspaceStore = create<WorkspaceStore>()(
   },
 
   renameWorkspace: (workspaceId: string, newName: string) => {
-    const v2Data = loadStorage();
+    const v2Data = loadStorageSynced();
     if (!v2Data) {
       console.warn('[WorkspaceStore] Cannot rename workspace: no storage found');
       return;
@@ -565,7 +631,7 @@ export const useWorkspaceStore = create<WorkspaceStore>()(
   // =============================================================================
 
   saveRandomiserList: (name: string, choices: string[]): string => {
-    const v2Data = loadStorage();
+    const v2Data = loadStorageSynced();
     if (!v2Data) {
       console.warn('[WorkspaceStore] Cannot save randomiser list: no storage found');
       return '';
@@ -602,7 +668,7 @@ export const useWorkspaceStore = create<WorkspaceStore>()(
   },
 
   deleteRandomiserList: (id: string) => {
-    const v2Data = loadStorage();
+    const v2Data = loadStorageSynced();
     if (!v2Data || !v2Data.savedCollections) {
       return;
     }
@@ -615,7 +681,7 @@ export const useWorkspaceStore = create<WorkspaceStore>()(
   },
 
   saveQuestionBank: (name: string, questions: Array<{ text: string; studentName?: string }>): string => {
-    const v2Data = loadStorage();
+    const v2Data = loadStorageSynced();
     if (!v2Data) {
       console.warn('[WorkspaceStore] Cannot save question bank: no storage found');
       return '';
@@ -652,7 +718,7 @@ export const useWorkspaceStore = create<WorkspaceStore>()(
   },
 
   deleteQuestionBank: (id: string) => {
-    const v2Data = loadStorage();
+    const v2Data = loadStorageSynced();
     if (!v2Data || !v2Data.savedCollections) {
       return;
     }
@@ -665,7 +731,7 @@ export const useWorkspaceStore = create<WorkspaceStore>()(
   },
 
   savePollQuestion: (name: string, question: string, options: string[]): string => {
-    const v2Data = loadStorage();
+    const v2Data = loadStorageSynced();
     if (!v2Data) {
       console.warn('[WorkspaceStore] Cannot save poll question: no storage found');
       return '';
@@ -712,7 +778,7 @@ export const useWorkspaceStore = create<WorkspaceStore>()(
   },
 
   deletePollQuestion: (id: string) => {
-    const v2Data = loadStorage();
+    const v2Data = loadStorageSynced();
     if (!v2Data || !v2Data.savedCollections || !v2Data.savedCollections.pollQuestions) {
       return;
     }
@@ -765,7 +831,7 @@ export const useWorkspaceStore = create<WorkspaceStore>()(
 
           // Populate workspace management state
           if (state) {
-            let v2Data = loadStorage();
+            let v2Data = loadStorageSynced();
 
             // If no storage exists, create default V2 storage with a workspace
             if (!v2Data) {

--- a/packages/teacher/src/store/workspaceStore.simple.ts
+++ b/packages/teacher/src/store/workspaceStore.simple.ts
@@ -108,6 +108,10 @@ let lastPersistedZustandValue: string | null = null;
 // drag stops. Batch rapid updates and write at most once per window.
 const PERSIST_DEBOUNCE_MS = 300;
 let pendingPersistValue: string | null = null;
+// Workspace the pending value belongs to, captured when the write is queued:
+// another window can change currentWorkspaceId in localStorage before the
+// flush fires, and the value must not be written under the new id
+let pendingPersistWorkspaceId: string | null = null;
 let persistTimeoutId: ReturnType<typeof setTimeout> | null = null;
 
 function flushPendingPersist(): void {
@@ -117,8 +121,10 @@ function flushPendingPersist(): void {
   }
   if (pendingPersistValue !== null) {
     const value = pendingPersistValue;
+    const workspaceId = pendingPersistWorkspaceId;
     pendingPersistValue = null;
-    writeStorageValue(value);
+    pendingPersistWorkspaceId = null;
+    writeStorageValue(value, workspaceId);
   }
 }
 
@@ -129,8 +135,12 @@ function loadStorageSynced() {
   return loadStorage();
 }
 
+// Flush on every leave-the-page signal we can get. A hard kill (crash, power
+// loss, native app terminating the webview) can still lose up to
+// PERSIST_DEBOUNCE_MS of changes — an accepted trade-off
 if (typeof window !== 'undefined') {
   window.addEventListener('pagehide', flushPendingPersist);
+  window.addEventListener('beforeunload', flushPendingPersist);
   document.addEventListener('visibilitychange', () => {
     if (document.visibilityState === 'hidden') {
       flushPendingPersist();
@@ -217,13 +227,21 @@ const workspaceStorage: StateStorage = {
     }
 
     pendingPersistValue = value;
+    try {
+      pendingPersistWorkspaceId = useWorkspaceStore.getState().currentWorkspaceId || null;
+    } catch {
+      // Store not constructed yet (persist can fire during creation)
+      pendingPersistWorkspaceId = null;
+    }
     if (persistTimeoutId === null) {
       persistTimeoutId = setTimeout(() => {
         persistTimeoutId = null;
         if (pendingPersistValue !== null) {
           const pending = pendingPersistValue;
+          const workspaceId = pendingPersistWorkspaceId;
           pendingPersistValue = null;
-          writeStorageValue(pending);
+          pendingPersistWorkspaceId = null;
+          writeStorageValue(pending, workspaceId);
         }
       }, PERSIST_DEBOUNCE_MS);
     }
@@ -235,13 +253,14 @@ const workspaceStorage: StateStorage = {
       persistTimeoutId = null;
     }
     pendingPersistValue = null;
+    pendingPersistWorkspaceId = null;
     localStorage.removeItem(STORAGE_KEY);
     localStorage.removeItem(LEGACY_STORAGE_KEY);
     lastPersistedZustandValue = null;
   }
 };
 
-function writeStorageValue(value: string): void {
+function writeStorageValue(value: string, capturedWorkspaceId?: string | null): void {
     if (value === lastPersistedZustandValue) {
       return;
     }
@@ -265,8 +284,9 @@ function writeStorageValue(value: string): void {
         v2Data = createDefaultStorageV2();
       }
 
-      // Update current workspace with new state
-      const currentWorkspaceId = v2Data.currentWorkspaceId;
+      // Update the workspace the value was captured for; fall back to the
+      // pointer in storage when no id was captured (e.g. during startup)
+      const currentWorkspaceId = capturedWorkspaceId || v2Data.currentWorkspaceId;
       const currentWorkspace = v2Data.workspaces[currentWorkspaceId] ||
         createDefaultWorkspace(currentWorkspaceId);
 
@@ -379,7 +399,9 @@ export const useWorkspaceStore = create<WorkspaceStore>()(
       type,
       position: position || { x: 100 + get().widgets.length * 20, y: 100 + get().widgets.length * 20 },
       size: config?.defaultSize || { width: 350, height: 350 },
-      zIndex: get().widgets.length
+      // Max + 1 (not array length): removals leave gaps, and a new widget
+      // must always land on top of existing ones
+      zIndex: get().widgets.reduce((max, w) => Math.max(max, w.zIndex), -1) + 1
     };
 
     // Update recent widgets: move this type to the front, remove duplicates, limit to N
@@ -429,10 +451,15 @@ export const useWorkspaceStore = create<WorkspaceStore>()(
       if (widgetIndex === -1) {
         return { focusedWidgetId: widgetId };
       }
-      // Already on top: skip the array rebuild (and the persist write it
-      // would trigger) — this runs on every click inside a widget
-      if (widgetIndex === state.widgets.length - 1) {
-        return state.focusedWidgetId === widgetId ? {} : { focusedWidgetId: widgetId };
+      // Already on top: skip the reorder — this runs on every click inside a
+      // widget. "Last in array" alone isn't enough: persisted workspaces (and
+      // historical addWidget behavior) can hold gapped or out-of-order
+      // zIndexes, so require fully normalized values before skipping
+      if (
+        widgetIndex === state.widgets.length - 1 &&
+        state.widgets.every((w, i) => w.zIndex === i)
+      ) {
+        return state.focusedWidgetId === widgetId ? state : { focusedWidgetId: widgetId };
       }
       const reordered = [...state.widgets];
       const [moved] = reordered.splice(widgetIndex, 1);

--- a/packages/teacher/src/utils/enableRenderTracking.ts
+++ b/packages/teacher/src/utils/enableRenderTracking.ts
@@ -32,7 +32,7 @@ export function enableRenderTracking() {
       // Log functional component renders
       debug(`[Render] ${args[0].name}`);
     }
-    return originalCreateElement.apply(React, args);
+    return originalCreateElement.apply(React, args as Parameters<typeof React.createElement>);
   } as typeof React.createElement;
 }
 


### PR DESCRIPTION
## Summary

Audit-driven pass over the teacher frontend to reduce re-render/persistence overhead and fix stability bugs. All changes were adversarially reviewed in two rounds (one MAJOR finding from round 1 was fixed and re-verified; round 2 verdict was ship-clean).

### Performance

- **Debounced localStorage persistence** — every store change (including focus changes and drag stops) used to synchronously do two `JSON.parse` calls, a full re-stringify of the entire multi-workspace storage object, and writes to two localStorage keys. Writes are now batched into a 300ms window, flushed on `pagehide`/`beforeunload`/tab-hidden. Store actions that read storage directly flush pending writes first, and each queued write captures its owning workspace id so a deferred flush can't land under a workspace switched to (or deleted) by another window in the interim.
- **`bringToFront`** — runs on every click inside a widget; now early-returns as a true Zustand no-op when the widget is already on top with normalized zIndexes, and creates new objects instead of mutating widgets in place (stale-reference hazard). `addWidget` now assigns `max(zIndex)+1` instead of array length, so new widgets always land on top after deletions.
- **Toolbar** — no longer subscribes to the widgets array (`useCreateWidget` reads state at call time); widget buttons memoized with a stable `onSelect` callback.
- **Clock** — colon blink moved to CSS; component re-renders once per minute instead of 3×/sec.
- **Background** — memoized; the SVG/gradient layers were reconciled on every zoom tick.

### Bug fixes

- **`useSocketEvents`** — callers passing inline `events` objects caused every socket listener to be torn down and re-registered on each render (a window where events could drop). Now registers stable wrappers reading the latest handler from a ref, re-subscribing only when the set of event names changes.
- **Session recovery** — abort listeners on the shared `AbortSignal` are now detached on both the delay-resolve and per-attempt-timeout paths (they previously accumulated across retries and fired stale rejections).
- **Voice command service** — fetches are now bounded (15s command / 5s health) so a wedged backend can't hang the voice UI, with a readable timeout message.
- **All 7 pre-existing TypeScript errors fixed**; `tsc --noEmit` is clean and a `typecheck` script was added. One of these (a broken type import in `WidgetRegistry`) was silently degrading feature lookups to `any`. Debug launch-all timer pile-up removed.

### Trade-offs / follow-ups

- Workspace saves now lag changes by up to 300ms; a hard kill (crash, native wrapper terminating the webview) inside that window loses those changes. Mitigated by flush-on-hide/unload; documented in code.
- Pre-existing (not regressions, noted during review, candidates for a multi-window hardening pass): `refreshWorkspaceList` can desync workspace id/data across two windows; `partialize` omits `scrollPosition` so stored scroll resets on every write.

## Testing

- `tsc --noEmit`: clean (was 7 errors on master)
- `vitest`: 12 files, 85/85 passing
- `vite build`: succeeds
- Two rounds of adversarial review on the full diff (store/persistence + hooks/UI), all findings addressed

https://claude.ai/code/session_01AS8Z36BeW8B8nAXY4gMF5o

---
_Generated by [Claude Code](https://claude.ai/code/session_01AS8Z36BeW8B8nAXY4gMF5o)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tinkertanker/classroom-widgets/pull/59" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->