### PR TITLE
fix: show layout toggle whenever in column mode (exit column mode on any screen)

### DIFF
--- a/packages/teacher/src/app/App.tsx
+++ b/packages/teacher/src/app/App.tsx
@@ -625,7 +625,7 @@ function App() {
             v{APP_VERSION}
           </a>
 
-          {/* Narrow mode layout toggle - shows when in narrow screen mode */}
+          {/* Layout toggle - shows whenever in column mode (escape hatch to canvas) or on narrow screens */}
           <NarrowModeExitButton
             isNarrowScreen={isNarrowScreen}
             layoutFormat={layoutFormat}

--- a/packages/teacher/src/features/hud/components/NarrowModeExitButton.tsx
+++ b/packages/teacher/src/features/hud/components/NarrowModeExitButton.tsx
@@ -52,6 +52,9 @@ const NarrowModeExitButton: React.FC<NarrowModeExitButtonProps> = ({
     <button
       type="button"
       onClick={onToggleLayout}
+      // Teacher-app chrome: hidden in the macOS dashboard overlay (like TopControls),
+      // so the fixed button never floats over the desktop when the dashboard is dismissed.
+      data-dashboard-chrome="true"
       className={clsx(
         `fixed bottom-2 right-2 ${zIndex.hud} px-2 py-1.5 h-auto`,
         "flex flex-col items-center gap-0.5",

--- a/packages/teacher/src/features/hud/components/NarrowModeExitButton.tsx
+++ b/packages/teacher/src/features/hud/components/NarrowModeExitButton.tsx
@@ -36,8 +36,10 @@ const NarrowModeExitButton: React.FC<NarrowModeExitButtonProps> = ({
   layoutFormat,
   onToggleLayout
 }) => {
-  // Only show in narrow screen mode
-  if (!isNarrowScreen) {
+  // Show whenever the user is in column mode (so there is always a visible
+  // escape hatch back to canvas at any screen width), plus on narrow screens
+  // where column layout is force-enabled.
+  if (!isNarrowScreen && layoutFormat !== 'column') {
     return null;
   }
 


### PR DESCRIPTION
## Problem

"Column mode" is `layoutFormat === 'column'` — a **per-workspace setting persisted to localStorage**. The floating layout toggle button (`NarrowModeExitButton`) only rendered when the window was **narrower than 540px** (`isNarrowScreen`).

On a normal wide screen the button never appeared, so the only way to exit column mode was the buried Bottom Bar → hamburger menu → "Column Layout" toggle. Worse, because the value is persisted per-workspace, a **freshly opened tab inherits column mode** — again with no visible escape hatch. Users reported being unable to get out of column mode.

## Fix

Render the floating toggle **whenever `layoutFormat === 'column'`** (in addition to narrow screens), giving an always-visible one-click "Canvas" escape hatch at any screen width.

```diff
- if (!isNarrowScreen) {
+ if (!isNarrowScreen && layoutFormat !== 'column') {
    return null;
  }
```

## Changes
- `packages/teacher/src/features/hud/components/NarrowModeExitButton.tsx` — widen the render guard.
- `packages/teacher/src/app/App.tsx` — update the accompanying comment.

## Verification (Chrome, 1400px wide)
1. Canvas + wide → no button (unchanged). ✅
2. Toggle to column → **"Canvas" escape button appears** bottom-right; zoom controls hide. ✅
3. Click it → back to canvas; button disappears; zoom controls return. ✅
4. Column mode + **reload** (= "new tab stuck in column mode") → loads in column with the "Canvas" button present for a one-click exit. ✅

Typecheck passes (`tsc --noEmit`). Button sits clear in the bottom-right corner with no bottom-bar overlap.

## Note
Persistence semantics are intentionally unchanged — column layout stays a saved per-workspace preference; the fix only guarantees there is always a visible way out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tinkertanker/classroom-widgets/pull/66" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->