### PR TITLE
Make the macOS dashboard look and feel more native

### DIFF
--- a/packages/macos-dashboard/Sources/ClassroomWidgetsDashboard/AppDelegate.swift
+++ b/packages/macos-dashboard/Sources/ClassroomWidgetsDashboard/AppDelegate.swift
@@ -31,11 +31,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
     )
     private lazy var settingsWindowCoordinator = SettingsWindowCoordinator { [weak self] in
-        guard let self else {
-            return NSView()
-        }
-
-        return NSHostingView(rootView: DashboardSettingsView(context: self.settingsContext))
+        self?.settingsContext
     }
 
     func applicationDidFinishLaunching(_ notification: Notification) {

--- a/packages/macos-dashboard/Sources/ClassroomWidgetsDashboard/AppDelegate.swift
+++ b/packages/macos-dashboard/Sources/ClassroomWidgetsDashboard/AppDelegate.swift
@@ -42,6 +42,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         DashboardDefaults.register()
         NSApp.setActivationPolicy(.accessory)
         NSApp.applicationIconImage = NSImage(named: "AppIcon") ?? NSApp.applicationIconImage
+        setupMainMenu()
 
         let controller = DashboardWindowController()
         controller.onVisibilityChanged = { [weak self] _ in
@@ -63,6 +64,50 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     func applicationWillTerminate(_ notification: Notification) {
         hotKeys.removeAll()
+    }
+
+    // Accessory apps have no visible menu bar, but NSApp.mainMenu still routes
+    // key equivalents. Without it, Cmd+C/V/X/Z/A never reach the web view's
+    // text fields and Cmd+W cannot close the Settings window.
+    private func setupMainMenu() {
+        let mainMenu = NSMenu()
+
+        let appMenuItem = NSMenuItem()
+        let appMenu = NSMenu()
+        let aboutItem = NSMenuItem(title: "About Classroom Widgets", action: #selector(showAbout), keyEquivalent: "")
+        aboutItem.target = self
+        appMenu.addItem(aboutItem)
+        appMenu.addItem(.separator())
+        let settingsItem = NSMenuItem(title: "Settings…", action: #selector(showSettings), keyEquivalent: ",")
+        settingsItem.target = self
+        appMenu.addItem(settingsItem)
+        appMenu.addItem(.separator())
+        appMenu.addItem(NSMenuItem(title: "Hide Classroom Widgets", action: #selector(NSApplication.hide(_:)), keyEquivalent: "h"))
+        appMenu.addItem(NSMenuItem(title: "Quit Classroom Widgets", action: #selector(NSApplication.terminate(_:)), keyEquivalent: "q"))
+        appMenuItem.submenu = appMenu
+        mainMenu.addItem(appMenuItem)
+
+        let editMenuItem = NSMenuItem()
+        let editMenu = NSMenu(title: "Edit")
+        editMenu.addItem(NSMenuItem(title: "Undo", action: Selector(("undo:")), keyEquivalent: "z"))
+        editMenu.addItem(NSMenuItem(title: "Redo", action: Selector(("redo:")), keyEquivalent: "Z"))
+        editMenu.addItem(.separator())
+        editMenu.addItem(NSMenuItem(title: "Cut", action: #selector(NSText.cut(_:)), keyEquivalent: "x"))
+        editMenu.addItem(NSMenuItem(title: "Copy", action: #selector(NSText.copy(_:)), keyEquivalent: "c"))
+        editMenu.addItem(NSMenuItem(title: "Paste", action: #selector(NSText.paste(_:)), keyEquivalent: "v"))
+        editMenu.addItem(NSMenuItem(title: "Select All", action: #selector(NSText.selectAll(_:)), keyEquivalent: "a"))
+        editMenuItem.submenu = editMenu
+        mainMenu.addItem(editMenuItem)
+
+        let windowMenuItem = NSMenuItem()
+        let windowMenu = NSMenu(title: "Window")
+        let closeItem = NSMenuItem(title: "Close Window", action: #selector(closeFrontWindow), keyEquivalent: "w")
+        closeItem.target = self
+        windowMenu.addItem(closeItem)
+        windowMenuItem.submenu = windowMenu
+        mainMenu.addItem(windowMenuItem)
+
+        NSApp.mainMenu = mainMenu
     }
 
     private func setupStatusItem() {
@@ -251,6 +296,25 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     @objc private func reloadDashboard() {
         controller?.reloadDashboard()
+    }
+
+    @objc private func closeFrontWindow() {
+        guard let keyWindow = NSApp.keyWindow else {
+            NSSound.beep()
+            return
+        }
+
+        // The borderless dashboard window has no close button, so Cmd+W hides
+        // the dashboard instead of beeping.
+        if keyWindow is DashboardWindow {
+            if controller?.isDashboardVisible == true {
+                controller?.toggleDashboard()
+                updateStatusMenu()
+            }
+            return
+        }
+
+        keyWindow.performClose(nil)
     }
 
     @objc private func showSettings() {

--- a/packages/macos-dashboard/Sources/ClassroomWidgetsDashboard/AppDelegate.swift
+++ b/packages/macos-dashboard/Sources/ClassroomWidgetsDashboard/AppDelegate.swift
@@ -78,7 +78,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         settingsItem.target = self
         appMenu.addItem(settingsItem)
         appMenu.addItem(.separator())
-        appMenu.addItem(NSMenuItem(title: "Hide Classroom Widgets", action: #selector(NSApplication.hide(_:)), keyEquivalent: "h"))
+        // No app-level "Hide" (Cmd+H): for a menu-bar accessory app with the
+        // status icon optionally hidden, hiding every window can strand the
+        // user with no way back. Cmd+W hides the dashboard instead.
         appMenu.addItem(NSMenuItem(title: "Quit Classroom Widgets", action: #selector(NSApplication.terminate(_:)), keyEquivalent: "q"))
         appMenuItem.submenu = appMenu
         mainMenu.addItem(appMenuItem)
@@ -306,6 +308,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             if controller?.isDashboardVisible == true {
                 controller?.toggleDashboard()
                 updateStatusMenu()
+            } else {
+                // Already hiding (window lingers briefly for the exit
+                // animation) — nothing to close.
+                NSSound.beep()
             }
             return
         }

--- a/packages/macos-dashboard/Sources/ClassroomWidgetsDashboard/AppDelegate.swift
+++ b/packages/macos-dashboard/Sources/ClassroomWidgetsDashboard/AppDelegate.swift
@@ -31,7 +31,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
     )
     private lazy var settingsWindowCoordinator = SettingsWindowCoordinator { [weak self] in
-        self?.settingsContext
+        guard let self else {
+            return NSView()
+        }
+
+        return NSHostingView(rootView: DashboardSettingsView(context: self.settingsContext))
     }
 
     func applicationDidFinishLaunching(_ notification: Notification) {

--- a/packages/macos-dashboard/Sources/ClassroomWidgetsDashboard/AppDelegate.swift
+++ b/packages/macos-dashboard/Sources/ClassroomWidgetsDashboard/AppDelegate.swift
@@ -163,7 +163,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         menu.addItem(NSMenuItem.separator())
 
-        let reloadItem = NSMenuItem(title: "Reload Dashboard", action: #selector(reloadDashboard), keyEquivalent: "r")
+        // No key equivalent: Cmd+R is far too generic for a global-ish menu
+        // item, and the web process now auto-reloads on crash, so this is just
+        // a manual recovery valve.
+        let reloadItem = NSMenuItem(title: "Reload Dashboard", action: #selector(reloadDashboard), keyEquivalent: "")
         reloadItem.target = self
         menu.addItem(reloadItem)
 

--- a/packages/macos-dashboard/Sources/ClassroomWidgetsDashboard/DashboardScriptMessageHandler.swift
+++ b/packages/macos-dashboard/Sources/ClassroomWidgetsDashboard/DashboardScriptMessageHandler.swift
@@ -1,10 +1,16 @@
 import CoreGraphics
 import WebKit
 
+struct DashboardGlassRegion {
+    let rect: CGRect
+    let radius: CGFloat
+}
+
 @MainActor
 final class DashboardScriptMessageHandler: NSObject, WKScriptMessageHandler {
     var onVisibilityChanged: (@MainActor (Bool) -> Void)?
     var onInteractiveRegionsChanged: (@MainActor ([CGRect]) -> Void)?
+    var onGlassRegionsChanged: (@MainActor ([DashboardGlassRegion]) -> Void)?
 
     func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
         guard
@@ -26,6 +32,19 @@ final class DashboardScriptMessageHandler: NSObject, WKScriptMessageHandler {
                     y: region["y"] ?? 0,
                     width: region["width"] ?? 0,
                     height: region["height"] ?? 0
+                )
+            })
+        case "glass-regions-changed":
+            guard let rawRegions = body["regions"] as? [[String: Double]] else { return }
+            onGlassRegionsChanged?(rawRegions.map { region in
+                DashboardGlassRegion(
+                    rect: CGRect(
+                        x: region["x"] ?? 0,
+                        y: region["y"] ?? 0,
+                        width: region["width"] ?? 0,
+                        height: region["height"] ?? 0
+                    ),
+                    radius: CGFloat(region["radius"] ?? 0)
                 )
             })
         default:

--- a/packages/macos-dashboard/Sources/ClassroomWidgetsDashboard/DashboardScriptMessageHandler.swift
+++ b/packages/macos-dashboard/Sources/ClassroomWidgetsDashboard/DashboardScriptMessageHandler.swift
@@ -13,6 +13,14 @@ final class DashboardScriptMessageHandler: NSObject, WKScriptMessageHandler {
     var onGlassRegionsChanged: (@MainActor ([DashboardGlassRegion]) -> Void)?
 
     func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
+        // The user script is injected into all frames, so only honour messages
+        // from a frame actually served by our bundle. Combined with the
+        // navigation policy (which keeps foreign content out of the web view),
+        // this stops any embedded/remote content from driving the native shell.
+        guard message.frameInfo.request.url?.scheme == dashboardURLScheme else {
+            return
+        }
+
         guard
             let body = message.body as? [String: Any],
             let type = body["type"] as? String

--- a/packages/macos-dashboard/Sources/ClassroomWidgetsDashboard/DashboardSettings.swift
+++ b/packages/macos-dashboard/Sources/ClassroomWidgetsDashboard/DashboardSettings.swift
@@ -19,7 +19,7 @@ enum DashboardSettingKeys {
 }
 
 enum DashboardDefaults {
-    static let toggleShortcutKeyCode = Int(kVK_Space)
+    static let toggleShortcutKeyCode = Int(kVK_ANSI_D)
     static let launcherShortcutKeyCode = Int(kVK_ANSI_K)
     static let settingsShortcutKeyCode = Int(kVK_ANSI_Comma)
     static let shortcutModifiers = Int(NSEvent.ModifierFlags([.command, .option]).rawValue)

--- a/packages/macos-dashboard/Sources/ClassroomWidgetsDashboard/DashboardSettings.swift
+++ b/packages/macos-dashboard/Sources/ClassroomWidgetsDashboard/DashboardSettings.swift
@@ -106,13 +106,7 @@ final class DashboardSettingsContext {
     }
 }
 
-struct DashboardSettingsView: View {
-    @AppStorage(DashboardSettingKeys.toggleShortcutKeyCode) private var toggleShortcutKeyCode = DashboardDefaults.toggleShortcutKeyCode
-    @AppStorage(DashboardSettingKeys.toggleShortcutModifiers) private var toggleShortcutModifiers = DashboardDefaults.shortcutModifiers
-    @AppStorage(DashboardSettingKeys.launcherShortcutKeyCode) private var launcherShortcutKeyCode = DashboardDefaults.launcherShortcutKeyCode
-    @AppStorage(DashboardSettingKeys.launcherShortcutModifiers) private var launcherShortcutModifiers = DashboardDefaults.shortcutModifiers
-    @AppStorage(DashboardSettingKeys.settingsShortcutKeyCode) private var settingsShortcutKeyCode = DashboardDefaults.settingsShortcutKeyCode
-    @AppStorage(DashboardSettingKeys.settingsShortcutModifiers) private var settingsShortcutModifiers = DashboardDefaults.shortcutModifiers
+struct DashboardGeneralSettingsView: View {
     @AppStorage(DashboardSettingKeys.showDashboardAtLaunch) private var showDashboardAtLaunch = false
     @AppStorage(DashboardSettingKeys.clickThroughEmptyAreas) private var clickThroughEmptyAreas = true
     @AppStorage(DashboardSettingKeys.keepOnAllSpaces) private var keepOnAllSpaces = true
@@ -126,133 +120,71 @@ struct DashboardSettingsView: View {
     let context: DashboardSettingsContext
 
     var body: some View {
-        TabView {
-            Form {
-                Section("Startup") {
-                    Toggle("Launch at login", isOn: launchAtLoginBinding)
-                        .disabled(!context.canConfigureLaunchAtLogin)
+        Form {
+            Section("Startup") {
+                Toggle("Launch at login", isOn: launchAtLoginBinding)
+                    .disabled(!context.canConfigureLaunchAtLogin)
 
-                    Text("If macOS asks for approval, enable Classroom Widgets Dashboard in System Settings > General > Login Items.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .fixedSize(horizontal: false, vertical: true)
+                Text("If macOS asks for approval, enable Classroom Widgets Dashboard in System Settings > General > Login Items.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
 
-                    Toggle("Show dashboard at launch", isOn: $showDashboardAtLaunch)
-                }
-
-                Section("Menu Bar") {
-                    Toggle("Show menu bar icon", isOn: $showMenuBarIcon)
-                        .onChange(of: showMenuBarIcon) { newValue in
-                            context.menuBarIconChanged()
-
-                            if !newValue && !hasSeenMenuBarHideInfo {
-                                showHideIconInfoAlert = true
-                                hasSeenMenuBarHideInfo = true
-                            }
-                        }
-
-                    Text("If the icon is hidden, use the Settings shortcut or relaunch the app to reopen Settings.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .fixedSize(horizontal: false, vertical: true)
-                }
-
-                Section("Actions") {
-                    HStack {
-                        Button("Show Dashboard", systemImage: "rectangle.inset.filled") {
-                            context.showDashboard()
-                        }
-
-                        Button("Open Widget Launcher", systemImage: "square.grid.2x2") {
-                            context.showWidgetLauncher()
-                        }
-
-                        Button("Reload Dashboard", systemImage: "arrow.clockwise") {
-                            context.reloadDashboard()
-                        }
-                    }
-
-                    Text("Keep the native companion ready from the menu bar, then show the dashboard only when class needs it.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .fixedSize(horizontal: false, vertical: true)
-                }
-
-                Section("Dashboard Layer") {
-                    Toggle("Show on all Spaces", isOn: $keepOnAllSpaces)
-
-                    Toggle("Float above other windows", isOn: $floatingOverlay)
-
-                    Toggle("Click through empty dashboard areas", isOn: $clickThroughEmptyAreas)
-                }
-            }
-            .formStyle(.grouped)
-            .tabItem {
-                Label("General", systemImage: "switch.2")
+                Toggle("Show dashboard at launch", isOn: $showDashboardAtLaunch)
             }
 
-            Form {
-                Section("Keyboard Shortcuts") {
-                    shortcutRow("Show or hide dashboard") {
-                        KeyboardShortcutRecorder(
-                            keyCode: $toggleShortcutKeyCode,
-                            modifiers: $toggleShortcutModifiers,
-                            placeholder: "None"
-                        )
+            Section("Menu Bar") {
+                Toggle("Show menu bar icon", isOn: $showMenuBarIcon)
+                    .onChange(of: showMenuBarIcon) { newValue in
+                        context.menuBarIconChanged()
+
+                        if !newValue && !hasSeenMenuBarHideInfo {
+                            showHideIconInfoAlert = true
+                            hasSeenMenuBarHideInfo = true
+                        }
                     }
 
-                    shortcutRow("Open widget launcher") {
-                        KeyboardShortcutRecorder(
-                            keyCode: $launcherShortcutKeyCode,
-                            modifiers: $launcherShortcutModifiers,
-                            placeholder: "None"
-                        )
-                    }
-
-                    shortcutRow("Open Settings") {
-                        KeyboardShortcutRecorder(
-                            keyCode: $settingsShortcutKeyCode,
-                            modifiers: $settingsShortcutModifiers,
-                            placeholder: "None"
-                        )
-                    }
-
-                    Text("These shortcuts work across macOS while Classroom Widgets Dashboard is running. Keep each action on a distinct shortcut.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .fixedSize(horizontal: false, vertical: true)
-
-                    if let shortcutConflictMessage {
-                        Label(shortcutConflictMessage, systemImage: "exclamationmark.triangle")
-                            .font(.caption)
-                            .foregroundStyle(.orange)
-                            .fixedSize(horizontal: false, vertical: true)
-                    }
-                }
-
-                Section {
-                    Button("Restore Default Shortcuts") {
-                        toggleShortcutKeyCode = DashboardDefaults.toggleShortcutKeyCode
-                        toggleShortcutModifiers = DashboardDefaults.shortcutModifiers
-                        launcherShortcutKeyCode = DashboardDefaults.launcherShortcutKeyCode
-                        launcherShortcutModifiers = DashboardDefaults.shortcutModifiers
-                        settingsShortcutKeyCode = DashboardDefaults.settingsShortcutKeyCode
-                        settingsShortcutModifiers = DashboardDefaults.shortcutModifiers
-                    }
-                }
+                Text("If the icon is hidden, use the Settings shortcut or relaunch the app to reopen Settings.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
             }
-            .formStyle(.grouped)
-            .tabItem {
-                Label("Shortcuts", systemImage: "keyboard")
+
+            Section("Actions") {
+                HStack {
+                    Button("Show Dashboard", systemImage: "rectangle.inset.filled") {
+                        context.showDashboard()
+                    }
+
+                    Button("Open Widget Launcher", systemImage: "square.grid.2x2") {
+                        context.showWidgetLauncher()
+                    }
+
+                    Button("Reload Dashboard", systemImage: "arrow.clockwise") {
+                        context.reloadDashboard()
+                    }
+                }
+
+                Text("Keep the native companion ready from the menu bar, then show the dashboard only when class needs it.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Section("Dashboard Layer") {
+                Toggle("Show on all Spaces", isOn: $keepOnAllSpaces)
+
+                Toggle("Float above other windows", isOn: $floatingOverlay)
+
+                Toggle("Click through empty dashboard areas", isOn: $clickThroughEmptyAreas)
             }
         }
-        .frame(width: 540, height: 430)
-        .padding(20)
+        .formStyle(.grouped)
+        .frame(width: 560, height: 500)
         .task {
             syncLaunchAtLoginState()
         }
         .onChange(of: windowBehaviorSignature) { _ in context.windowBehaviorChanged() }
-        .onChange(of: shortcutsSignature) { _ in context.shortcutsChanged() }
         .alert("Launch at login", isPresented: launchAtLoginAlertIsPresented) {
             Button("OK", role: .cancel) {
                 launchAtLoginAlertMessage = nil
@@ -265,41 +197,6 @@ struct DashboardSettingsView: View {
         } message: {
             Text("Use the Settings shortcut or relaunch Classroom Widgets Dashboard to reopen Settings.")
         }
-    }
-
-    @ViewBuilder
-    private func shortcutRow<Content: View>(_ title: String, @ViewBuilder content: () -> Content) -> some View {
-        LabeledContent {
-            content()
-                .frame(width: 210, alignment: .trailing)
-        } label: {
-            Text(title)
-        }
-    }
-
-    private var shortcutConflictMessage: String? {
-        let shortcuts: [(label: String, keyCode: Int, modifiers: Int)] = [
-            ("Show or hide dashboard", toggleShortcutKeyCode, toggleShortcutModifiers),
-            ("Open widget launcher", launcherShortcutKeyCode, launcherShortcutModifiers),
-            ("Open Settings", settingsShortcutKeyCode, settingsShortcutModifiers)
-        ]
-
-        for index in shortcuts.indices {
-            let current = shortcuts[index]
-            guard current.keyCode != -1 else { continue }
-            guard index + 1 < shortcuts.count else { continue }
-
-            for comparisonIndex in (index + 1)..<shortcuts.count {
-                let comparison = shortcuts[comparisonIndex]
-                guard comparison.keyCode != -1 else { continue }
-
-                if current.keyCode == comparison.keyCode && current.modifiers == comparison.modifiers {
-                    return "\(current.label) and \(comparison.label) should not share the same shortcut."
-                }
-            }
-        }
-
-        return nil
     }
 
     private func syncLaunchAtLoginState() {
@@ -346,6 +243,108 @@ struct DashboardSettingsView: View {
             floatingOverlay
         ].map(String.init).joined(separator: ":")
     }
+}
+
+struct DashboardShortcutSettingsView: View {
+    @AppStorage(DashboardSettingKeys.toggleShortcutKeyCode) private var toggleShortcutKeyCode = DashboardDefaults.toggleShortcutKeyCode
+    @AppStorage(DashboardSettingKeys.toggleShortcutModifiers) private var toggleShortcutModifiers = DashboardDefaults.shortcutModifiers
+    @AppStorage(DashboardSettingKeys.launcherShortcutKeyCode) private var launcherShortcutKeyCode = DashboardDefaults.launcherShortcutKeyCode
+    @AppStorage(DashboardSettingKeys.launcherShortcutModifiers) private var launcherShortcutModifiers = DashboardDefaults.shortcutModifiers
+    @AppStorage(DashboardSettingKeys.settingsShortcutKeyCode) private var settingsShortcutKeyCode = DashboardDefaults.settingsShortcutKeyCode
+    @AppStorage(DashboardSettingKeys.settingsShortcutModifiers) private var settingsShortcutModifiers = DashboardDefaults.shortcutModifiers
+
+    let context: DashboardSettingsContext
+
+    var body: some View {
+        Form {
+            Section("Keyboard Shortcuts") {
+                shortcutRow("Show or hide dashboard") {
+                    KeyboardShortcutRecorder(
+                        keyCode: $toggleShortcutKeyCode,
+                        modifiers: $toggleShortcutModifiers,
+                        placeholder: "None"
+                    )
+                }
+
+                shortcutRow("Open widget launcher") {
+                    KeyboardShortcutRecorder(
+                        keyCode: $launcherShortcutKeyCode,
+                        modifiers: $launcherShortcutModifiers,
+                        placeholder: "None"
+                    )
+                }
+
+                shortcutRow("Open Settings") {
+                    KeyboardShortcutRecorder(
+                        keyCode: $settingsShortcutKeyCode,
+                        modifiers: $settingsShortcutModifiers,
+                        placeholder: "None"
+                    )
+                }
+
+                Text("These shortcuts work across macOS while Classroom Widgets Dashboard is running. Keep each action on a distinct shortcut.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                if let shortcutConflictMessage {
+                    Label(shortcutConflictMessage, systemImage: "exclamationmark.triangle")
+                        .font(.caption)
+                        .foregroundStyle(.orange)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+
+            Section {
+                Button("Restore Default Shortcuts") {
+                    toggleShortcutKeyCode = DashboardDefaults.toggleShortcutKeyCode
+                    toggleShortcutModifiers = DashboardDefaults.shortcutModifiers
+                    launcherShortcutKeyCode = DashboardDefaults.launcherShortcutKeyCode
+                    launcherShortcutModifiers = DashboardDefaults.shortcutModifiers
+                    settingsShortcutKeyCode = DashboardDefaults.settingsShortcutKeyCode
+                    settingsShortcutModifiers = DashboardDefaults.shortcutModifiers
+                }
+            }
+        }
+        .formStyle(.grouped)
+        .frame(width: 560, height: 380)
+        .onChange(of: shortcutsSignature) { _ in context.shortcutsChanged() }
+    }
+
+    @ViewBuilder
+    private func shortcutRow<Content: View>(_ title: String, @ViewBuilder content: () -> Content) -> some View {
+        LabeledContent {
+            content()
+                .frame(width: 210, alignment: .trailing)
+        } label: {
+            Text(title)
+        }
+    }
+
+    private var shortcutConflictMessage: String? {
+        let shortcuts: [(label: String, keyCode: Int, modifiers: Int)] = [
+            ("Show or hide dashboard", toggleShortcutKeyCode, toggleShortcutModifiers),
+            ("Open widget launcher", launcherShortcutKeyCode, launcherShortcutModifiers),
+            ("Open Settings", settingsShortcutKeyCode, settingsShortcutModifiers)
+        ]
+
+        for index in shortcuts.indices {
+            let current = shortcuts[index]
+            guard current.keyCode != -1 else { continue }
+            guard index + 1 < shortcuts.count else { continue }
+
+            for comparisonIndex in (index + 1)..<shortcuts.count {
+                let comparison = shortcuts[comparisonIndex]
+                guard comparison.keyCode != -1 else { continue }
+
+                if current.keyCode == comparison.keyCode && current.modifiers == comparison.modifiers {
+                    return "\(current.label) and \(comparison.label) should not share the same shortcut."
+                }
+            }
+        }
+
+        return nil
+    }
 
     private var shortcutsSignature: String {
         [
@@ -359,15 +358,25 @@ struct DashboardSettingsView: View {
     }
 }
 
+// Preference-style tab view controller that keeps the window title in sync
+// with the selected pane, matching System Settings behaviour.
+final class SettingsTabViewController: NSTabViewController {
+    override func tabView(_ tabView: NSTabView, didSelect tabViewItem: NSTabViewItem?) {
+        super.tabView(tabView, didSelect: tabViewItem)
+
+        if let label = tabViewItem?.label, !label.isEmpty {
+            view.window?.title = label
+        }
+    }
+}
+
 @MainActor
 final class SettingsWindowCoordinator: NSObject, NSWindowDelegate {
-    private static let defaultWindowSize = NSSize(width: 580, height: 470)
-
-    private let makeContentView: @MainActor () -> NSView
+    private let makeContext: @MainActor () -> DashboardSettingsContext?
     private(set) var window: NSWindow?
 
-    init(makeContentView: @escaping @MainActor () -> NSView) {
-        self.makeContentView = makeContentView
+    init(makeContext: @escaping @MainActor () -> DashboardSettingsContext?) {
+        self.makeContext = makeContext
         super.init()
     }
 
@@ -378,16 +387,31 @@ final class SettingsWindowCoordinator: NSObject, NSWindowDelegate {
             return
         }
 
-        let window = NSWindow(
-            contentRect: NSRect(origin: .zero, size: Self.defaultWindowSize),
-            styleMask: [.titled, .closable],
-            backing: .buffered,
-            defer: false
+        guard let context = makeContext() else { return }
+
+        let tabViewController = SettingsTabViewController()
+        tabViewController.tabStyle = .toolbar
+
+        let generalItem = NSTabViewItem(
+            viewController: NSHostingController(rootView: DashboardGeneralSettingsView(context: context))
         )
-        window.title = "Classroom Widgets Settings"
+        generalItem.label = "General"
+        generalItem.image = NSImage(systemSymbolName: "switch.2", accessibilityDescription: "General")
+        tabViewController.addTabViewItem(generalItem)
+
+        let shortcutsItem = NSTabViewItem(
+            viewController: NSHostingController(rootView: DashboardShortcutSettingsView(context: context))
+        )
+        shortcutsItem.label = "Shortcuts"
+        shortcutsItem.image = NSImage(systemSymbolName: "keyboard", accessibilityDescription: "Shortcuts")
+        tabViewController.addTabViewItem(shortcutsItem)
+
+        let window = NSWindow(contentViewController: tabViewController)
+        window.styleMask = [.titled, .closable]
+        window.toolbarStyle = .preference
+        window.title = generalItem.label
         window.isReleasedWhenClosed = false
         window.delegate = self
-        window.contentView = makeContentView()
         window.center()
         window.makeKeyAndOrderFront(nil)
         NSApp.activate(ignoringOtherApps: true)

--- a/packages/macos-dashboard/Sources/ClassroomWidgetsDashboard/DashboardSettings.swift
+++ b/packages/macos-dashboard/Sources/ClassroomWidgetsDashboard/DashboardSettings.swift
@@ -181,7 +181,6 @@ struct DashboardGeneralSettingsView: View {
             }
         }
         .formStyle(.grouped)
-        .frame(width: 560, height: 500)
         .task {
             syncLaunchAtLoginState()
         }
@@ -314,7 +313,6 @@ struct DashboardShortcutSettingsView: View {
             }
         }
         .formStyle(.grouped)
-        .frame(width: 560, height: 380)
         .onChange(of: shortcutsSignature) { _ in context.shortcutsChanged() }
     }
 
@@ -365,25 +363,45 @@ struct DashboardShortcutSettingsView: View {
     }
 }
 
-// Preference-style tab view controller that keeps the window title in sync
-// with the selected pane, matching System Settings behaviour.
-final class SettingsTabViewController: NSTabViewController {
-    override func tabView(_ tabView: NSTabView, didSelect tabViewItem: NSTabViewItem?) {
-        super.tabView(tabView, didSelect: tabViewItem)
+struct DashboardSettingsView: View {
+    let context: DashboardSettingsContext
 
-        if let label = tabViewItem?.label, !label.isEmpty {
-            view.window?.title = label
+    var body: some View {
+        TabView {
+            DashboardGeneralSettingsView(context: context)
+                .tabItem { Text("General") }
+
+            DashboardShortcutSettingsView(context: context)
+                .tabItem { Text("Shortcuts") }
+        }
+        .dashboardTabBarStyle()
+        .frame(width: 600, height: 640)
+        .navigationTitle("Classroom Widgets Settings")
+    }
+}
+
+private extension View {
+    // .tabBarOnly is macOS 15+, but the app deploys to 13; the default tab
+    // style renders as a top tab bar on older systems anyway.
+    @ViewBuilder
+    func dashboardTabBarStyle() -> some View {
+        if #available(macOS 15.0, *) {
+            tabViewStyle(.tabBarOnly)
+        } else {
+            self
         }
     }
 }
 
 @MainActor
 final class SettingsWindowCoordinator: NSObject, NSWindowDelegate {
-    private let makeContext: @MainActor () -> DashboardSettingsContext?
+    private static let windowSize = NSSize(width: 600, height: 640)
+
+    private let makeContentView: @MainActor () -> NSView
     private(set) var window: NSWindow?
 
-    init(makeContext: @escaping @MainActor () -> DashboardSettingsContext?) {
-        self.makeContext = makeContext
+    init(makeContentView: @escaping @MainActor () -> NSView) {
+        self.makeContentView = makeContentView
         super.init()
     }
 
@@ -394,31 +412,16 @@ final class SettingsWindowCoordinator: NSObject, NSWindowDelegate {
             return
         }
 
-        guard let context = makeContext() else { return }
-
-        let tabViewController = SettingsTabViewController()
-        tabViewController.tabStyle = .toolbar
-
-        let generalItem = NSTabViewItem(
-            viewController: NSHostingController(rootView: DashboardGeneralSettingsView(context: context))
+        let window = NSWindow(
+            contentRect: NSRect(origin: .zero, size: Self.windowSize),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
         )
-        generalItem.label = "General"
-        generalItem.image = NSImage(systemSymbolName: "switch.2", accessibilityDescription: "General")
-        tabViewController.addTabViewItem(generalItem)
-
-        let shortcutsItem = NSTabViewItem(
-            viewController: NSHostingController(rootView: DashboardShortcutSettingsView(context: context))
-        )
-        shortcutsItem.label = "Shortcuts"
-        shortcutsItem.image = NSImage(systemSymbolName: "keyboard", accessibilityDescription: "Shortcuts")
-        tabViewController.addTabViewItem(shortcutsItem)
-
-        let window = NSWindow(contentViewController: tabViewController)
-        window.styleMask = [.titled, .closable]
-        window.toolbarStyle = .preference
-        window.title = generalItem.label
+        window.title = "Classroom Widgets Settings"
         window.isReleasedWhenClosed = false
         window.delegate = self
+        window.contentView = makeContentView()
         window.center()
         window.makeKeyAndOrderFront(nil)
         NSApp.activate(ignoringOtherApps: true)

--- a/packages/macos-dashboard/Sources/ClassroomWidgetsDashboard/DashboardSettings.swift
+++ b/packages/macos-dashboard/Sources/ClassroomWidgetsDashboard/DashboardSettings.swift
@@ -1,5 +1,6 @@
 import AppKit
 import Carbon
+import Combine
 import SwiftUI
 
 enum DashboardSettingKeys {
@@ -182,6 +183,12 @@ struct DashboardGeneralSettingsView: View {
         .formStyle(.grouped)
         .frame(width: 560, height: 500)
         .task {
+            syncLaunchAtLoginState()
+        }
+        // The Settings window is reused (orderOut, not closed), so .task runs
+        // only once. Re-read the login-item state whenever the window comes
+        // back to the front, in case it changed via the menu or System Settings.
+        .onReceive(NotificationCenter.default.publisher(for: NSWindow.didBecomeKeyNotification)) { _ in
             syncLaunchAtLoginState()
         }
         .onChange(of: windowBehaviorSignature) { _ in context.windowBehaviorChanged() }

--- a/packages/macos-dashboard/Sources/ClassroomWidgetsDashboard/DashboardWindowController.swift
+++ b/packages/macos-dashboard/Sources/ClassroomWidgetsDashboard/DashboardWindowController.swift
@@ -415,6 +415,11 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
         let target: CGFloat = visible ? 1 : 0
         guard backdropContainer.alphaValue != target else { return }
 
+        if NSWorkspace.shared.accessibilityDisplayShouldReduceMotion {
+            backdropContainer.alphaValue = target
+            return
+        }
+
         NSAnimationContext.runAnimationGroup { context in
             context.duration = visible ? 0.45 : 0.18
             context.timingFunction = CAMediaTimingFunction(name: .easeOut)

--- a/packages/macos-dashboard/Sources/ClassroomWidgetsDashboard/DashboardWindowController.swift
+++ b/packages/macos-dashboard/Sources/ClassroomWidgetsDashboard/DashboardWindowController.swift
@@ -5,6 +5,9 @@ import WebKit
 final class DashboardWindowController: NSWindowController, WKNavigationDelegate {
     private let webView: WKWebView
     private let scriptMessageHandler: DashboardScriptMessageHandler
+    private let backdropContainer = NSView()
+    private var glassBackdropViews: [NSVisualEffectView] = []
+    private var glassRegions: [DashboardGlassRegion] = []
     private var dashboardVisible: Bool
     private var interactiveRegions: [CGRect] = []
     private var localMouseMonitor: Any?
@@ -44,7 +47,19 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate 
         window.hasShadow = false
         window.level = .floating
         window.ignoresMouseEvents = !dashboardVisible
-        window.contentView = webView
+
+        // The backdrop layer sits behind the (transparent) web view and hosts
+        // NSVisualEffectViews aligned with the web layer's glass surfaces, so
+        // widgets get a real desktop blur that CSS backdrop-filter cannot do.
+        let contentView = NSView()
+        window.contentView = contentView
+        backdropContainer.frame = contentView.bounds
+        backdropContainer.autoresizingMask = [.width, .height]
+        backdropContainer.alphaValue = dashboardVisible ? 1 : 0
+        contentView.addSubview(backdropContainer)
+        webView.frame = contentView.bounds
+        webView.autoresizingMask = [.width, .height]
+        contentView.addSubview(webView)
 
         super.init(window: window)
         webView.navigationDelegate = self
@@ -61,6 +76,11 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate 
             guard let self else { return }
             self.interactiveRegions = regions
             self.updateMousePassthrough()
+        }
+        scriptMessageHandler.onGlassRegionsChanged = { [weak self] regions in
+            guard let self else { return }
+            self.glassRegions = regions
+            self.updateGlassBackdrops()
         }
         webView.configuration.userContentController.add(scriptMessageHandler, name: "classroomDashboard")
         loadDashboard()
@@ -151,11 +171,13 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate 
 
         guard dashboardVisible else {
             window.ignoresMouseEvents = true
+            setBackdropsVisible(false)
             scheduleOrderOut(window)
             return
         }
 
         hideGeneration += 1
+        setBackdropsVisible(true)
         if !window.isVisible {
             window.makeKeyAndOrderFront(nil)
         }
@@ -234,6 +256,70 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate 
         let pointInWindow = window.convertPoint(fromScreen: screenPoint)
         let webPoint = CGPoint(x: pointInWindow.x, y: webView.bounds.height - pointInWindow.y)
         window.ignoresMouseEvents = !interactiveRegions.contains { $0.contains(webPoint) }
+    }
+
+    private func updateGlassBackdrops() {
+        while glassBackdropViews.count < glassRegions.count {
+            let view = NSVisualEffectView()
+            view.blendingMode = .behindWindow
+            view.material = .popover
+            view.state = .active
+            backdropContainer.addSubview(view)
+            glassBackdropViews.append(view)
+        }
+
+        while glassBackdropViews.count > glassRegions.count {
+            glassBackdropViews.removeLast().removeFromSuperview()
+        }
+
+        // Web rects are top-left origin; AppKit views are bottom-left.
+        let containerHeight = backdropContainer.bounds.height
+        for (view, region) in zip(glassBackdropViews, glassRegions) {
+            view.frame = CGRect(
+                x: region.rect.minX,
+                y: containerHeight - region.rect.minY - region.rect.height,
+                width: region.rect.width,
+                height: region.rect.height
+            )
+            // maskImage (not layer.cornerRadius) is what clips the
+            // behind-window blur region, per NSVisualEffectView docs.
+            view.maskImage = maskImage(cornerRadius: region.radius)
+        }
+    }
+
+    private var maskImageCache: [CGFloat: NSImage] = [:]
+
+    private func maskImage(cornerRadius radius: CGFloat) -> NSImage? {
+        guard radius > 0 else { return nil }
+
+        if let cached = maskImageCache[radius] {
+            return cached
+        }
+
+        let edge = radius * 2 + 1
+        let image = NSImage(size: NSSize(width: edge, height: edge), flipped: false) { rect in
+            NSColor.black.setFill()
+            NSBezierPath(roundedRect: rect, xRadius: radius, yRadius: radius).fill()
+            return true
+        }
+        image.capInsets = NSEdgeInsets(top: radius, left: radius, bottom: radius, right: radius)
+        image.resizingMode = .stretch
+        maskImageCache[radius] = image
+        return image
+    }
+
+    // Fading the backdrops (slow in, fast out) hides that they sit at the
+    // widgets' final positions while the web layer plays its entrance and
+    // exit animations.
+    private func setBackdropsVisible(_ visible: Bool) {
+        let target: CGFloat = visible ? 1 : 0
+        guard backdropContainer.alphaValue != target else { return }
+
+        NSAnimationContext.runAnimationGroup { context in
+            context.duration = visible ? 0.45 : 0.18
+            context.timingFunction = CAMediaTimingFunction(name: .easeOut)
+            backdropContainer.animator().alphaValue = target
+        }
     }
 
     private func loadDashboard() {

--- a/packages/macos-dashboard/Sources/ClassroomWidgetsDashboard/DashboardWindowController.swift
+++ b/packages/macos-dashboard/Sources/ClassroomWidgetsDashboard/DashboardWindowController.swift
@@ -2,7 +2,7 @@ import AppKit
 import WebKit
 
 @MainActor
-final class DashboardWindowController: NSWindowController, WKNavigationDelegate {
+final class DashboardWindowController: NSWindowController, WKNavigationDelegate, WKUIDelegate {
     private let webView: WKWebView
     private let scriptMessageHandler: DashboardScriptMessageHandler
     private let backdropContainer = NSView()
@@ -15,6 +15,7 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate 
     private var pendingWidgetLauncherOpen = false
     private var widgetLauncherOpenAttemptInFlight = false
     private var hideGeneration = 0
+    private var visibilityPushGeneration = 0
     var isDashboardVisible: Bool { dashboardVisible }
     var onVisibilityChanged: (@MainActor (Bool) -> Void)?
 
@@ -55,7 +56,11 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate 
         window.contentView = contentView
         backdropContainer.frame = contentView.bounds
         backdropContainer.autoresizingMask = [.width, .height]
+        // Layer-backed so alphaValue is a well-defined layer opacity animation
+        // for the hosted NSVisualEffectViews.
+        backdropContainer.wantsLayer = true
         backdropContainer.alphaValue = dashboardVisible ? 1 : 0
+        backdropContainer.postsFrameChangedNotifications = true
         contentView.addSubview(backdropContainer)
         webView.frame = contentView.bounds
         webView.autoresizingMask = [.width, .height]
@@ -63,8 +68,26 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate 
 
         super.init(window: window)
         webView.navigationDelegate = self
+        webView.uiDelegate = self
         applySettings()
         installMouseMonitors()
+
+        // Backdrops are positioned from a snapshot of the container height at
+        // message time, so re-place them whenever the window (and thus the
+        // container) resizes, and re-fit the window when the display layout
+        // changes underneath it.
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(backdropContainerFrameDidChange),
+            name: NSView.frameDidChangeNotification,
+            object: backdropContainer
+        )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(screenParametersDidChange),
+            name: NSApplication.didChangeScreenParametersNotification,
+            object: nil
+        )
 
         scriptMessageHandler.onVisibilityChanged = { [weak self] visible in
             guard let self else { return }
@@ -98,6 +121,7 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate 
             if let globalMouseMonitor {
                 NSEvent.removeMonitor(globalMouseMonitor)
             }
+            NotificationCenter.default.removeObserver(self)
             webView.configuration.userContentController.removeScriptMessageHandler(forName: "classroomDashboard")
         }
     }
@@ -108,6 +132,67 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate 
         if pendingWidgetLauncherOpen && !widgetLauncherOpenAttemptInFlight {
             openWidgetLauncher()
         }
+    }
+
+    // The dashboard must never navigate away from the bundled app. Allow only
+    // our custom scheme; hand any other URL (including student-submitted links
+    // rendered inside widgets) to the user's browser. Without this a single
+    // link click would replace the chromeless full-screen overlay with
+    // arbitrary web content that still has access to the native bridge.
+    func webView(
+        _ webView: WKWebView,
+        decidePolicyFor navigationAction: WKNavigationAction,
+        decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
+    ) {
+        guard let url = navigationAction.request.url else {
+            decisionHandler(.allow)
+            return
+        }
+
+        // Our bundle (custom scheme) plus about:blank, which WebKit may use
+        // internally during setup. Everything else is foreign content.
+        if url.scheme == dashboardURLScheme || url.scheme == "about" {
+            decisionHandler(.allow)
+            return
+        }
+
+        decisionHandler(.cancel)
+        if navigationAction.navigationType == .linkActivated {
+            NSWorkspace.shared.open(url)
+        }
+    }
+
+    // target="_blank" / window.open links: open externally instead of spawning
+    // a chromeless child web view.
+    func webView(
+        _ webView: WKWebView,
+        createWebViewWith configuration: WKWebViewConfiguration,
+        for navigationAction: WKNavigationAction,
+        windowFeatures: WKWindowFeatures
+    ) -> WKWebView? {
+        if let url = navigationAction.request.url, url.scheme != dashboardURLScheme {
+            NSWorkspace.shared.open(url)
+        }
+        return nil
+    }
+
+    func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
+        // The old page's regions don't apply to whatever is loading; drop them
+        // so stale blur slabs and click-through holes don't linger.
+        clearWebDrivenState()
+    }
+
+    func webViewWebContentProcessDidTerminate(_ webView: WKWebView) {
+        DashboardLog.web.error("Web content process terminated; reloading dashboard")
+        clearWebDrivenState()
+        loadDashboard()
+    }
+
+    private func clearWebDrivenState() {
+        interactiveRegions = []
+        glassRegions = []
+        updateGlassBackdrops()
+        updateMousePassthrough()
     }
 
     func showDashboard() {
@@ -148,7 +233,11 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate 
         DashboardLog.web.info("Reloading bundled dashboard")
         pendingWidgetLauncherOpen = false
         widgetLauncherOpenAttemptInFlight = false
-        webView.reloadFromOrigin()
+        clearWebDrivenState()
+        // Rebuild the URL from current state rather than reloadFromOrigin(),
+        // which would reload the stale launch-time ?visible= value (and, after
+        // an external navigation slipped through, the wrong page entirely).
+        loadDashboard()
     }
 
     func applySettings() {
@@ -172,6 +261,15 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate 
         guard dashboardVisible else {
             window.ignoresMouseEvents = true
             setBackdropsVisible(false)
+            // The window lingers ~350ms for the exit animation. While it does,
+            // it must not keep eating keystrokes into the invisible web view
+            // (e.g. Cmd+V would hit the app's global paste handler and silently
+            // spawn a widget). Yield activation back to the app underneath —
+            // guarded on the dashboard being the key window so changing a
+            // setting from the Settings window doesn't deactivate the app.
+            if window.isKeyWindow {
+                NSApp.deactivate()
+            }
             scheduleOrderOut(window)
             return
         }
@@ -282,8 +380,10 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate 
                 height: region.rect.height
             )
             // maskImage (not layer.cornerRadius) is what clips the
-            // behind-window blur region, per NSVisualEffectView docs.
-            view.maskImage = maskImage(cornerRadius: region.radius)
+            // behind-window blur region, per NSVisualEffectView docs. Clamp the
+            // radius so a small region can't produce a distorted mask.
+            let clampedRadius = min(region.radius, region.rect.width / 2, region.rect.height / 2).rounded()
+            view.maskImage = maskImage(cornerRadius: clampedRadius)
         }
     }
 
@@ -336,7 +436,18 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate 
         webView.load(URLRequest(url: url))
     }
 
-    private func setWebDashboardVisible(_ visible: Bool, retriesRemaining: Int = 3) {
+    private func setWebDashboardVisible(_ visible: Bool) {
+        // Each push starts a new generation; any in-flight retry chain from an
+        // earlier (now superseded) push is abandoned. Without this, two rapid
+        // toggles during page load race independent retry timers and a stale
+        // value can land last, leaving the web layer disagreeing with native.
+        visibilityPushGeneration += 1
+        pushWebDashboardVisible(visible, generation: visibilityPushGeneration, retriesRemaining: 3)
+    }
+
+    private func pushWebDashboardVisible(_ visible: Bool, generation: Int, retriesRemaining: Int) {
+        guard generation == visibilityPushGeneration else { return }
+
         let expression = """
         (() => {
           if (window.classroomDashboard?.setVisible) {
@@ -347,16 +458,28 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate 
         })()
         """
         webView.evaluateJavaScript(expression) { [weak self] result, _ in
+            guard let self else { return }
             guard
+                self.visibilityPushGeneration == generation,
                 result as? Bool != true,
                 retriesRemaining > 0
             else { return }
 
             Task { @MainActor in
                 try? await Task.sleep(nanoseconds: 150_000_000)
-                self?.setWebDashboardVisible(visible, retriesRemaining: retriesRemaining - 1)
+                self.pushWebDashboardVisible(visible, generation: generation, retriesRemaining: retriesRemaining - 1)
             }
         }
+    }
+
+    @objc private func backdropContainerFrameDidChange() {
+        updateGlassBackdrops()
+    }
+
+    @objc private func screenParametersDidChange() {
+        guard dashboardVisible, let window else { return }
+        window.setFrame(Self.combinedVisibleFrame(), display: true)
+        updateGlassBackdrops()
     }
 
     private func openWidgetLauncher(retriesRemaining: Int = 5) {
@@ -397,9 +520,18 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate 
     }
 
     private static func combinedVisibleFrame() -> NSRect {
-        NSScreen.screens.reduce(NSRect.null) { partial, screen in
+        let union = NSScreen.screens.reduce(NSRect.null) { partial, screen in
             partial.union(screen.visibleFrame)
         }
+
+        // NSScreen.screens can be transiently empty during display
+        // reconfiguration; feeding NSRect.null (origin +inf) to a window frame
+        // is undefined, so fall back to the main screen.
+        guard !union.isNull, !union.isEmpty else {
+            return NSScreen.main?.visibleFrame ?? NSRect(x: 0, y: 0, width: 1440, height: 900)
+        }
+
+        return union
     }
 }
 

--- a/packages/macos-dashboard/Sources/ClassroomWidgetsDashboard/DashboardWindowController.swift
+++ b/packages/macos-dashboard/Sources/ClassroomWidgetsDashboard/DashboardWindowController.swift
@@ -11,6 +11,7 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate 
     private var globalMouseMonitor: Any?
     private var pendingWidgetLauncherOpen = false
     private var widgetLauncherOpenAttemptInFlight = false
+    private var hideGeneration = 0
     var isDashboardVisible: Bool { dashboardVisible }
     var onVisibilityChanged: (@MainActor (Bool) -> Void)?
 
@@ -150,10 +151,11 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate 
 
         guard dashboardVisible else {
             window.ignoresMouseEvents = true
-            window.orderOut(nil)
+            scheduleOrderOut(window)
             return
         }
 
+        hideGeneration += 1
         if !window.isVisible {
             window.makeKeyAndOrderFront(nil)
         }
@@ -162,6 +164,24 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate 
 
         if activateApp {
             NSApp.activate(ignoringOtherApps: true)
+        }
+    }
+
+    // Keep the window on screen briefly while the web layer plays its exit
+    // animation; mouse events are already disabled so the overlay is inert.
+    private func scheduleOrderOut(_ window: NSWindow) {
+        guard window.isVisible else {
+            window.orderOut(nil)
+            return
+        }
+
+        hideGeneration += 1
+        let generation = hideGeneration
+
+        Task { @MainActor [weak self] in
+            try? await Task.sleep(nanoseconds: 350_000_000)
+            guard let self, self.hideGeneration == generation, !self.dashboardVisible else { return }
+            self.window?.orderOut(nil)
         }
     }
 

--- a/packages/teacher/src/app/App.css
+++ b/packages/teacher/src/app/App.css
@@ -221,6 +221,21 @@ html.desktop-dashboard-mode .widget-wrapper > .widget-surface[data-dashboard-gla
   -webkit-backdrop-filter: blur(18px) saturate(1.35);
 }
 
+/* The native app draws an NSVisualEffectView behind each glass surface, so
+   thin out the standard card backgrounds to let the desktop blur through.
+   The dark rule is more specific, so it wins when both classes are present. */
+html.desktop-dashboard-mode
+  .widget-surface[data-dashboard-glass='true']
+  :is(.bg-soft-white, .bg-soft-white\/90, .bg-soft-white\/95) {
+  background-color: rgba(253, 252, 251, 0.6) !important;
+}
+
+html.dark.desktop-dashboard-mode
+  .widget-surface[data-dashboard-glass='true']
+  :is(.dark\:bg-warm-gray-800, .dark\:bg-warm-gray-800\/90) {
+  background-color: rgba(61, 56, 53, 0.55) !important;
+}
+
 @keyframes desktop-widget-depth-in {
   0% {
     opacity: 0;

--- a/packages/teacher/src/app/App.css
+++ b/packages/teacher/src/app/App.css
@@ -139,9 +139,16 @@ html.desktop-dashboard-mode .board-scale-wrapper {
 
 html.desktop-dashboard-mode .widget-wrapper {
   filter: drop-shadow(0 24px 42px rgba(0, 0, 0, 0.22));
+  transition: opacity 260ms ease;
 }
 
 html.desktop-dashboard-mode .widget-wrapper > .widget-surface {
+  transition: transform 300ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+/* Scoped to the visible state so the entrance replays on every show and the
+   animation fill stops overriding the hidden-state transform below. */
+html.desktop-dashboard-visible .widget-wrapper > .widget-surface {
   animation: desktop-widget-depth-in 360ms cubic-bezier(0.16, 1, 0.3, 1) both;
 }
 
@@ -227,6 +234,47 @@ html.desktop-dashboard-mode .widget-wrapper > .widget-surface[data-dashboard-gla
     opacity: 1;
     transform: translateY(0) scale(1) rotateX(0deg);
   }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html.desktop-dashboard-mode .widget-wrapper,
+  html.desktop-dashboard-mode .widget-wrapper > .widget-surface,
+  html.desktop-dashboard-visible .widget-wrapper > .widget-surface,
+  html.desktop-dashboard-mode .toolbar-container {
+    animation: none;
+    transition: none;
+  }
+
+  html.desktop-dashboard-hidden .widget-wrapper > .widget-surface,
+  html.desktop-dashboard-hidden [role="dialog"] {
+    transform: none;
+  }
+}
+
+/* Native macOS apps use the system font, the arrow cursor over UI chrome, and
+   don't let labels be text-selected or images dragged. Scoped to the desktop
+   dashboard so the browser app keeps its own look. Tailwind's select-* utilities
+   still win over the inherited value where selection is wanted. */
+html.desktop-dashboard-mode body,
+html.desktop-dashboard-mode .font-sans {
+  font-family: -apple-system, BlinkMacSystemFont, system-ui, 'Helvetica Neue', sans-serif;
+}
+
+html.desktop-dashboard-mode body {
+  cursor: default;
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+html.desktop-dashboard-mode input,
+html.desktop-dashboard-mode textarea,
+html.desktop-dashboard-mode [contenteditable='true'] {
+  -webkit-user-select: text;
+  user-select: text;
+}
+
+html.desktop-dashboard-mode img {
+  -webkit-user-drag: none;
 }
 
 /* Toolbar content wrapper also needs to pass through clicks in padding areas */

--- a/packages/teacher/src/app/App.css
+++ b/packages/teacher/src/app/App.css
@@ -272,7 +272,7 @@ html.dark.desktop-dashboard-mode
    still win over the inherited value where selection is wanted. */
 html.desktop-dashboard-mode body,
 html.desktop-dashboard-mode .font-sans {
-  font-family: -apple-system, BlinkMacSystemFont, system-ui, 'Helvetica Neue', sans-serif;
+  font-family: ui-rounded, -apple-system, BlinkMacSystemFont, system-ui, 'Helvetica Neue', sans-serif;
 }
 
 html.desktop-dashboard-mode body {

--- a/packages/teacher/src/app/App.tsx
+++ b/packages/teacher/src/app/App.tsx
@@ -63,7 +63,7 @@ function App() {
   const [screenTooSmall, setScreenTooSmall] = useState(
     typeof window !== 'undefined' ? window.innerWidth < MIN_SCREEN_WIDTH : false
   );
-  const { isDashboardMode, isDashboardVisible, setDashboardVisible } = useDesktopDashboardMode();
+  const { isDashboardMode, isDashboardVisible, dashboardTheme, setDashboardVisible } = useDesktopDashboardMode();
 
   // Voice control state
   const [isVoiceControlActive, setIsVoiceControlActive] = useState(false);
@@ -84,8 +84,9 @@ function App() {
   
   // Apply theme class to document
   useEffect(() => {
-    document.documentElement.classList.toggle('dark', theme === 'dark');
-  }, [theme]);
+    const effectiveTheme = isDashboardMode ? dashboardTheme : theme;
+    document.documentElement.classList.toggle('dark', effectiveTheme === 'dark');
+  }, [dashboardTheme, isDashboardMode, theme]);
 
   const updateStickerMode = useCallback((mode: boolean, type?: string | null) => {
     const nextType = mode ? (type ?? stickerStateRef.current.type) : null;

--- a/packages/teacher/src/app/App.tsx
+++ b/packages/teacher/src/app/App.tsx
@@ -160,7 +160,11 @@ function App() {
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       // Only handle if not typing in an input field
-      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) {
+      if (
+        e.target instanceof HTMLInputElement ||
+        e.target instanceof HTMLTextAreaElement ||
+        e.target instanceof HTMLSelectElement
+      ) {
         return;
       }
 
@@ -179,15 +183,17 @@ function App() {
       }
 
       // In the macOS desktop overlay, Escape dismisses the dashboard like
-      // Mission Control/Launchpad - but only when nothing else claims it
-      // (open modals handle Escape themselves, sticker mode returns above).
+      // Mission Control/Launchpad - but only when nothing else claims it:
+      // open modals and menus handle Escape themselves, the voice overlay is
+      // open, sticker mode returned above, or text is being edited.
       if (
         isDashboardMode &&
         isDashboardVisible &&
         e.key === 'Escape' &&
         !e.defaultPrevented &&
+        !isVoiceControlActive &&
         !(e.target instanceof HTMLElement && e.target.isContentEditable) &&
-        !document.querySelector('[role="dialog"]')
+        !document.querySelector('[role="dialog"], [role="menu"]')
       ) {
         e.preventDefault();
         setDashboardVisible(false);
@@ -242,7 +248,7 @@ function App() {
         clearTimeout(voiceTimeout);
       }
     };
-  }, [stickerMode, lastCommandPress, voiceTimeout, voiceControlEnabled, updateStickerMode, isDashboardMode, isDashboardVisible, setDashboardVisible]);
+  }, [stickerMode, lastCommandPress, voiceTimeout, voiceControlEnabled, updateStickerMode, isDashboardMode, isDashboardVisible, setDashboardVisible, isVoiceControlActive]);
 
   // Global paste handler for creating widgets from clipboard content
   useEffect(() => {

--- a/packages/teacher/src/app/App.tsx
+++ b/packages/teacher/src/app/App.tsx
@@ -63,7 +63,7 @@ function App() {
   const [screenTooSmall, setScreenTooSmall] = useState(
     typeof window !== 'undefined' ? window.innerWidth < MIN_SCREEN_WIDTH : false
   );
-  const { isDashboardMode, isDashboardVisible } = useDesktopDashboardMode();
+  const { isDashboardMode, isDashboardVisible, setDashboardVisible } = useDesktopDashboardMode();
 
   // Voice control state
   const [isVoiceControlActive, setIsVoiceControlActive] = useState(false);
@@ -178,6 +178,22 @@ function App() {
         return;
       }
 
+      // In the macOS desktop overlay, Escape dismisses the dashboard like
+      // Mission Control/Launchpad - but only when nothing else claims it
+      // (open modals handle Escape themselves, sticker mode returns above).
+      if (
+        isDashboardMode &&
+        isDashboardVisible &&
+        e.key === 'Escape' &&
+        !e.defaultPrevented &&
+        !(e.target instanceof HTMLElement && e.target.isContentEditable) &&
+        !document.querySelector('[role="dialog"]')
+      ) {
+        e.preventDefault();
+        setDashboardVisible(false);
+        return;
+      }
+
       // Handle Command/Ctrl key press for voice activation (only when Cmd is pressed alone)
       // This should NOT trigger for Cmd+letter combinations
       // Only enable when voice control alpha feature is enabled
@@ -226,7 +242,7 @@ function App() {
         clearTimeout(voiceTimeout);
       }
     };
-  }, [stickerMode, lastCommandPress, voiceTimeout, voiceControlEnabled, updateStickerMode]);
+  }, [stickerMode, lastCommandPress, voiceTimeout, voiceControlEnabled, updateStickerMode, isDashboardMode, isDashboardVisible, setDashboardVisible]);
 
   // Global paste handler for creating widgets from clipboard content
   useEffect(() => {

--- a/packages/teacher/src/features/desktop/useDesktopDashboardMode.ts
+++ b/packages/teacher/src/features/desktop/useDesktopDashboardMode.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { isDesktopDashboardMode } from '@shared/utils/dashboardMode';
+import { useWorkspaceStore } from '../../store/workspaceStore.simple';
 
 type DashboardBridge = {
   setVisible: (visible: boolean) => void;

--- a/packages/teacher/src/features/desktop/useDesktopDashboardMode.ts
+++ b/packages/teacher/src/features/desktop/useDesktopDashboardMode.ts
@@ -143,6 +143,16 @@ export function useDesktopDashboardMode() {
 
     let frame = 0;
 
+    // Native positions views and hit-tests from these rects; integer pixels
+    // are enough precision and stop sub-pixel float churn from spamming the
+    // bridge on every layout tick.
+    const roundRect = (rect: DOMRect) => ({
+      x: Math.round(rect.left),
+      y: Math.round(rect.top),
+      width: Math.round(rect.width),
+      height: Math.round(rect.height)
+    });
+
     const collectRegions = () => {
       if (!isDashboardVisible) return [];
 
@@ -150,30 +160,41 @@ export function useDesktopDashboardMode() {
         .filter(isElementInteractable)
         .map((element) => element.getBoundingClientRect())
         .filter((rect) => rect.width > 0 && rect.height > 0)
-        .map((rect) => ({
-          x: rect.left,
-          y: rect.top,
-          width: rect.width,
-          height: rect.height
-        }));
+        .map(roundRect);
     };
 
-    const collectGlassRegions = (): DashboardGlassRegion[] => {
-      if (!isDashboardVisible) return [];
+    // Returns null to mean "leave the native backdrops as they are" — distinct
+    // from [] ("remove them"). We never send [] on hide so the native side can
+    // fade its existing blur out instead of having it yanked mid-animation.
+    const collectGlassRegions = (): DashboardGlassRegion[] | null => {
+      if (!isDashboardVisible) return null;
 
-      return Array.from(document.querySelectorAll(DASHBOARD_GLASS_SELECTOR))
-        .filter(isElementInteractable)
+      // Behind-window blur is expensive to recomposite, so don't reposition it
+      // every frame of a drag; the post-drop DOM settle publishes the final
+      // positions.
+      if (useWorkspaceStore.getState().dragState.isDragging) return null;
+
+      const elements = Array.from(document.querySelectorAll(DASHBOARD_GLASS_SELECTOR))
+        .filter(isElementInteractable);
+
+      // A surface mid entrance/scale animation reports a transformed rect, so
+      // publishing now would place the blur displaced and then snap it. Defer
+      // until it settles — animationend reschedules a publish (and reduced
+      // motion has no running animation, so this publishes immediately).
+      const animating = elements.some((element) =>
+        element.getAnimations().some((animation) => animation.playState === 'running')
+      );
+      if (animating) return null;
+
+      return elements
         .map((element) => ({
           rect: element.getBoundingClientRect(),
           radius: parseFloat(window.getComputedStyle(element).borderTopLeftRadius) || 0
         }))
         .filter(({ rect }) => rect.width > 0 && rect.height > 0)
         .map(({ rect, radius }) => ({
-          x: rect.left,
-          y: rect.top,
-          width: rect.width,
-          height: rect.height,
-          radius
+          ...roundRect(rect),
+          radius: Math.round(radius)
         }));
     };
 
@@ -196,6 +217,7 @@ export function useDesktopDashboardMode() {
       }
 
       const glassRegions = collectGlassRegions();
+      if (glassRegions === null) return;
       const glassKey = glassRegions
         .map((region) => `${region.x},${region.y},${region.width},${region.height},${region.radius}`)
         .join(';');

--- a/packages/teacher/src/features/desktop/useDesktopDashboardMode.ts
+++ b/packages/teacher/src/features/desktop/useDesktopDashboardMode.ts
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { isDesktopDashboardMode } from '@shared/utils/dashboardMode';
-import { useWorkspaceStore } from '../../store/workspaceStore.simple';
 
 type DashboardBridge = {
   setVisible: (visible: boolean) => void;
@@ -19,6 +18,8 @@ type DashboardInteractiveRegion = {
 type DashboardGlassRegion = DashboardInteractiveRegion & {
   radius: number;
 };
+
+type DashboardTheme = 'light' | 'dark';
 
 declare global {
   interface Window {
@@ -56,6 +57,14 @@ const DASHBOARD_GLASS_SELECTOR = [
 
 const supportsCheckVisibility =
   typeof Element !== 'undefined' && 'checkVisibility' in Element.prototype;
+
+const getSystemDashboardTheme = (): DashboardTheme => {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    return 'light';
+  }
+
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+};
 
 function isElementInteractable(element: Element) {
   // pointer-events is inherited and can be re-enabled by descendants
@@ -99,6 +108,7 @@ export function useDesktopDashboardMode() {
 
     return new URLSearchParams(window.location.search).get('visible') !== '0';
   });
+  const [dashboardTheme, setDashboardTheme] = useState<DashboardTheme>(() => getSystemDashboardTheme());
   const [interactiveRegions, setInteractiveRegions] = useState<DashboardInteractiveRegion[]>([]);
 
   const setVisible = useCallback((visible: boolean) => {
@@ -261,15 +271,15 @@ export function useDesktopDashboardMode() {
     };
   }, [isDashboardMode, isDashboardVisible]);
 
-  // WKWebView reports the macOS appearance through prefers-color-scheme, so
-  // the desktop overlay follows the system (including automatic light/dark
-  // switching) instead of the manually toggled in-app theme.
+  // WKWebView reports the macOS appearance through prefers-color-scheme. Keep
+  // this transient so dashboard mode does not overwrite the user's persisted
+  // browser theme preference.
   useEffect(() => {
-    if (!isDashboardMode) return;
+    if (!isDashboardMode || typeof window.matchMedia !== 'function') return;
 
     const media = window.matchMedia('(prefers-color-scheme: dark)');
     const applySystemTheme = () => {
-      useWorkspaceStore.getState().setTheme(media.matches ? 'dark' : 'light');
+      setDashboardTheme(media.matches ? 'dark' : 'light');
     };
 
     applySystemTheme();
@@ -324,6 +334,7 @@ export function useDesktopDashboardMode() {
   return {
     isDashboardMode,
     isDashboardVisible,
+    dashboardTheme,
     setDashboardVisible,
     toggleDashboard: toggle
   };

--- a/packages/teacher/src/features/desktop/useDesktopDashboardMode.ts
+++ b/packages/teacher/src/features/desktop/useDesktopDashboardMode.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { isDesktopDashboardMode } from '@shared/utils/dashboardMode';
+import { useWorkspaceStore } from '../../store/workspaceStore.simple';
 
 type DashboardBridge = {
   setVisible: (visible: boolean) => void;
@@ -187,6 +188,22 @@ export function useDesktopDashboardMode() {
       mutationObserver.disconnect();
     };
   }, [isDashboardMode, isDashboardVisible]);
+
+  // WKWebView reports the macOS appearance through prefers-color-scheme, so
+  // the desktop overlay follows the system (including automatic light/dark
+  // switching) instead of the manually toggled in-app theme.
+  useEffect(() => {
+    if (!isDashboardMode) return;
+
+    const media = window.matchMedia('(prefers-color-scheme: dark)');
+    const applySystemTheme = () => {
+      useWorkspaceStore.getState().setTheme(media.matches ? 'dark' : 'light');
+    };
+
+    applySystemTheme();
+    media.addEventListener('change', applySystemTheme);
+    return () => media.removeEventListener('change', applySystemTheme);
+  }, [isDashboardMode]);
 
   useEffect(() => {
     if (!isDashboardMode) return;

--- a/packages/teacher/src/features/desktop/useDesktopDashboardMode.ts
+++ b/packages/teacher/src/features/desktop/useDesktopDashboardMode.ts
@@ -16,6 +16,10 @@ type DashboardInteractiveRegion = {
   height: number;
 };
 
+type DashboardGlassRegion = DashboardInteractiveRegion & {
+  radius: number;
+};
+
 declare global {
   interface Window {
     classroomDashboard?: DashboardBridge;
@@ -42,6 +46,14 @@ const DASHBOARD_INTERACTIVE_SELECTOR = [
   '.delete-button'
 ].join(', ');
 
+// Surfaces that get a native NSVisualEffectView blur behind the window,
+// so the real desktop shows through (CSS backdrop-filter can only blur
+// other web content, never what's behind the transparent window).
+const DASHBOARD_GLASS_SELECTOR = [
+  '.widget-surface[data-dashboard-glass="true"]',
+  '[role="dialog"]'
+].join(', ');
+
 function isEditableTarget(target: EventTarget | null) {
   if (!(target instanceof HTMLElement)) return false;
 
@@ -50,6 +62,9 @@ function isEditableTarget(target: EventTarget | null) {
   );
 }
 
+const supportsCheckVisibility =
+  typeof Element !== 'undefined' && 'checkVisibility' in Element.prototype;
+
 function isElementInteractable(element: Element) {
   // pointer-events is inherited and can be re-enabled by descendants
   // (e.g. .toolbar-container and .toolbar-content disable it, the buttons
@@ -57,6 +72,12 @@ function isElementInteractable(element: Element) {
   // meaningful — an ancestor's 'none' must not disqualify the element.
   if (window.getComputedStyle(element).pointerEvents === 'none') {
     return false;
+  }
+
+  // Single native call instead of a getComputedStyle walk per ancestor;
+  // this runs for every tracked element on every region update.
+  if (supportsCheckVisibility) {
+    return element.checkVisibility({ checkOpacity: true, checkVisibilityCSS: true });
   }
 
   let current: Element | null = element;
@@ -137,7 +158,27 @@ export function useDesktopDashboardMode() {
         }));
     };
 
+    const collectGlassRegions = (): DashboardGlassRegion[] => {
+      if (!isDashboardVisible) return [];
+
+      return Array.from(document.querySelectorAll(DASHBOARD_GLASS_SELECTOR))
+        .filter(isElementInteractable)
+        .map((element) => ({
+          rect: element.getBoundingClientRect(),
+          radius: parseFloat(window.getComputedStyle(element).borderTopLeftRadius) || 0
+        }))
+        .filter(({ rect }) => rect.width > 0 && rect.height > 0)
+        .map(({ rect, radius }) => ({
+          x: rect.left,
+          y: rect.top,
+          width: rect.width,
+          height: rect.height,
+          radius
+        }));
+    };
+
     let lastPublishedKey: string | null = null;
+    let lastPublishedGlassKey: string | null = null;
 
     const publishRegions = () => {
       frame = 0;
@@ -145,13 +186,26 @@ export function useDesktopDashboardMode() {
       const key = regions
         .map((region) => `${region.x},${region.y},${region.width},${region.height}`)
         .join(';');
-      if (key === lastPublishedKey) return;
-      lastPublishedKey = key;
-      setInteractiveRegions(regions);
-      window.webkit?.messageHandlers?.classroomDashboard?.postMessage({
-        type: 'interactive-regions-changed',
-        regions
-      });
+      if (key !== lastPublishedKey) {
+        lastPublishedKey = key;
+        setInteractiveRegions(regions);
+        window.webkit?.messageHandlers?.classroomDashboard?.postMessage({
+          type: 'interactive-regions-changed',
+          regions
+        });
+      }
+
+      const glassRegions = collectGlassRegions();
+      const glassKey = glassRegions
+        .map((region) => `${region.x},${region.y},${region.width},${region.height},${region.radius}`)
+        .join(';');
+      if (glassKey !== lastPublishedGlassKey) {
+        lastPublishedGlassKey = glassKey;
+        window.webkit?.messageHandlers?.classroomDashboard?.postMessage({
+          type: 'glass-regions-changed',
+          regions: glassRegions
+        });
+      }
     };
 
     const schedulePublish = () => {
@@ -163,6 +217,9 @@ export function useDesktopDashboardMode() {
     window.addEventListener('resize', schedulePublish);
     window.addEventListener('scroll', schedulePublish, true);
     document.addEventListener('transitionend', schedulePublish, true);
+    // The widget entrance/exit effects are CSS animations, not transitions;
+    // without this the published rects go stale after each show.
+    document.addEventListener('animationend', schedulePublish, true);
 
     const resizeObserver = new ResizeObserver(schedulePublish);
     resizeObserver.observe(document.documentElement);
@@ -184,6 +241,7 @@ export function useDesktopDashboardMode() {
       window.removeEventListener('resize', schedulePublish);
       window.removeEventListener('scroll', schedulePublish, true);
       document.removeEventListener('transitionend', schedulePublish, true);
+      document.removeEventListener('animationend', schedulePublish, true);
       resizeObserver.disconnect();
       mutationObserver.disconnect();
     };

--- a/packages/teacher/src/features/desktop/useDesktopDashboardMode.ts
+++ b/packages/teacher/src/features/desktop/useDesktopDashboardMode.ts
@@ -54,14 +54,6 @@ const DASHBOARD_GLASS_SELECTOR = [
   '[role="dialog"]'
 ].join(', ');
 
-function isEditableTarget(target: EventTarget | null) {
-  if (!(target instanceof HTMLElement)) return false;
-
-  return Boolean(
-    target.closest('input, textarea, select, [contenteditable="true"]')
-  );
-}
-
 const supportsCheckVisibility =
   typeof Element !== 'undefined' && 'checkVisibility' in Element.prototype;
 
@@ -301,21 +293,9 @@ export function useDesktopDashboardMode() {
     return () => window.cancelAnimationFrame(frame);
   }, [isDashboardMode]);
 
-  useEffect(() => {
-    if (!isDashboardMode) return;
-
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (isEditableTarget(event.target)) return;
-
-      if ((event.metaKey || event.ctrlKey) && event.shiftKey && event.code === 'Space') {
-        event.preventDefault();
-        toggle();
-      }
-    };
-
-    window.addEventListener('keydown', handleKeyDown);
-    return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [isDashboardMode, toggle]);
+  // Toggling is owned by the native global hotkey (default ⌥⌘D). A duplicate
+  // web handler on the same combo would double-fire while the overlay is
+  // focused (both fire, cancelling out), so there is intentionally none here.
 
   useEffect(() => {
     if (!isDashboardMode) return;

--- a/packages/teacher/src/features/hud/components/BottomBar.tsx
+++ b/packages/teacher/src/features/hud/components/BottomBar.tsx
@@ -36,6 +36,16 @@ const defaultRecentWidgets = [
   WidgetType.TRAFFIC_LIGHT
 ];
 
+const getVisibleWidgetConfigs = (types: WidgetType[]) => types.flatMap((type) => {
+  const config = widgetRegistry.get(type);
+
+  if (!config || config.features?.hidden) {
+    return [];
+  }
+
+  return [config];
+});
+
 const getStickerState = () => {
   const state = (window as any).getStickerState?.();
 
@@ -241,14 +251,15 @@ const BottomBar: React.FC<BottomBarProps> = ({ onToggleLayout }) => {
     });
   };
 
-  // Use recent widgets for the toolbar, fallback to defaults
+  // Use recent widgets for the toolbar, fallback to visible defaults
   const widgetsToShow = recentWidgets && recentWidgets.length > 0
     ? recentWidgets
     : defaultRecentWidgets;
 
-  const recentConfigs = widgetsToShow
-    .map(type => widgetRegistry.get(type))
-    .filter(Boolean);
+  const recentConfigs = getVisibleWidgetConfigs(widgetsToShow);
+  const toolbarWidgetConfigs = recentConfigs.length > 0
+    ? recentConfigs
+    : getVisibleWidgetConfigs(defaultRecentWidgets);
 
   return (
     <>
@@ -303,11 +314,11 @@ const BottomBar: React.FC<BottomBarProps> = ({ onToggleLayout }) => {
 
           {/* Middle section - recent widget buttons */}
           <div className="flex items-center gap-2 overflow-x-auto scrollbar-hide flex-1 min-w-0 max-[540px]:hidden">
-            {recentConfigs.map((config) => (
+            {toolbarWidgetConfigs.map((config) => (
               <WidgetButton
-                key={config!.type}
-                config={config!}
-                onClick={() => handleAddWidget(config!.type)}
+                key={config.type}
+                config={config}
+                onClick={() => handleAddWidget(config.type)}
                 className={clsx(
                   stickerMode ? 'opacity-50 cursor-not-allowed' : '',
                   'flex-shrink-0'

--- a/packages/teacher/src/features/hud/components/BottomBarMenu.tsx
+++ b/packages/teacher/src/features/hud/components/BottomBarMenu.tsx
@@ -22,6 +22,7 @@ import { clsx } from 'clsx';
 import { useWorkspace, useTheme, useBottomBar } from '@shared/hooks/useWorkspace';
 import { useWorkspaceStore } from '../../../store/workspaceStore.simple';
 import { useWidgets } from '@shared/hooks/useWidget';
+import { isDesktopDashboardMode } from '@shared/utils/dashboardMode';
 import { BackgroundType } from '@shared/types';
 import { dropdownContainer, zIndex } from '@shared/utils/styles';
 import { MenuItem, MenuDivider, MenuSectionHeader } from '../../../components/ui';
@@ -41,6 +42,9 @@ const BottomBarMenu: React.FC<BottomBarMenuProps> = ({ onClose, onToggleLayout }
 
   const layoutFormat = useWorkspaceStore((state) => state.layoutFormat);
   const voiceControlEnabled = bottomBar.voiceControlEnabled ?? false;
+  // In the macOS overlay the theme follows the system appearance, so a manual
+  // toggle here would just get reverted on the next appearance change.
+  const isDashboardMode = isDesktopDashboardMode();
 
   const handleToggleVoiceControl = () => {
     updateBottomBar({ voiceControlEnabled: !voiceControlEnabled });
@@ -97,19 +101,22 @@ const BottomBarMenu: React.FC<BottomBarMenuProps> = ({ onClose, onToggleLayout }
   return (
     <div
       ref={menuRef}
+      role="menu"
       className={clsx(
         'absolute right-4 bottom-16 min-w-[200px] py-2',
         dropdownContainer,
         zIndex.hudDropdown
       )}
     >
-      {/* Theme Toggle */}
-      <MenuItem
-        onClick={toggleTheme}
-        icon={theme === 'light' ? FaMoon : FaSun}
-      >
-        {theme === 'light' ? 'Dark Mode' : 'Light Mode'}
-      </MenuItem>
+      {/* Theme Toggle - hidden in the macOS overlay where the system drives it */}
+      {!isDashboardMode && (
+        <MenuItem
+          onClick={toggleTheme}
+          icon={theme === 'light' ? FaMoon : FaSun}
+        >
+          {theme === 'light' ? 'Dark Mode' : 'Light Mode'}
+        </MenuItem>
+      )}
 
       {/* Layout Format Toggle */}
       <MenuItem

--- a/packages/teacher/src/features/hud/components/BottomBarMenu.tsx
+++ b/packages/teacher/src/features/hud/components/BottomBarMenu.tsx
@@ -61,8 +61,20 @@ const BottomBarMenu: React.FC<BottomBarMenuProps> = ({ onClose, onToggleLayout }
       }
     };
 
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        onClose();
+      }
+    };
+
     document.addEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
+    document.addEventListener('keydown', handleEscape);
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('keydown', handleEscape);
+    };
   }, [onClose]);
 
   const handleReset = () => {

--- a/packages/teacher/src/features/session/components/SessionBanner/index.tsx
+++ b/packages/teacher/src/features/session/components/SessionBanner/index.tsx
@@ -138,11 +138,11 @@ const ActiveSessionBanner: React.FC<ActiveSessionBannerProps> = ({
             "max-[540px]:hidden",
             isExpanded ? "flex max-w-[1200px] opacity-100 ml-2 min-[540px]:ml-3" : "hidden max-w-0 opacity-0 overflow-hidden"
           )}>
-            <code className="text-2xl min-[540px]:text-5xl font-bold text-warm-gray-800 dark:text-warm-gray-200 tracking-wider leading-none">
+            <code className="select-text text-2xl min-[540px]:text-5xl font-bold text-warm-gray-800 dark:text-warm-gray-200 tracking-wider leading-none">
               {sessionCode}
             </code>
             <div className="w-px h-6 min-[540px]:h-8 bg-warm-gray-300 dark:bg-warm-gray-600" />
-            <span className="text-sm min-[540px]:text-3xl font-semibold text-warm-gray-600 dark:text-warm-gray-300 truncate max-w-[160px] min-[540px]:max-w-[420px]">
+            <span className="select-text text-sm min-[540px]:text-3xl font-semibold text-warm-gray-600 dark:text-warm-gray-300 truncate max-w-[160px] min-[540px]:max-w-[420px]">
               {displayUrl?.replace(/^https?:\/\//, '')}
             </span>
             {connected && (
@@ -177,11 +177,11 @@ const ActiveSessionBanner: React.FC<ActiveSessionBannerProps> = ({
             zIndex.hud
           )}
         >
-          <code className="text-2xl font-bold text-warm-gray-800 dark:text-warm-gray-200 tracking-wider leading-none">
+          <code className="select-text text-2xl font-bold text-warm-gray-800 dark:text-warm-gray-200 tracking-wider leading-none">
             {sessionCode}
           </code>
           <div className="w-px h-6 bg-warm-gray-300 dark:bg-warm-gray-600" />
-          <span className="text-sm font-semibold text-warm-gray-600 dark:text-warm-gray-300 truncate max-w-[160px]">
+          <span className="select-text text-sm font-semibold text-warm-gray-600 dark:text-warm-gray-300 truncate max-w-[160px]">
             {displayUrl?.replace(/^https?:\/\//, '')}
           </span>
           {connected && (

--- a/packages/teacher/src/features/widgets/shared/WidgetWrapper.tsx
+++ b/packages/teacher/src/features/widgets/shared/WidgetWrapper.tsx
@@ -121,7 +121,10 @@ const WidgetWrapper: React.FC<WidgetWrapperProps> = ({ widgetId, children, dashb
       // Only apply transitions when NOT dragging - transitions cause input lag during drag
       'transition-all duration-200': !isBeingDragged && !isResizing,
       'ring-2 ring-sage-500': isBeingDragged && !isTransparent,
-      'hover:scale-[1.01]': !isBeingDragged && !isTransparent
+      // No hover scale in the macOS overlay: the scaled rect wouldn't match the
+      // interactive/glass regions published to native, leaving the blur edge and
+      // click-through ring misaligned for the whole hover.
+      'hover:scale-[1.01]': !isBeingDragged && !isTransparent && !isDashboardMode
     }
   );
 

--- a/packages/teacher/src/services/WidgetRegistry.ts
+++ b/packages/teacher/src/services/WidgetRegistry.ts
@@ -258,7 +258,10 @@ export class WidgetRegistry {
       columnSizing: 'aspect-ratio',
       features: {
         requiresApiKey: true,
-        isResizable: true
+        isResizable: true,
+        // Needs a build-time Short.io key (VITE_SHORTIO_API_KEY); without one
+        // the widget can only show an error, so keep it out of the launcher.
+        hidden: !import.meta.env.VITE_SHORTIO_API_KEY
       }
     });
 


### PR DESCRIPTION
Polishes the macOS dashboard (the `WKWebView` overlay wrapper in `packages/macos-dashboard`) so it feels native, then hardens it after an adversarial review. All verified locally via `npm run macos:run -- --verify` (builds, installs to `/Applications`, launches).

## Native feel
- **Main menu** so standard key equivalents reach the web view: ⌘C/V/X/Z/A in text fields, ⌘, for Settings, ⌘W to hide the overlay.
- **System appearance**: dark/light follows macOS (`prefers-color-scheme`), including live switching.
- **Real glass**: native `NSVisualEffectView` backdrops behind glass widget/dialog surfaces (CSS `backdrop-filter` can't blur the desktop behind a transparent window). Web publishes surface rects+radius; native positions a pooled set of effect views.
- **Show/hide animates** instead of blinking (delayed `orderOut` so the CSS exit plays; entrance replays per show).
- **SF Rounded** UI font, arrow cursor, non-selectable chrome (inputs stay selectable), `prefers-reduced-motion` respected.
- **Escape** dismisses the overlay (Mission Control-style), deferring to open modals/menus, the voice overlay, and text fields.
- Default toggle shortcut **⌥⌘D** (launcher ⌥⌘K); dropped the over-generic ⌘R reload and a redundant web-side toggle.

## Hardening (from adversarial review)
- **Navigation policy + UI delegate**: the overlay can never navigate to foreign content — only the bundled custom scheme loads in-frame; links (incl. student-submitted URLs in Link Share) and `target=_blank` open in the user's browser. Message handler validates frame origin.
- **Visibility generation token** so a superseded retry can't land a stale value and desync web/native.
- **Crash/reload recovery**: clear stale interactive/glass regions on nav-start and web-process termination (auto-reload), preventing ghost blur slabs and click-eating dead regions.
- **Reload** rebuilds the URL from current state instead of `reloadFromOrigin()`.
- Yield activation on hide so keystrokes during the exit grace don't land in the invisible web view.
- Glass publishes only settled rects (never `[]` on hide); recompute on resize/display-layout change; integer-rounded; suppressed mid-drag.

## Settings window
- Rebuilt as a SwiftUI `TabView` (JustNow-style) in a plain `NSWindow` — fixes the "Untitled" title and edge-clipping the `NSTabViewController` caused.

## Other
- **Link Shortener** hidden from the launcher unless a Short.io key is configured at build time (it could otherwise only render an error). Follow-up tracked in #60 (make it a runtime setting; audit all server-requiring widgets).

Teacher web build + all 85 tests pass; Swift builds clean on the macOS 13 deployment target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tinkertanker/classroom-widgets/pull/61" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->