### PR TITLE
[Follow-up to #72] Fix iPad Studio access and recovery flows

### DIFF
--- a/apps/ipad/Sources/Networking/StudioAPIClient.swift
+++ b/apps/ipad/Sources/Networking/StudioAPIClient.swift
@@ -365,7 +365,12 @@ enum StudioAPIError: LocalizedError, Equatable {
         case .invalidURL, .invalidResponse, .transport, .decoding, .server: "Studio could not complete this request. Check your connection and try again."
         }
     }
-    var requiresRegistration: Bool { if case .server(401, let code, _) = self { return code == "DEVICE_REGISTRATION_REQUIRED" || code == "DEVICE_TOKEN_REQUIRED" }; return false }
+    var requiresRegistration: Bool {
+        if self == .registrationRequired { return true }
+        if case .server(401, let code, _) = self { return code == "DEVICE_REGISTRATION_REQUIRED" || code == "DEVICE_TOKEN_REQUIRED" }
+        return false
+    }
+    var isArtifactNotFound: Bool { if case .server(404, let code, _) = self { return code == "ARTIFACT_NOT_FOUND" }; return false }
     var requiresRefresh: Bool {
         if requiresRegistration { return true }
         if case .server(422, let code, _) = self { return code == "PUBLICATION_EXPIRY_LIMIT_REACHED" }

--- a/apps/ipad/Sources/Networking/StudioAPIClient.swift
+++ b/apps/ipad/Sources/Networking/StudioAPIClient.swift
@@ -366,11 +366,16 @@ enum StudioAPIError: LocalizedError, Equatable {
         }
     }
     var requiresRegistration: Bool {
-        if self == .registrationRequired { return true }
-        if case .server(401, let code, _) = self { return code == "DEVICE_REGISTRATION_REQUIRED" || code == "DEVICE_TOKEN_REQUIRED" }
+        if case .registrationRequired = self { return true }
+        if case .server(401, let code, _) = self {
+            return code == "DEVICE_REGISTRATION_REQUIRED" || code == "DEVICE_TOKEN_REQUIRED"
+        }
         return false
     }
-    var isArtifactNotFound: Bool { if case .server(404, let code, _) = self { return code == "ARTIFACT_NOT_FOUND" }; return false }
+    var isArtifactNotFound: Bool {
+        if case .server(404, let code, _) = self { return code == "ARTIFACT_NOT_FOUND" }
+        return false
+    }
     var requiresRefresh: Bool {
         if requiresRegistration { return true }
         if case .server(422, let code, _) = self { return code == "PUBLICATION_EXPIRY_LIMIT_REACHED" }

--- a/apps/ipad/Sources/Preview/WidgetPreviewWebView.swift
+++ b/apps/ipad/Sources/Preview/WidgetPreviewWebView.swift
@@ -57,7 +57,10 @@ struct WidgetPreviewWebView: UIViewRepresentable {
         context.coordinator.presentableError = $presentableError
         context.coordinator.onSnapshot = onSnapshot
         context.coordinator.handler.assets = localAssets
-        context.coordinator.load(source)
+        let coordinator = context.coordinator
+        Task { @MainActor in
+            coordinator.load(source)
+        }
     }
 
     @MainActor

--- a/apps/ipad/Sources/Preview/WidgetPreviewWebView.swift
+++ b/apps/ipad/Sources/Preview/WidgetPreviewWebView.swift
@@ -58,7 +58,7 @@ struct WidgetPreviewWebView: UIViewRepresentable {
         context.coordinator.onSnapshot = onSnapshot
         context.coordinator.handler.assets = localAssets
         let coordinator = context.coordinator
-        Task { @MainActor in
+        DispatchQueue.main.async {
             coordinator.load(source)
         }
     }

--- a/apps/ipad/Sources/Store/StudioStore.swift
+++ b/apps/ipad/Sources/Store/StudioStore.swift
@@ -53,13 +53,24 @@ struct StudioErrorPresentation { let title, message: String; let requestsWorksho
             }
             return
         }
-        workshopAccessState = await api.hasDeviceCredential() ? .ready : .registrationRequired
+        let hasCredential = await api.hasDeviceCredential()
+        workshopAccessState = hasCredential ? .ready : .registrationRequired
+        showsWorkshopAccess = !hasCredential
     }
     func requestWorkshopAccess() { showsWorkshopAccess = true }
     func dismissWorkshopAccess() { showsWorkshopAccess = false }
     func registerWorkshopAccess(_ code: String) async throws { try await api.registerDevice(accessCode: code); workshopAccessState = .ready; showsWorkshopAccess = false }
     func present(_ error: Error, during operation: StudioOperation) -> StudioErrorPresentation {
-        StudioErrorPresentation(title: "Studio could not complete this action", message: (error as? LocalizedError)?.errorDescription ?? error.localizedDescription, requestsWorkshopAccess: false)
+        if let apiError = error as? StudioAPIError, apiError.requiresRegistration {
+            workshopAccessState = .registrationRequired
+            showsWorkshopAccess = true
+            return StudioErrorPresentation(
+                title: "Studio access needed",
+                message: "Enter your workshop code to continue.",
+                requestsWorkshopAccess: true
+            )
+        }
+        return StudioErrorPresentation(title: "Studio could not complete this action", message: (error as? LocalizedError)?.errorDescription ?? error.localizedDescription, requestsWorkshopAccess: false)
     }
     func resetGuidedMake() { guidedMakeDraft = .init(); guidedMakeQuestionIndex = 0; guidedMakeResponse = ""; guidedMakeShowsSummary = false }
     func createApprovedBrief(_ brief: GuidedBriefDraft) async throws -> ArtifactProject {
@@ -111,7 +122,13 @@ struct StudioErrorPresentation { let title, message: String; let requestsWorksho
     func unpublish(projectID: String) async throws { var current = try project(projectID); if let slug = current.artifact.publication?.slug { try await api.revoke(slug: slug) }; current.artifact.publication = nil; upsert(current) }
     func extendPublication(projectID: String) async throws { var current = try project(projectID); guard let slug = current.artifact.publication?.slug else { return }; current.artifact.publication = try await api.extend(slug: slug, days: 90); upsert(current) }
     func deleteProject(projectID: String) async throws {
-        try await api.deleteArtifact(id: projectID)
+        do {
+            try await api.deleteArtifact(id: projectID)
+        } catch let error as StudioAPIError where error.isArtifactNotFound {
+            // The server may have expired the recovery copy already. The local
+            // project must still remain deletable.
+        }
+        projects.first(where: { $0.id == projectID })?.localAssets.forEach(LocalWidgetAssetStorage.remove)
         projects.removeAll { $0.id == projectID }
         let name = projectID.addingPercentEncoding(withAllowedCharacters: .alphanumerics) ?? projectID
         try? FileManager.default.removeItem(at: cacheDirectory.appending(path: "\(name).json"))
@@ -121,11 +138,21 @@ struct StudioErrorPresentation { let title, message: String; let requestsWorksho
         defer { isRestoringFromStudio = false }
         let artifacts = try await api.listArtifacts()
         var count = 0
+        var failures = 0
         for artifact in artifacts {
-            let fetched = try await api.getArtifact(id: artifact.id)
-            let remote = try await cacheAssets(in: fetched)
-            upsert(remote)
-            count += 1
+            do {
+                let fetched = try await api.getArtifact(id: artifact.id)
+                let remote = try await cacheAssets(in: fetched)
+                upsert(remote)
+                count += 1
+            } catch {
+                failures += 1
+            }
+        }
+        if failures > 0 {
+            recoveryNotice = count > 0
+                ? "Studio restored \(count) widget(s), but could not restore \(failures). Try again later."
+                : "Studio could not restore your widgets. Try again later."
         }
         return count
     }

--- a/apps/ipad/Sources/Store/StudioStore.swift
+++ b/apps/ipad/Sources/Store/StudioStore.swift
@@ -67,7 +67,7 @@ struct StudioErrorPresentation { let title, message: String; let requestsWorksho
         }
         let hasCredential = await api.hasDeviceCredential()
         workshopAccessState = hasCredential ? .ready : .registrationRequired
-        showsWorkshopAccess = !hasCredential
+        if !hasCredential { showsWorkshopAccess = true }
     }
     func requestWorkshopAccess() { showsWorkshopAccess = true }
     func dismissWorkshopAccess() { showsWorkshopAccess = false }
@@ -130,15 +130,24 @@ struct StudioErrorPresentation { let title, message: String; let requestsWorksho
     func unpublish(projectID: String) async throws { var current = try project(projectID); if let slug = current.artifact.publication?.slug { try await api.revoke(slug: slug) }; current.artifact.publication = nil; upsert(current) }
     func extendPublication(projectID: String) async throws { var current = try project(projectID); guard let slug = current.artifact.publication?.slug else { return }; current.artifact.publication = try await api.extend(slug: slug, days: 90); upsert(current) }
     func deleteProject(projectID: String) async throws {
+        let current = try project(projectID)
         do {
             try await api.deleteArtifact(id: projectID)
-        } catch let error as StudioAPIError where error.isArtifactNotFound {
+        } catch let error as StudioAPIError
+            where error.isArtifactNotFound
+                && Self.hasNoPotentiallyLivePublication(current.artifact.publication) {
             // The server may have expired the recovery copy already. The local
             // project must still remain deletable.
         }
         projects.removeAll { $0.id == projectID }
         let name = projectID.addingPercentEncoding(withAllowedCharacters: .alphanumerics) ?? projectID
         try? FileManager.default.removeItem(at: projectDirectory.appending(path: "\(name).json"))
+    }
+    private static func hasNoPotentiallyLivePublication(_ publication: ArtifactPublication?) -> Bool {
+        guard let publication else { return true }
+        if publication.revokedAt != nil { return true }
+        guard let expirationDate = publication.expirationDate else { return false }
+        return expirationDate <= .now
     }
     func restoreFromStudio() async throws -> Int {
         isRestoringFromStudio = true
@@ -152,6 +161,9 @@ struct StudioErrorPresentation { let title, message: String; let requestsWorksho
                 let remote = try await cacheAssets(in: fetched)
                 upsert(remote)
                 count += 1
+            } catch let error as StudioAPIError where error.requiresRegistration {
+                _ = present(error, during: .restore)
+                throw error
             } catch {
                 failures += 1
             }

--- a/apps/ipad/Sources/Store/StudioStore.swift
+++ b/apps/ipad/Sources/Store/StudioStore.swift
@@ -22,20 +22,32 @@ struct StudioErrorPresentation { let title, message: String; let requestsWorksho
     var guidedMakeDraft = GuidedBriefDraft(); var guidedMakeQuestionIndex = 0; var guidedMakeResponse = ""; var guidedMakeShowsSummary = false
     var isCreatingGuidedDraft = false
     private let api: any StudioAPI
-    private let cacheDirectory: URL
+    private let projectDirectory: URL
     private let isUITesting: Bool
     private var uploadedSnapshotRevisionIDs: Set<String> = []
 
     init(api: any StudioAPI = StudioAPIClient.live(), storageDirectory: URL? = nil, bundle: Bundle = .main) {
         self.api = api
         isUITesting = ProcessInfo.processInfo.arguments.contains("--ui-testing-reset")
-        let root = storageDirectory ?? (try? FileManager.default.url(for: .cachesDirectory, in: .userDomainMask, appropriateFor: nil, create: true)) ?? FileManager.default.temporaryDirectory
-        cacheDirectory = root.appending(path: "ArtifactProjects", directoryHint: .isDirectory)
-        if isUITesting {
-            try? FileManager.default.removeItem(at: cacheDirectory)
+        if let storageDirectory {
+            projectDirectory = storageDirectory.appending(path: "ArtifactProjects", directoryHint: .isDirectory)
+        } else {
+            let applicationSupport = (try? FileManager.default.url(for: .applicationSupportDirectory, in: .userDomainMask, appropriateFor: nil, create: true)) ?? FileManager.default.temporaryDirectory
+            projectDirectory = applicationSupport
+                .appending(path: "Classroom Widgets Studio", directoryHint: .isDirectory)
+                .appending(path: "ArtifactProjects", directoryHint: .isDirectory)
+            if let caches = try? FileManager.default.url(for: .cachesDirectory, in: .userDomainMask, appropriateFor: nil, create: false) {
+                Self.copyLegacyProjects(
+                    from: caches.appending(path: "ArtifactProjects", directoryHint: .isDirectory),
+                    to: projectDirectory
+                )
+            }
         }
-        try? FileManager.default.createDirectory(at: cacheDirectory, withIntermediateDirectories: true)
-        projects = Self.loadCachedProjects(from: cacheDirectory)
+        if isUITesting {
+            try? FileManager.default.removeItem(at: projectDirectory)
+        }
+        try? FileManager.default.createDirectory(at: projectDirectory, withIntermediateDirectories: true)
+        projects = Self.loadCachedProjects(from: projectDirectory)
         examples = Self.loadExamples(bundle: bundle)
     }
     var selectedProject: ArtifactProject? { projects.first { $0.id == selectedProjectID } ?? examples.first { $0.id == selectedProjectID } }
@@ -90,14 +102,10 @@ struct StudioErrorPresentation { let title, message: String; let requestsWorksho
         let project = try await api.generate(request: request); upsert(project); open(project); return project
     }
     func remix(_ example: ArtifactProject) async throws {
-        let artifact = example.artifact
-        let request = GuidedGenerationRequest(creationBrief: artifact.creationBrief, brief: .init(
-            learnerContext: artifact.level ?? artifact.subject ?? "General learners",
-            learningObjective: artifact.learningObjective ?? artifact.title,
-            studentAction: artifact.summary, sourceContent: nil,
-            feedback: "Provide clear feedback", classroomFit: "Use in a short classroom activity"
-        ), preferredExampleRevisionId: example.source.revision.id)
-        let project = try await api.generate(request: request)
+        let project = try await api.remix(
+            id: example.artifact.id,
+            revisionId: example.source.revision.id
+        )
         upsert(project)
         open(project)
     }
@@ -130,7 +138,7 @@ struct StudioErrorPresentation { let title, message: String; let requestsWorksho
         }
         projects.removeAll { $0.id == projectID }
         let name = projectID.addingPercentEncoding(withAllowedCharacters: .alphanumerics) ?? projectID
-        try? FileManager.default.removeItem(at: cacheDirectory.appending(path: "\(name).json"))
+        try? FileManager.default.removeItem(at: projectDirectory.appending(path: "\(name).json"))
     }
     func restoreFromStudio() async throws -> Int {
         isRestoringFromStudio = true
@@ -201,13 +209,7 @@ struct StudioErrorPresentation { let title, message: String; let requestsWorksho
     private func cacheAssets(in project: ArtifactProject) async throws -> ArtifactProject {
         var project = project
         let existingIDs = Set(project.localAssets.map(\.id))
-        let pattern = #"assets/([A-Za-z0-9][A-Za-z0-9._-]*)"#
-        let expression = try NSRegularExpression(pattern: pattern)
-        let range = NSRange(project.source.html.startIndex..., in: project.source.html)
-        let assetIDs = Set<String>(expression.matches(in: project.source.html, range: range).compactMap { match in
-            guard let range = Range(match.range(at: 1), in: project.source.html) else { return nil }
-            return String(project.source.html[range])
-        })
+        let assetIDs = Self.referencedAssetIDs(in: project.source.html)
         for assetID in assetIDs where !existingIDs.contains(assetID) {
             let downloaded = try await api.downloadAsset(id: assetID)
             project.localAssets.append(try LocalWidgetAssetStorage.store(downloaded, id: assetID))
@@ -226,7 +228,7 @@ struct StudioErrorPresentation { let title, message: String; let requestsWorksho
     }
     private func persist(_ project: ArtifactProject) {
         let name = project.id.addingPercentEncoding(withAllowedCharacters: .alphanumerics) ?? UUID().uuidString
-        do { try JSONEncoder().encode(project).write(to: cacheDirectory.appending(path: "\(name).json"), options: [.atomic, .completeFileProtectionUntilFirstUserAuthentication]) }
+        do { try JSONEncoder().encode(project).write(to: projectDirectory.appending(path: "\(name).json"), options: [.atomic, .completeFileProtectionUntilFirstUserAuthentication]) }
         catch { recoveryNotice = "Studio could not save this widget for offline use." }
     }
     private static func loadCachedProjects(from directory: URL) -> [ArtifactProject] {
@@ -235,6 +237,42 @@ struct StudioErrorPresentation { let title, message: String; let requestsWorksho
             guard url.pathExtension == "json", let data = try? Data(contentsOf: url) else { return nil }
             return try? JSONDecoder().decode(ArtifactProject.self, from: data)
         }
+    }
+    static func referencedAssetIDs(in html: String) -> Set<String> {
+        let patterns = [
+            #"\b(?:src|href|action)\s*=\s*(?:"\s*assets/([A-Za-z0-9_-]+)\s*"|'\s*assets/([A-Za-z0-9_-]+)\s*'|assets/([A-Za-z0-9_-]+))"#,
+            #"\burl\(\s*(?:"\s*assets/([A-Za-z0-9_-]+)\s*"|'\s*assets/([A-Za-z0-9_-]+)\s*'|assets/([A-Za-z0-9_-]+))\s*\)"#
+        ]
+        var result: Set<String> = []
+        for pattern in patterns {
+            guard let expression = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive]) else { continue }
+            let range = NSRange(html.startIndex..., in: html)
+            for match in expression.matches(in: html, range: range) {
+                for capture in 1..<match.numberOfRanges {
+                    guard match.range(at: capture).location != NSNotFound,
+                          let range = Range(match.range(at: capture), in: html)
+                    else { continue }
+                    result.insert(String(html[range]))
+                }
+            }
+        }
+        return result
+    }
+    static func copyLegacyProjects(from source: URL, to destination: URL) {
+        let marker = destination.appending(path: ".legacy-cache-migrated", directoryHint: .notDirectory)
+        guard !FileManager.default.fileExists(atPath: marker.path),
+              FileManager.default.fileExists(atPath: source.path),
+              let files = try? FileManager.default.contentsOfDirectory(at: source, includingPropertiesForKeys: nil)
+        else { return }
+        try? FileManager.default.createDirectory(at: destination, withIntermediateDirectories: true)
+        var completed = true
+        for file in files where file.pathExtension == "json" {
+            let target = destination.appending(path: file.lastPathComponent, directoryHint: .notDirectory)
+            guard !FileManager.default.fileExists(atPath: target.path) else { continue }
+            do { try FileManager.default.copyItem(at: file, to: target) }
+            catch { completed = false }
+        }
+        if completed { try? Data().write(to: marker, options: .atomic) }
     }
     private static func loadExamples(bundle: Bundle) -> [ArtifactProject] {
         guard let url = bundle.url(forResource: "manifest", withExtension: "json", subdirectory: "Examples"), let data = try? Data(contentsOf: url), let records = try? JSONDecoder().decode([ExampleArtifact].self, from: data) else { return [fallback] }

--- a/apps/ipad/Sources/Store/StudioStore.swift
+++ b/apps/ipad/Sources/Store/StudioStore.swift
@@ -102,10 +102,27 @@ struct StudioErrorPresentation { let title, message: String; let requestsWorksho
         let project = try await api.generate(request: request); upsert(project); open(project); return project
     }
     func remix(_ example: ArtifactProject) async throws {
-        let project = try await api.remix(
-            id: example.artifact.id,
-            revisionId: example.source.revision.id
-        )
+        let project: ArtifactProject
+        if example.artifact.id == "example-fallback" {
+            let artifact = example.artifact
+            project = try await api.generate(request: GuidedGenerationRequest(
+                creationBrief: artifact.creationBrief,
+                brief: .init(
+                    learnerContext: artifact.level ?? artifact.subject ?? "General learners",
+                    learningObjective: artifact.learningObjective ?? artifact.title,
+                    studentAction: artifact.summary,
+                    sourceContent: nil,
+                    feedback: "Provide clear feedback",
+                    classroomFit: "Use in a short classroom activity"
+                ),
+                preferredExampleRevisionId: nil
+            ))
+        } else {
+            project = try await api.remix(
+                id: example.artifact.id,
+                revisionId: example.source.revision.id
+            )
+        }
         upsert(project)
         open(project)
     }

--- a/apps/ipad/Sources/Store/StudioStore.swift
+++ b/apps/ipad/Sources/Store/StudioStore.swift
@@ -128,7 +128,6 @@ struct StudioErrorPresentation { let title, message: String; let requestsWorksho
             // The server may have expired the recovery copy already. The local
             // project must still remain deletable.
         }
-        projects.first(where: { $0.id == projectID })?.localAssets.forEach(LocalWidgetAssetStorage.remove)
         projects.removeAll { $0.id == projectID }
         let name = projectID.addingPercentEncoding(withAllowedCharacters: .alphanumerics) ?? projectID
         try? FileManager.default.removeItem(at: cacheDirectory.appending(path: "\(name).json"))

--- a/apps/ipad/Tests/StudioStoreTests.swift
+++ b/apps/ipad/Tests/StudioStoreTests.swift
@@ -72,6 +72,31 @@ final class StudioStoreTests: XCTestCase {
     }
 
     @MainActor
+    func testFallbackExampleCopyUsesGenerationWithoutServerRevision() async throws {
+        let fallback = makeProject(
+            artifactID: "example-fallback",
+            revisionID: "example-fallback-seed",
+            html: "<html>Fallback</html>"
+        )
+        let copy = makeProject(revisionID: "copy-revision", html: "<html>Copy</html>")
+        let api = ArtifactAPIStub(generated: copy, revised: copy)
+        let store = StudioStore(
+            api: api,
+            storageDirectory: temporaryDirectory(),
+            bundle: Bundle(for: Self.self)
+        )
+
+        try await store.remix(fallback)
+
+        let generation = await api.lastGenerationRequest
+        let remix = await api.lastRemixRequest
+        XCTAssertEqual(generation?.creationBrief, fallback.artifact.creationBrief)
+        XCTAssertNil(generation?.preferredExampleRevisionId)
+        XCTAssertNil(remix)
+        XCTAssertEqual(store.selectedProjectID, copy.id)
+    }
+
+    @MainActor
     func testMissingCredentialAndRegistrationErrorReopenWorkshopAccess() async {
         let project = makeProject(revisionID: "r1", html: "<html></html>")
         let api = ArtifactAPIStub(

--- a/apps/ipad/Tests/StudioStoreTests.swift
+++ b/apps/ipad/Tests/StudioStoreTests.swift
@@ -109,6 +109,22 @@ final class StudioStoreTests: XCTestCase {
     }
 
     @MainActor
+    func testSuccessfulCredentialRefreshDoesNotCloseManuallyOpenedAccess() async {
+        let project = makeProject(revisionID: "r1", html: "<html></html>")
+        let store = StudioStore(
+            api: ArtifactAPIStub(generated: project, revised: project),
+            storageDirectory: temporaryDirectory(),
+            bundle: Bundle(for: Self.self)
+        )
+        store.requestWorkshopAccess()
+
+        await store.refreshWorkshopAccess()
+
+        XCTAssertEqual(store.workshopAccessState, .ready)
+        XCTAssertTrue(store.showsWorkshopAccess)
+    }
+
+    @MainActor
     func testRestoreContinuesAfterOneArtifactFails() async throws {
         let failed = makeProject(
             artifactID: "failed",
@@ -142,9 +158,42 @@ final class StudioStoreTests: XCTestCase {
     }
 
     @MainActor
+    func testRestorePropagatesRegistrationFailures() async {
+        let project = makeProject(revisionID: "r1", html: "<html></html>")
+        let api = ArtifactAPIStub(
+            generated: project,
+            revised: project,
+            artifactErrors: [project.id: .registrationRequired]
+        )
+        let store = StudioStore(
+            api: api,
+            storageDirectory: temporaryDirectory(),
+            bundle: Bundle(for: Self.self)
+        )
+
+        do {
+            _ = try await store.restoreFromStudio()
+            XCTFail("Expected registration to be requested")
+        } catch let error as StudioAPIError {
+            XCTAssertTrue(error.requiresRegistration)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+        XCTAssertEqual(store.workshopAccessState, .registrationRequired)
+        XCTAssertTrue(store.showsWorkshopAccess)
+    }
+
+    @MainActor
     func testDeleteRemovesLocalProjectWhenServerCopyHasExpired() async throws {
         let directory = temporaryDirectory()
-        let project = makeProject(revisionID: "r1", html: "<html></html>")
+        var project = makeProject(revisionID: "r1", html: "<html></html>")
+        project.artifact.publication = ArtifactPublication(
+            slug: "expired-link",
+            url: URL(string: "https://example.test/expired-link")!,
+            title: "Forces",
+            createdAt: "1999-08-02T00:00:00Z",
+            expiresAt: "2000-08-02T00:00:00Z"
+        )
         let api = ArtifactAPIStub(
             generated: project,
             revised: project,
@@ -169,6 +218,78 @@ final class StudioStoreTests: XCTestCase {
             bundle: Bundle(for: Self.self)
         )
         XCTAssertTrue(restored.projects.isEmpty)
+    }
+
+    @MainActor
+    func testDeleteKeepsLocalProjectWhenMissingRemoteMayStillBePublished() async {
+        var project = makeProject(revisionID: "r1", html: "<html></html>")
+        project.artifact.publication = ArtifactPublication(
+            slug: "active-link",
+            url: URL(string: "https://example.test/active-link")!,
+            title: "Forces",
+            createdAt: "2026-08-02T00:00:00Z",
+            expiresAt: "2099-11-02T00:00:00Z"
+        )
+        let api = ArtifactAPIStub(
+            generated: project,
+            revised: project,
+            deleteError: .server(404, "ARTIFACT_NOT_FOUND", "Missing artifact")
+        )
+        let store = StudioStore(
+            api: api,
+            storageDirectory: temporaryDirectory(),
+            bundle: Bundle(for: Self.self)
+        )
+        var brief = GuidedBriefDraft()
+        brief.learningObjective = "Forces"
+        brief.studentAction = "Choose"
+        _ = try await store.createApprovedBrief(brief)
+
+        do {
+            try await store.deleteProject(projectID: project.id)
+            XCTFail("Expected deletion to preserve the active publication record")
+        } catch let error as StudioAPIError {
+            XCTAssertTrue(error.isArtifactNotFound)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+        XCTAssertEqual(store.projects.map(\.id), [project.id])
+    }
+
+    @MainActor
+    func testDeleteKeepsLocalProjectWhenPublicationExpiryIsMalformed() async throws {
+        var project = makeProject(revisionID: "r1", html: "<html></html>")
+        project.artifact.publication = ArtifactPublication(
+            slug: "unknown-expiry-link",
+            url: URL(string: "https://example.test/unknown-expiry-link")!,
+            title: "Forces",
+            createdAt: "2026-08-02T00:00:00Z",
+            expiresAt: "not-a-date"
+        )
+        let api = ArtifactAPIStub(
+            generated: project,
+            revised: project,
+            deleteError: .server(404, "ARTIFACT_NOT_FOUND", "Missing artifact")
+        )
+        let store = StudioStore(
+            api: api,
+            storageDirectory: temporaryDirectory(),
+            bundle: Bundle(for: Self.self)
+        )
+        var brief = GuidedBriefDraft()
+        brief.learningObjective = "Forces"
+        brief.studentAction = "Choose"
+        _ = try await store.createApprovedBrief(brief)
+
+        do {
+            try await store.deleteProject(projectID: project.id)
+            XCTFail("Expected deletion to preserve the publication record")
+        } catch let error as StudioAPIError {
+            XCTAssertTrue(error.isArtifactNotFound)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+        XCTAssertEqual(store.projects.map(\.id), [project.id])
     }
 
     func testAssetExtractionMatchesManagedHtmlReferencesOnly() {

--- a/apps/ipad/Tests/StudioStoreTests.swift
+++ b/apps/ipad/Tests/StudioStoreTests.swift
@@ -51,36 +51,88 @@ final class StudioStoreTests: XCTestCase {
     }
 
     @MainActor
-    func testMissingCredentialAndRegistrationErrorRequestWorkshopAccess() async {
+    func testExampleCopyUsesExactRemixWithoutGeneration() async throws {
+        let example = makeProject(revisionID: "seed-revision", html: "<html>Seed</html>")
+        let copy = makeProject(revisionID: "copy-revision", html: "<html>Seed</html>")
+        let api = ArtifactAPIStub(generated: example, revised: copy)
+        let store = StudioStore(
+            api: api,
+            storageDirectory: temporaryDirectory(),
+            bundle: Bundle(for: Self.self)
+        )
+
+        try await store.remix(example)
+
+        let remix = await api.lastRemixRequest
+        let generation = await api.lastGenerationRequest
+        XCTAssertEqual(remix?.artifactID, example.artifact.id)
+        XCTAssertEqual(remix?.revisionID, example.source.revision.id)
+        XCTAssertNil(generation)
+        XCTAssertEqual(store.selectedProjectID, copy.id)
+    }
+
+    @MainActor
+    func testMissingCredentialAndRegistrationErrorReopenWorkshopAccess() async {
         let project = makeProject(revisionID: "r1", html: "<html></html>")
-        let api = ArtifactAPIStub(generated: project, revised: project, hasCredential: false)
-        let store = StudioStore(api: api, storageDirectory: temporaryDirectory(), bundle: Bundle(for: Self.self))
+        let api = ArtifactAPIStub(
+            generated: project,
+            revised: project,
+            hasCredential: false
+        )
+        let store = StudioStore(
+            api: api,
+            storageDirectory: temporaryDirectory(),
+            bundle: Bundle(for: Self.self)
+        )
 
         await store.refreshWorkshopAccess()
-
         XCTAssertEqual(store.workshopAccessState, .registrationRequired)
         XCTAssertTrue(store.showsWorkshopAccess)
 
         store.dismissWorkshopAccess()
         let presentation = store.present(
-            StudioAPIError.server(401, "DEVICE_REGISTRATION_REQUIRED", "Registration required"),
+            StudioAPIError.server(401, "DEVICE_REGISTRATION_REQUIRED", "Register again"),
             during: .generation
         )
+
         XCTAssertTrue(presentation.requestsWorkshopAccess)
+        XCTAssertEqual(store.workshopAccessState, .registrationRequired)
+        XCTAssertTrue(store.showsWorkshopAccess)
+
+        store.dismissWorkshopAccess()
+        let localPresentation = store.present(
+            StudioAPIError.registrationRequired,
+            during: .generation
+        )
+        XCTAssertTrue(localPresentation.requestsWorkshopAccess)
         XCTAssertTrue(store.showsWorkshopAccess)
     }
 
     @MainActor
     func testRestoreContinuesAfterOneArtifactFails() async throws {
-        let failed = makeProject(artifactID: "failed", revisionID: "r1", html: "<html>Failed</html>")
-        let restored = makeProject(artifactID: "restored", revisionID: "r2", html: "<html>Restored</html>")
+        let failed = makeProject(
+            artifactID: "failed",
+            revisionID: "r1",
+            html: "<html>Failed</html>"
+        )
+        let restored = makeProject(
+            artifactID: "restored",
+            revisionID: "r2",
+            html: "<html>Restored</html>"
+        )
         let api = ArtifactAPIStub(
             generated: restored,
             revised: restored,
             listedArtifacts: [failed.artifact, restored.artifact],
-            artifactErrors: [failed.id: .server(404, "SOURCE_NOT_FOUND", "Missing source")]
+            artifactErrors: [
+                failed.id: .server(404, "SOURCE_NOT_FOUND", "Missing source")
+            ]
         )
-        let store = StudioStore(api: api, storageDirectory: temporaryDirectory(), bundle: Bundle(for: Self.self))
+        let store = StudioStore(
+            api: api,
+            storageDirectory: temporaryDirectory(),
+            bundle: Bundle(for: Self.self)
+        )
 
         let count = try await store.restoreFromStudio()
 
@@ -98,7 +150,11 @@ final class StudioStoreTests: XCTestCase {
             revised: project,
             deleteError: .server(404, "ARTIFACT_NOT_FOUND", "Missing artifact")
         )
-        let store = StudioStore(api: api, storageDirectory: directory, bundle: Bundle(for: Self.self))
+        let store = StudioStore(
+            api: api,
+            storageDirectory: directory,
+            bundle: Bundle(for: Self.self)
+        )
         var brief = GuidedBriefDraft()
         brief.learningObjective = "Forces"
         brief.studentAction = "Choose"
@@ -107,10 +163,59 @@ final class StudioStoreTests: XCTestCase {
         try await store.deleteProject(projectID: project.id)
 
         XCTAssertTrue(store.projects.isEmpty)
-        let restored = StudioStore(api: api, storageDirectory: directory, bundle: Bundle(for: Self.self))
+        let restored = StudioStore(
+            api: api,
+            storageDirectory: directory,
+            bundle: Bundle(for: Self.self)
+        )
         XCTAssertTrue(restored.projects.isEmpty)
     }
 
+    func testAssetExtractionMatchesManagedHtmlReferencesOnly() {
+        let html = """
+        <img src="assets/image-one">
+        <a href=' assets/image-two '>Image</a>
+        <style>.card { background: url(assets/image-three) }</style>
+        <script>const example = "assets/not-a-reference";</script>
+        """
+
+        XCTAssertEqual(
+            StudioStore.referencedAssetIDs(in: html),
+            ["image-one", "image-two", "image-three"]
+        )
+    }
+
+    func testLegacyCacheMigrationCopiesOnlyProjectFilesWithoutOverwriting() throws {
+        let root = temporaryDirectory()
+        let source = root.appending(path: "legacy", directoryHint: .isDirectory)
+        let destination = root.appending(path: "support", directoryHint: .isDirectory)
+        try FileManager.default.createDirectory(at: source, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: destination, withIntermediateDirectories: true)
+        try Data("legacy".utf8).write(to: source.appending(path: "project.json"))
+        try Data("ignore".utf8).write(to: source.appending(path: "notes.txt"))
+        try Data("current".utf8).write(to: destination.appending(path: "current.json"))
+
+        StudioStore.copyLegacyProjects(from: source, to: destination)
+
+        XCTAssertEqual(
+            try String(contentsOf: destination.appending(path: "project.json"), encoding: .utf8),
+            "legacy"
+        )
+        XCTAssertEqual(
+            try String(contentsOf: destination.appending(path: "current.json"), encoding: .utf8),
+            "current"
+        )
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: destination.appending(path: "notes.txt").path)
+        )
+
+        try FileManager.default.removeItem(at: destination.appending(path: "project.json"))
+        StudioStore.copyLegacyProjects(from: source, to: destination)
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: destination.appending(path: "project.json").path),
+            "A one-time migration must not resurrect a project deleted from Application Support."
+        )
+    }
     private func temporaryDirectory() -> URL {
         FileManager.default.temporaryDirectory
             .appending(path: "StudioStoreTests-\(UUID().uuidString)", directoryHint: .isDirectory)
@@ -122,6 +227,10 @@ private actor ArtifactAPIStub: StudioAPI {
         let instruction: String
         let expectedHeadRevisionID: String
     }
+    struct RemixRequest: Sendable {
+        let artifactID: String
+        let revisionID: String?
+    }
 
     let generated: ArtifactProject
     let revised: ArtifactProject
@@ -131,6 +240,7 @@ private actor ArtifactAPIStub: StudioAPI {
     let deleteError: StudioAPIError?
     private(set) var lastGenerationRequest: GuidedGenerationRequest?
     private(set) var lastRevisionRequest: RevisionRequest?
+    private(set) var lastRemixRequest: RemixRequest?
 
     init(
         generated: ArtifactProject,
@@ -161,7 +271,9 @@ private actor ArtifactAPIStub: StudioAPI {
         return generated
     }
     func updateArtifact(_ artifact: Artifact) async throws -> Artifact { artifact }
-    func deleteArtifact(id: String) async throws { if let deleteError { throw deleteError } }
+    func deleteArtifact(id: String) async throws {
+        if let deleteError { throw deleteError }
+    }
     func revise(id: String, instruction: String, expectedHeadRevisionId: String) async throws -> ArtifactProject {
         lastRevisionRequest = RevisionRequest(
             instruction: instruction,
@@ -172,7 +284,10 @@ private actor ArtifactAPIStub: StudioAPI {
     func revisions(id: String) async throws -> [ArtifactRevision] { generated.revisions }
     func source(revision: ArtifactRevision) async throws -> ArtifactSource { generated.source }
     func setHead(id: String, revisionId: String, expectedHeadRevisionId: String) async throws -> ArtifactProject { revised }
-    func remix(id: String, revisionId: String?) async throws -> ArtifactProject { revised }
+    func remix(id: String, revisionId: String?) async throws -> ArtifactProject {
+        lastRemixRequest = RemixRequest(artifactID: id, revisionID: revisionId)
+        return revised
+    }
     func downloadAsset(id: String) async throws -> DownloadedWidgetAsset {
         DownloadedWidgetAsset(data: Data([1, 2, 3]), mediaType: "image/jpeg")
     }

--- a/apps/ipad/Tests/StudioStoreTests.swift
+++ b/apps/ipad/Tests/StudioStoreTests.swift
@@ -221,7 +221,7 @@ final class StudioStoreTests: XCTestCase {
     }
 
     @MainActor
-    func testDeleteKeepsLocalProjectWhenMissingRemoteMayStillBePublished() async {
+    func testDeleteKeepsLocalProjectWhenMissingRemoteMayStillBePublished() async throws {
         var project = makeProject(revisionID: "r1", html: "<html></html>")
         project.artifact.publication = ArtifactPublication(
             slug: "active-link",
@@ -292,6 +292,7 @@ final class StudioStoreTests: XCTestCase {
         XCTAssertEqual(store.projects.map(\.id), [project.id])
     }
 
+    @MainActor
     func testAssetExtractionMatchesManagedHtmlReferencesOnly() {
         let html = """
         <img src="assets/image-one">
@@ -306,6 +307,7 @@ final class StudioStoreTests: XCTestCase {
         )
     }
 
+    @MainActor
     func testLegacyCacheMigrationCopiesOnlyProjectFilesWithoutOverwriting() throws {
         let root = temporaryDirectory()
         let source = root.appending(path: "legacy", directoryHint: .isDirectory)

--- a/apps/ipad/Tests/StudioStoreTests.swift
+++ b/apps/ipad/Tests/StudioStoreTests.swift
@@ -50,6 +50,67 @@ final class StudioStoreTests: XCTestCase {
         XCTAssertEqual(store.projects.first?.source.html, revised.source.html)
     }
 
+    @MainActor
+    func testMissingCredentialAndRegistrationErrorRequestWorkshopAccess() async {
+        let project = makeProject(revisionID: "r1", html: "<html></html>")
+        let api = ArtifactAPIStub(generated: project, revised: project, hasCredential: false)
+        let store = StudioStore(api: api, storageDirectory: temporaryDirectory(), bundle: Bundle(for: Self.self))
+
+        await store.refreshWorkshopAccess()
+
+        XCTAssertEqual(store.workshopAccessState, .registrationRequired)
+        XCTAssertTrue(store.showsWorkshopAccess)
+
+        store.dismissWorkshopAccess()
+        let presentation = store.present(
+            StudioAPIError.server(401, "DEVICE_REGISTRATION_REQUIRED", "Registration required"),
+            during: .generation
+        )
+        XCTAssertTrue(presentation.requestsWorkshopAccess)
+        XCTAssertTrue(store.showsWorkshopAccess)
+    }
+
+    @MainActor
+    func testRestoreContinuesAfterOneArtifactFails() async throws {
+        let failed = makeProject(artifactID: "failed", revisionID: "r1", html: "<html>Failed</html>")
+        let restored = makeProject(artifactID: "restored", revisionID: "r2", html: "<html>Restored</html>")
+        let api = ArtifactAPIStub(
+            generated: restored,
+            revised: restored,
+            listedArtifacts: [failed.artifact, restored.artifact],
+            artifactErrors: [failed.id: .server(404, "SOURCE_NOT_FOUND", "Missing source")]
+        )
+        let store = StudioStore(api: api, storageDirectory: temporaryDirectory(), bundle: Bundle(for: Self.self))
+
+        let count = try await store.restoreFromStudio()
+
+        XCTAssertEqual(count, 1)
+        XCTAssertEqual(store.projects.map(\.id), [restored.id])
+        XCTAssertNotNil(store.recoveryNotice)
+    }
+
+    @MainActor
+    func testDeleteRemovesLocalProjectWhenServerCopyHasExpired() async throws {
+        let directory = temporaryDirectory()
+        let project = makeProject(revisionID: "r1", html: "<html></html>")
+        let api = ArtifactAPIStub(
+            generated: project,
+            revised: project,
+            deleteError: .server(404, "ARTIFACT_NOT_FOUND", "Missing artifact")
+        )
+        let store = StudioStore(api: api, storageDirectory: directory, bundle: Bundle(for: Self.self))
+        var brief = GuidedBriefDraft()
+        brief.learningObjective = "Forces"
+        brief.studentAction = "Choose"
+        _ = try await store.createApprovedBrief(brief)
+
+        try await store.deleteProject(projectID: project.id)
+
+        XCTAssertTrue(store.projects.isEmpty)
+        let restored = StudioStore(api: api, storageDirectory: directory, bundle: Bundle(for: Self.self))
+        XCTAssertTrue(restored.projects.isEmpty)
+    }
+
     private func temporaryDirectory() -> URL {
         FileManager.default.temporaryDirectory
             .appending(path: "StudioStoreTests-\(UUID().uuidString)", directoryHint: .isDirectory)
@@ -64,25 +125,43 @@ private actor ArtifactAPIStub: StudioAPI {
 
     let generated: ArtifactProject
     let revised: ArtifactProject
+    let hasCredential: Bool
+    let listedArtifacts: [Artifact]
+    let artifactErrors: [String: StudioAPIError]
+    let deleteError: StudioAPIError?
     private(set) var lastGenerationRequest: GuidedGenerationRequest?
     private(set) var lastRevisionRequest: RevisionRequest?
 
-    init(generated: ArtifactProject, revised: ArtifactProject) {
+    init(
+        generated: ArtifactProject,
+        revised: ArtifactProject,
+        hasCredential: Bool = true,
+        listedArtifacts: [Artifact]? = nil,
+        artifactErrors: [String: StudioAPIError] = [:],
+        deleteError: StudioAPIError? = nil
+    ) {
         self.generated = generated
         self.revised = revised
+        self.hasCredential = hasCredential
+        self.listedArtifacts = listedArtifacts ?? [generated.artifact]
+        self.artifactErrors = artifactErrors
+        self.deleteError = deleteError
     }
 
-    func hasDeviceCredential() async -> Bool { true }
+    func hasDeviceCredential() async -> Bool { hasCredential }
     func registerDevice(accessCode: String) async throws {}
     func generate(request: GuidedGenerationRequest) async throws -> ArtifactProject {
         lastGenerationRequest = request
         return generated
     }
-    func listArtifacts() async throws -> [Artifact] { [generated.artifact] }
+    func listArtifacts() async throws -> [Artifact] { listedArtifacts }
     func searchExamples(brief: String) async throws -> [ExampleSearchDescriptor] { [] }
-    func getArtifact(id: String) async throws -> ArtifactProject { generated }
+    func getArtifact(id: String) async throws -> ArtifactProject {
+        if let error = artifactErrors[id] { throw error }
+        return generated
+    }
     func updateArtifact(_ artifact: Artifact) async throws -> Artifact { artifact }
-    func deleteArtifact(id: String) async throws {}
+    func deleteArtifact(id: String) async throws { if let deleteError { throw deleteError } }
     func revise(id: String, instruction: String, expectedHeadRevisionId: String) async throws -> ArtifactProject {
         lastRevisionRequest = RevisionRequest(
             instruction: instruction,
@@ -132,11 +211,11 @@ private actor ArtifactAPIStub: StudioAPI {
 }
 
 private func makeProject(
+    artifactID: String = "artifact-1",
     revisionID: String,
     parentRevisionID: String? = nil,
     html: String
 ) -> ArtifactProject {
-    let artifactID = "artifact-1"
     let timestamp = "2026-08-02T00:00:00Z"
     let revision = ArtifactRevision(
         id: revisionID,

--- a/apps/ipad/UITests/ClassroomWidgetsStudioUITests.swift
+++ b/apps/ipad/UITests/ClassroomWidgetsStudioUITests.swift
@@ -5,14 +5,14 @@ final class ClassroomWidgetsStudioUITests: XCTestCase {
     func testLaunchesIntoExploreWithoutABlankCanvas() {
         let app = launchApp()
         XCTAssertTrue(app.staticTexts["Start with an example"].waitForExistence(timeout: 8))
-        XCTAssertTrue(app.staticTexts["Balanced Forces Check"].exists)
+        XCTAssertTrue(app.staticTexts["Catchment Under Pressure — Runoff Lab"].exists)
         XCTAssertTrue(app.buttons.matching(NSPredicate(format: "label == 'Try as student'")).firstMatch.exists)
     }
 
     @MainActor
     func testExploreOffersBundledHTMLSeedForRemixing() {
         let app = launchApp()
-        XCTAssertTrue(app.staticTexts["Balanced Forces Check"].waitForExistence(timeout: 8))
+        XCTAssertTrue(app.staticTexts["Catchment Under Pressure — Runoff Lab"].waitForExistence(timeout: 8))
         XCTAssertTrue(app.buttons["Make a copy"].exists)
     }
 
@@ -24,7 +24,7 @@ final class ClassroomWidgetsStudioUITests: XCTestCase {
         XCTAssertTrue(preview.waitForExistence(timeout: 8))
         preview.tap()
 
-        let playerHeading = app.staticTexts["Are the forces balanced?"]
+        let playerHeading = app.staticTexts["Catchment Under Pressure"]
         XCTAssertTrue(
             playerHeading.waitForExistence(timeout: 25),
             "The bundled HTML artifact should render, not a blank web view."

--- a/evals/model/README.md
+++ b/evals/model/README.md
@@ -1,10 +1,10 @@
 # Live HTML artifact evaluation
 
-This harness evaluates an OpenAI-compatible provider against classroom briefs
-for the Studio HTML rewrite. The canonical output shape is `{html,
-designCard?}`. `artifact-eval.mjs` parses plain or fenced JSON, applies the same
-checks used by the seed corpus, and heuristically checks requested interaction,
-locale and content markers.
+This harness runs the Studio API's production provider, prompts, output checks
+and one-repair path against classroom briefs. Each request includes up to two
+reviewed, subject-matched HTML exemplars. `artifact-eval.mjs` adds the seed
+corpus render checks and heuristically checks requested interaction, locale and
+content markers.
 
 Run the focused helper tests without provider credentials:
 

--- a/evals/model/run.ts
+++ b/evals/model/run.ts
@@ -1,10 +1,20 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { resolve } from "node:path";
+import { OpenAiCompatibleProvider } from "../../services/studio-api/src/ai/openAiCompatibleProvider";
+import type {
+  DesignCard,
+  Exemplar,
+  TeacherBrief,
+} from "../../services/studio-api/src/ai/provider";
+import {
+  InvalidModelOutputError,
+  validateHtmlOutput,
+} from "../../services/studio-api/src/generation";
 import { assessArtifact } from "./artifact-eval.mjs";
 
 interface EvalCase {
   id: string;
-  brief: Record<string, unknown>;
+  brief: TeacherBrief;
   locale: string;
   expectedInteractions: string[];
   contentTerms: string[];
@@ -17,6 +27,17 @@ interface Manifest {
   cases: EvalCase[];
 }
 
+interface SeedManifest {
+  seeds: Array<{
+    id: string;
+    filename: string;
+    subject: string;
+    level: string;
+    descriptor: string;
+    designCard: DesignCard;
+  }>;
+}
+
 const repoRoot = resolve(process.env.INIT_CWD ?? process.cwd());
 const model = process.env.EVAL_MODEL ?? "deepseek-v4-flash";
 const baseUrl = (
@@ -27,69 +48,88 @@ if (!apiKey)
   throw new Error(
     "Set DEEPSEEK_API_KEY or AI_API_KEY to run the live artifact eval.",
   );
+const provider = new OpenAiCompatibleProvider({ baseUrl, apiKey, model });
 
-async function complete(
-  messages: Array<{ role: string; content: string }>,
-): Promise<string> {
-  const response = await fetch(`${baseUrl}/chat/completions`, {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${apiKey}`,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({
-      model,
-      response_format: { type: "json_object" },
-      messages,
-    }),
-  });
-  const body = (await response.json()) as {
-    choices?: Array<{ message?: { content?: string } }>;
-    error?: { message?: string };
-  };
-  const content = body.choices?.[0]?.message?.content;
-  if (!response.ok || !content)
-    throw new Error(
-      body.error?.message ?? `Provider returned HTTP ${response.status}.`,
-    );
-  return content;
+function serialise(candidate: unknown): string {
+  return typeof candidate === "string" ? candidate : JSON.stringify(candidate);
 }
 
-async function evaluate(entry: EvalCase) {
-  const system =
-    'Create one compact classroom widget as a complete, readable, self-contained HTML document with inline CSS and JavaScript. Use no packages, external assets, or network requests. Make controls touch-friendly and normally fit one screen. Return only JSON: {"html":"...","designCard":{"layout":"...","accent":"...","interaction":"..."}}.';
+function normalise(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+}
+
+async function loadExemplars(): Promise<Exemplar[]> {
+  const directory = resolve(repoRoot, "examples/studio-html");
+  const manifest = JSON.parse(
+    await readFile(resolve(directory, "manifest.json"), "utf8"),
+  ) as SeedManifest;
+  return Promise.all(
+    manifest.seeds.map(async (seed) => ({
+      revisionId: `${seed.id}-seed`,
+      html: await readFile(resolve(directory, seed.filename), "utf8"),
+      designCard: seed.designCard,
+      descriptor: seed.descriptor,
+    })),
+  );
+}
+
+async function evaluate(entry: EvalCase, seeds: Exemplar[], manifest: SeedManifest) {
   const request = {
     locale: entry.locale,
     expectedInteractions: entry.expectedInteractions,
     contentTerms: entry.contentTerms,
   };
+  const subject = normalise(entry.brief.subject);
+  const level = normalise(entry.brief.level);
+  const exemplars = manifest.seeds
+    .map((seed, index) => ({ seed, exemplar: seeds[index]! }))
+    .filter(({ seed }) => normalise(seed.subject) === subject)
+    .sort(
+      (a, b) =>
+        Number(normalise(b.seed.level) === level) -
+        Number(normalise(a.seed.level) === level),
+    )
+    .slice(0, 2)
+    .map(({ exemplar }) => exemplar);
   const started = performance.now();
-  const messages = [
-    { role: "system", content: system },
-    { role: "user", content: JSON.stringify(entry.brief) },
-  ];
-  let output = await complete(messages);
-  let assessment = assessArtifact(output, request);
-  const firstPassValid = assessment.valid;
-  let repairAttempts = 0;
-  while (!assessment.valid && repairAttempts < 1) {
-    repairAttempts += 1;
-    messages.push({ role: "assistant", content: output });
-    messages.push({
-      role: "user",
-      content: `Repair the artifact and return the same JSON shape. Findings: ${assessment.issues.map((issue: { code: string; message: string }) => `${issue.code}: ${issue.message}`).join("; ")}`,
-    });
-    output = await complete(messages);
-    assessment = assessArtifact(output, request);
+  let output = await provider.generate(entry.brief, exemplars);
+  let productionIssues: string[] = [];
+  let productionValid = false;
+  try {
+    output = validateHtmlOutput(output);
+    productionValid = true;
+  } catch (error) {
+    if (!(error instanceof InvalidModelOutputError)) throw error;
+    productionIssues = error.issues;
   }
+  const firstAssessment = assessArtifact(serialise(output), request);
+  const firstPassValid = productionValid && firstAssessment.valid;
+  let repairAttempts = 0;
+  if (!productionValid) {
+    repairAttempts += 1;
+    output = await provider.repair(output, productionIssues);
+    try {
+      output = validateHtmlOutput(output);
+      productionValid = true;
+      productionIssues = [];
+    } catch (error) {
+      if (!(error instanceof InvalidModelOutputError)) throw error;
+      productionIssues = error.issues;
+    }
+  }
+  const assessment = assessArtifact(serialise(output), request);
   return {
     id: entry.id,
     firstPassValid,
-    finalValid: assessment.valid,
+    finalValid: productionValid && assessment.valid,
     repairAttempts,
     latencyMs: Math.round(performance.now() - started),
+    exemplarRevisionIds: exemplars.map((exemplar) => exemplar.revisionId),
     heuristicChecks: assessment.checks,
-    issues: assessment.issues,
+    issues: [
+      ...productionIssues.map((message) => ({ code: "production", message })),
+      ...assessment.issues,
+    ],
   };
 }
 
@@ -100,10 +140,17 @@ async function main() {
       "utf8",
     ),
   ) as Manifest;
+  const seedManifest = JSON.parse(
+    await readFile(
+      resolve(repoRoot, "examples/studio-html/manifest.json"),
+      "utf8",
+    ),
+  ) as SeedManifest;
+  const exemplars = await loadExemplars();
   const results = [];
   for (const entry of manifest.cases) {
     process.stdout.write(`Evaluating ${entry.id}… `);
-    const result = await evaluate(entry);
+    const result = await evaluate(entry, exemplars, seedManifest);
     console.log(result.finalValid ? "valid" : "failed");
     results.push(result);
   }

--- a/scripts/lib/studio-html-artifact.mjs
+++ b/scripts/lib/studio-html-artifact.mjs
@@ -1,6 +1,6 @@
 import vm from 'node:vm';
 
-export const MAX_HTML_BYTES = 200 * 1024;
+export const MAX_HTML_BYTES = 200_000;
 
 const REQUIRED_MANIFEST_FIELDS = [
   'id',
@@ -92,7 +92,7 @@ export function validateSeedManifest(manifest, options = {}) {
     });
     if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(typeof seed.id === 'string' ? seed.id : '')) issues.push({ code: 'seed-id', message: `${label} has an unstable ID.` });
     if (!/^[a-z0-9-]+\.html$/.test(typeof seed.filename === 'string' ? seed.filename : '')) issues.push({ code: 'filename', message: `${label} has an invalid HTML filename.` });
-    if (!Array.isArray(seed.tags) || seed.tags.length < 3 || !seed.tags.every((tag) => typeof tag === 'string' && tag.trim())) issues.push({ code: 'tags', message: `${label} needs at least three non-empty string tags.` });
+    if (!Array.isArray(seed.tags) || seed.tags.length < 3 || seed.tags.length > 20 || !seed.tags.every((tag) => typeof tag === 'string' && tag.trim() && tag.length <= 50)) issues.push({ code: 'tags', message: `${label} needs 3–20 non-empty string tags of at most 50 characters.` });
     if (!seed.designCard || typeof seed.designCard !== 'object' || Array.isArray(seed.designCard)) issues.push({ code: 'design-card', message: `${label} needs an object designCard.` });
     for (const [value, set, name] of [[seed.id, ids, 'ID'], [seed.filename, filenames, 'filename'], [seed.title, titles, 'title']]) {
       if (set.has(value)) issues.push({ code: 'duplicate', message: `${label} duplicates ${name} ${value}.` });

--- a/scripts/studio-html-seeds.test.mjs
+++ b/scripts/studio-html-seeds.test.mjs
@@ -50,6 +50,8 @@ test('validates manifest uniqueness and required metadata', () => {
   const issues = validateSeedManifest({ schemaVersion: '1.0', seeds: [seed, { ...seed }] });
   assert.equal(issues.filter((issue) => issue.code === 'duplicate').length, 3);
   assert.equal(validateSeedManifest({ schemaVersion: '1.0', seeds: [seed] }, { expectedCount: 14 })[0].code, 'seed-count');
+  assert.equal(validateSeedManifest({ schemaVersion: '1.0', seeds: [{ ...seed, tags: Array(21).fill('tag') }] })[0].code, 'tags');
+  assert.equal(validateSeedManifest({ schemaVersion: '1.0', seeds: [{ ...seed, tags: ['a', 'b', 'x'.repeat(51)] }] })[0].code, 'tags');
 });
 
 test('builds a backend-neutral API record', () => {

--- a/services/studio-api/src/app.ts
+++ b/services/studio-api/src/app.ts
@@ -30,7 +30,7 @@ import {
 } from "./http";
 import { inspectTeacherBrief, inspectText } from "./moderation";
 import { PROMPT_VERSION } from "./ai/prompts";
-import type { SourceStore } from "./sourceStore";
+import { cleanupArtifactStorage, type SourceStore } from "./sourceStore";
 import type {
   ArtifactRecord,
   ContentReportReason,
@@ -38,7 +38,10 @@ import type {
   RevisionRecord,
   StudioRepository,
 } from "./storage/repository";
-import { CURATED_SEED_OWNER } from "./storage/repository";
+import {
+  CURATED_SEED_OWNER,
+  retrievalDescriptor,
+} from "./storage/repository";
 interface Deps {
   repository: StudioRepository;
   provider: ModelProvider;
@@ -666,10 +669,17 @@ export function createStudioApp(d: Deps) {
         throw new HttpError(404, "ARTIFACT_NOT_FOUND", "Artifact unavailable.");
       if (s.length === 3 && r.method === "GET")
         return json(await projectResponse(a, o, u.origin));
-      if (s.length === 3 && r.method === "DELETE")
-        return (await d.repository.deleteArtifact(a.id, o))
-          ? new Response(null, { status: 204 })
-          : apiError(404, "ARTIFACT_NOT_FOUND", "Unavailable");
+      if (s.length === 3 && r.method === "DELETE") {
+        const references = await d.repository.getArtifactStorageReferences(
+          a.id,
+          o,
+        );
+        if (!(await d.repository.deleteArtifact(a.id, o)))
+          return apiError(404, "ARTIFACT_NOT_FOUND", "Unavailable");
+        if (references)
+          await cleanupArtifactStorage(d.sources, references);
+        return new Response(null, { status: 204 });
+      }
       if (s.length === 3 && r.method === "PATCH") {
         const b = obj(await readJson(r, 10000));
         if (typeof b.title === "string" && b.headRevisionId === undefined)
@@ -852,7 +862,7 @@ export function createStudioApp(d: Deps) {
           rv,
           days(now(), d.config.publicationTtlDays),
           now().toISOString(),
-          html,
+          retrievalDescriptor(a, rv.designCard),
         );
         if (!p)
           throw new HttpError(

--- a/services/studio-api/src/index.ts
+++ b/services/studio-api/src/index.ts
@@ -5,7 +5,7 @@ import { readConfig, type StudioEnv } from "./env";
 import { CloudflareImageSafetyInspector } from "./imageSafety";
 import { CloudflareImageNormalizer } from "./imageNormalizer";
 import { D1StudioRepository } from "./storage/d1Repository";
-import { R2SourceStore } from "./sourceStore";
+import { cleanupArtifactStorage, R2SourceStore } from "./sourceStore";
 import { PUBLIC_REPORT_MARKER } from "./generation";
 
 export default {
@@ -46,11 +46,14 @@ export default {
     const draftBefore = new Date(
       now.getTime() - 180 * 86_400_000,
     ).toISOString();
-    await repository.deleteExpiredArtifacts(
+    const sourceStore = new R2SourceStore(env.MEDIA);
+    const expired = await repository.deleteExpiredArtifacts(
       draftBefore,
       now.toISOString(),
       100,
     );
+    for (const references of expired)
+      await cleanupArtifactStorage(sourceStore, references);
     const before = new Date(now.getTime() - 7 * 86_400_000).toISOString();
     const assetStore = new CloudflareAssetStore(env.DB, env.MEDIA);
     await assetStore.cleanupOrphans(before, now.toISOString(), 100);
@@ -74,10 +77,11 @@ export function injectPublicHtml(source: string, slug: string): string {
     /<head(\s[^>]*)?>/i,
     (head) => `${head}<base href="/${slug}/">`,
   );
-  const injected = withBase.replace(/<\/body\s*>/i, `${report}</body>`);
-  if (injected === withBase || withBase === source)
+  const bodyClosings = [...withBase.matchAll(/<\/body\s*>/gi)];
+  const bodyClosing = bodyClosings.at(-1);
+  if (bodyClosing?.index === undefined || withBase === source)
     throw new Error("Stored widget source is not a complete HTML document.");
-  return injected;
+  return `${withBase.slice(0, bodyClosing.index)}${report}${bodyClosing[0]}${withBase.slice(bodyClosing.index + bodyClosing[0].length)}`;
 }
 
 async function servePublic(

--- a/services/studio-api/src/index.ts
+++ b/services/studio-api/src/index.ts
@@ -77,7 +77,11 @@ export function injectPublicHtml(source: string, slug: string): string {
     /<head(\s[^>]*)?>/i,
     (head) => `${head}<base href="/${slug}/">`,
   );
-  const bodyClosings = [...withBase.matchAll(/<\/body\s*>/gi)];
+  const structure = withBase.replace(
+    /<!--[\s\S]*?-->|<(script|style|textarea|title)\b[^>]*>[\s\S]*?<\/\1\s*>/gi,
+    (content) => " ".repeat(content.length),
+  );
+  const bodyClosings = [...structure.matchAll(/<\/body\s*>/gi)];
   const bodyClosing = bodyClosings.at(-1);
   if (bodyClosing?.index === undefined || withBase === source)
     throw new Error("Stored widget source is not a complete HTML document.");

--- a/services/studio-api/src/moderation.ts
+++ b/services/studio-api/src/moderation.ts
@@ -31,8 +31,8 @@ export function inspectTeacherBrief(brief: TeacherBrief): ModerationFinding[] {
 export function inspectHtml(html: string): ModerationFinding[] {
   return inspectText(
     html
-      .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, " ")
       .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, " ")
+      .replace(/<\/?script\b[^>]*>/gi, " ")
       .replace(/<[^>]+>/g, " "),
   );
 }

--- a/services/studio-api/src/moderation.ts
+++ b/services/studio-api/src/moderation.ts
@@ -29,11 +29,21 @@ export function inspectTeacherBrief(brief: TeacherBrief): ModerationFinding[] {
 }
 
 export function inspectHtml(html: string): ModerationFinding[] {
+  const scriptStrings = [...html.matchAll(/<script\b[^>]*>([\s\S]*?)<\/script>/gi)]
+    .flatMap((script) =>
+      [...(script[1] ?? "").matchAll(/(["'`])((?:\\[\s\S]|(?!\1)[^\\])*)\1/g)].map(
+        (literal) =>
+          literal[1] === "`"
+            ? (literal[2] ?? "").replace(/\$\{[\s\S]*?\}/g, " ")
+            : (literal[2] ?? ""),
+      ),
+    )
+    .join("\n");
   return inspectText(
-    html
+    `${html
       .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, " ")
-      .replace(/<\/?script\b[^>]*>/gi, " ")
-      .replace(/<[^>]+>/g, " "),
+      .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, " ")
+      .replace(/<[^>]+>/g, " ")}\n${scriptStrings}`,
   );
 }
 

--- a/services/studio-api/src/sourceStore.ts
+++ b/services/studio-api/src/sourceStore.ts
@@ -1,7 +1,10 @@
+import type { ArtifactStorageReferences } from "./storage/repository";
+
 export interface SourceStore {
   putSource(hash: string, html: string): Promise<void>;
   getSource(hash: string): Promise<string | null>;
   putScreenshot(revisionId: string, bytes: Uint8Array): Promise<string>;
+  deleteScreenshot(key: string): Promise<void>;
 }
 export class R2SourceStore implements SourceStore {
   constructor(private readonly bucket: R2Bucket) {}
@@ -21,6 +24,18 @@ export class R2SourceStore implements SourceStore {
     });
     return key;
   }
+  async deleteScreenshot(key: string) {
+    await this.bucket.delete(key);
+  }
+}
+
+export async function cleanupArtifactStorage(
+  store: SourceStore,
+  references: ArtifactStorageReferences,
+): Promise<void> {
+  await Promise.allSettled(
+    references.screenshotKeys.map((key) => store.deleteScreenshot(key)),
+  );
 }
 export class MemorySourceStore implements SourceStore {
   readonly sources = new Map<string, string>();
@@ -32,7 +47,11 @@ export class MemorySourceStore implements SourceStore {
     return this.sources.get(hash) ?? null;
   }
   async putScreenshot(id: string, bytes: Uint8Array) {
-    this.screens.set(id, bytes);
-    return `screens/${id}.jpg`;
+    const key = `screens/${id}.jpg`;
+    this.screens.set(key, bytes);
+    return key;
+  }
+  async deleteScreenshot(key: string) {
+    this.screens.delete(key);
   }
 }

--- a/services/studio-api/src/storage/d1Repository.ts
+++ b/services/studio-api/src/storage/d1Repository.ts
@@ -1,5 +1,6 @@
 import type {
   ArtifactRecord,
+  ArtifactStorageReferences,
   ContentReportInput,
   CreateArtifactInput,
   CuratedSeedInput,
@@ -9,7 +10,7 @@ import type {
   RevisionRecord,
   StudioRepository,
 } from "./repository";
-import { CURATED_SEED_OWNER } from "./repository";
+import { CURATED_SEED_OWNER, retrievalDescriptor } from "./repository";
 type Row = Record<string, string | number | null>;
 const art = (r: Row): ArtifactRecord => ({
   id: r.id as string,
@@ -217,6 +218,7 @@ ON CONFLICT(artifact_id) DO UPDATE SET revision_id=?2,descriptor=?3,curated=1,up
     m: import("./repository").ArtifactMetadata,
     n: string,
   ) {
+    const descriptor = retrievalDescriptor(m, null);
     await this.db.batch([
       this.p(
         "UPDATE artifacts SET title=?1,summary=?2,subject=?3,level=?4,locale=?5,learning_objective=?6,tags_json=?7,creation_brief=?8,updated_at=?9 WHERE id=?10 AND owner_hash=?11",
@@ -232,16 +234,33 @@ ON CONFLICT(artifact_id) DO UPDATE SET revision_id=?2,descriptor=?3,curated=1,up
         id,
         o,
       ),
-      // Touching the projection fires retrieval_au, which refreshes the FTS
-      // title copied from the artifact without changing retrieval eligibility.
       this.p(
-        "UPDATE retrieval_entries SET updated_at=?1 WHERE artifact_id=?2 AND EXISTS(SELECT 1 FROM artifacts WHERE id=?2 AND owner_hash=?3)",
+        "UPDATE retrieval_entries SET descriptor=?1||coalesce((SELECT char(10)||design_card_json FROM revisions WHERE id=retrieval_entries.revision_id),''),updated_at=?2 WHERE artifact_id=?3 AND EXISTS(SELECT 1 FROM artifacts WHERE id=?3 AND owner_hash=?4)",
+        descriptor,
         n,
         id,
         o,
       ),
     ]);
     return this.getArtifact(id, o);
+  }
+  async getArtifactStorageReferences(
+    id: string,
+    o: string,
+  ): Promise<ArtifactStorageReferences | null> {
+    const rows = (
+      await this.p(
+        "SELECT r.screenshot_key FROM revisions r JOIN artifacts a ON a.id=r.artifact_id WHERE a.id=?1 AND a.owner_hash=?2",
+        id,
+        o,
+      ).all<Row>()
+    ).results;
+    if (!rows.length) return null;
+    return {
+      screenshotKeys: rows.flatMap((row) =>
+        row.screenshot_key ? [row.screenshot_key as string] : [],
+      ),
+    };
   }
   async deleteArtifact(id: string, o: string) {
     const r = await this.p(
@@ -252,14 +271,52 @@ ON CONFLICT(artifact_id) DO UPDATE SET revision_id=?2,descriptor=?3,curated=1,up
     return r.results.length === 1;
   }
   async deleteExpiredArtifacts(b: string, n: string, l = 100) {
-    const r = await this.p(
-      "DELETE FROM artifacts WHERE id IN(SELECT a.id FROM artifacts a WHERE updated_at<?1 AND owner_hash<>?4 AND NOT EXISTS(SELECT 1 FROM publications p WHERE p.artifact_id=a.id AND revoked_at IS NULL AND expires_at>?2) LIMIT ?3)",
-      b,
-      n,
-      l,
-      CURATED_SEED_OWNER,
-    ).run();
-    return r.meta.changes ?? 0;
+    const rows = (
+      await this.p(
+        `WITH candidates AS (
+  SELECT a.id,a.owner_hash FROM artifacts a
+  WHERE updated_at<?1 AND owner_hash<>?4
+    AND NOT EXISTS(SELECT 1 FROM publications p WHERE p.artifact_id=a.id AND revoked_at IS NULL AND expires_at>?2)
+  LIMIT ?3
+)
+SELECT c.id,c.owner_hash,r.screenshot_key
+FROM candidates c JOIN revisions r ON r.artifact_id=c.id`,
+        b,
+        n,
+        l,
+        CURATED_SEED_OWNER,
+      ).all<Row>()
+    ).results;
+    const candidates = new Map<
+      string,
+      { ownerHash: string; references: ArtifactStorageReferences }
+    >();
+    for (const row of rows) {
+      const id = row.id as string;
+      const candidate = candidates.get(id) ?? {
+        ownerHash: row.owner_hash as string,
+        references: { screenshotKeys: [] },
+      };
+      if (row.screenshot_key)
+        candidate.references.screenshotKeys.push(row.screenshot_key as string);
+      candidates.set(id, candidate);
+    }
+    if (!candidates.size) return [];
+    const entries = [...candidates.entries()];
+    const results = await this.db.batch(
+      entries.map(([id, candidate]) =>
+        this.p(
+          "DELETE FROM artifacts WHERE id=?1 AND owner_hash=?2 AND updated_at<?3 AND NOT EXISTS(SELECT 1 FROM publications p WHERE p.artifact_id=artifacts.id AND p.revoked_at IS NULL AND p.expires_at>?4)",
+          id,
+          candidate.ownerHash,
+          b,
+          n,
+        ),
+      ),
+    );
+    return entries.flatMap(([, candidate], index) =>
+      (results[index]?.meta.changes ?? 0) === 1 ? [candidate.references] : [],
+    );
   }
   async getRevision(id: string) {
     const r = await this.p(
@@ -377,7 +434,7 @@ WHERE a.id=?2 AND a.owner_hash=?14 AND a.head_revision_id=?3`,
     r: RevisionRecord,
     e: string,
     n: string,
-    _html: string,
+    descriptor: string,
   ) {
     const publicationWrite = this.p(
       `INSERT INTO publications(slug,artifact_id,revision_id,owner_hash,title,source_hash,created_at,expires_at)
@@ -407,7 +464,7 @@ ON CONFLICT(artifact_id) DO UPDATE SET
   revision_id=?2,descriptor=?3,updated_at=?4`,
       a.id,
       r.id,
-      r.designCard ?? a.creationBrief,
+      descriptor,
       n,
       a.ownerHash,
     );

--- a/services/studio-api/src/storage/memoryRepository.ts
+++ b/services/studio-api/src/storage/memoryRepository.ts
@@ -1,5 +1,6 @@
 import type {
   ArtifactRecord,
+  ArtifactStorageReferences,
   ContentReportInput,
   CreateArtifactInput,
   CuratedSeedInput,
@@ -8,7 +9,7 @@ import type {
   RevisionRecord,
   StudioRepository,
 } from "./repository";
-import { CURATED_SEED_OWNER } from "./repository";
+import { CURATED_SEED_OWNER, retrievalDescriptor } from "./repository";
 export class MemoryStudioRepository implements StudioRepository {
   readonly artifacts = new Map<string, ArtifactRecord>();
   readonly revisions = new Map<string, RevisionRecord>();
@@ -92,15 +93,39 @@ export class MemoryStudioRepository implements StudioRepository {
     Object.assign(a, metadata);
     a.updatedAt = n;
     const retrieval = this.retrieval.get(id);
-    if (retrieval) retrieval.title = metadata.title;
+    if (retrieval) {
+      retrieval.title = metadata.title;
+      retrieval.descriptor = retrievalDescriptor(
+        metadata,
+        this.revisions.get(retrieval.revisionId)?.designCard ?? null,
+      );
+    }
     return structuredClone(a);
+  }
+  async getArtifactStorageReferences(
+    id: string,
+    o: string,
+  ): Promise<ArtifactStorageReferences | null> {
+    const artifact = this.artifacts.get(id);
+    if (!artifact || artifact.ownerHash !== o) return null;
+    const revisions = [...this.revisions.values()].filter(
+      (revision) => revision.artifactId === id,
+    );
+    return {
+      screenshotKeys: revisions.flatMap((revision) =>
+        revision.screenshotKey ? [revision.screenshotKey] : [],
+      ),
+    };
   }
   async deleteArtifact(id: string, o: string) {
     const a = this.artifacts.get(id);
     if (!a || a.ownerHash !== o) return false;
     this.artifacts.delete(id);
     for (const [k, r] of this.revisions)
-      if (r.artifactId === id) this.revisions.delete(k);
+      if (r.artifactId === id) {
+        this.revisions.delete(k);
+        this.revisionAssets.delete(k);
+      }
     for (const [k, p] of this.publications)
       if (p.artifactId === id) this.publications.delete(k);
     this.retrieval.delete(id);
@@ -117,8 +142,16 @@ export class MemoryStudioRepository implements StudioRepository {
           ),
       )
       .slice(0, l);
-    for (const x of a) await this.deleteArtifact(x.id, x.ownerHash);
-    return a.length;
+    const deleted: ArtifactStorageReferences[] = [];
+    for (const x of a) {
+      const references = await this.getArtifactStorageReferences(
+        x.id,
+        x.ownerHash,
+      );
+      if (references && (await this.deleteArtifact(x.id, x.ownerHash)))
+        deleted.push(references);
+    }
+    return deleted;
   }
   async getRevision(id: string) {
     const r = this.revisions.get(id);
@@ -213,7 +246,7 @@ export class MemoryStudioRepository implements StudioRepository {
     r: RevisionRecord,
     expiresAt: string,
     now: string,
-    html: string,
+    descriptor: string,
   ) {
     const current = this.artifacts.get(a.id);
     if (!current || current.headRevisionId !== r.id) return null;
@@ -243,8 +276,8 @@ export class MemoryStudioRepository implements StudioRepository {
       artifactId: a.id,
       revisionId: r.id,
       title: a.title,
-      descriptor: r.designCard ?? a.creationBrief,
-      html,
+      descriptor,
+      html: "",
       curated: false,
     });
     return structuredClone(p);

--- a/services/studio-api/src/storage/repository.ts
+++ b/services/studio-api/src/storage/repository.ts
@@ -40,7 +40,6 @@ export function retrievalDescriptor(
       ? `Learning objective: ${artifact.learningObjective}`
       : null,
     artifact.tags.length ? `Tags: ${artifact.tags.join(", ")}` : null,
-    artifact.creationBrief,
     designCard,
   ]
     .filter((value): value is string => !!value)

--- a/services/studio-api/src/storage/repository.ts
+++ b/services/studio-api/src/storage/repository.ts
@@ -26,6 +26,27 @@ export type ArtifactMetadata = Pick<
   | "tags"
   | "creationBrief"
 >;
+
+export function retrievalDescriptor(
+  artifact: ArtifactMetadata,
+  designCard: string | null,
+): string {
+  return [
+    artifact.summary,
+    artifact.subject ? `Subject: ${artifact.subject}` : null,
+    artifact.level ? `Level: ${artifact.level}` : null,
+    artifact.locale ? `Locale: ${artifact.locale}` : null,
+    artifact.learningObjective
+      ? `Learning objective: ${artifact.learningObjective}`
+      : null,
+    artifact.tags.length ? `Tags: ${artifact.tags.join(", ")}` : null,
+    artifact.creationBrief,
+    designCard,
+  ]
+    .filter((value): value is string => !!value)
+    .join("\n");
+}
+
 export interface RevisionRecord {
   id: string;
   artifactId: string;
@@ -81,6 +102,9 @@ export interface CreateArtifactInput {
 export interface CuratedSeedInput extends CreateArtifactInput {
   descriptor: string;
 }
+export interface ArtifactStorageReferences {
+  screenshotKeys: string[];
+}
 
 export const CURATED_SEED_OWNER = "studio-curated-seed";
 
@@ -104,12 +128,16 @@ export interface StudioRepository {
     metadata: ArtifactMetadata,
     now: string,
   ): Promise<ArtifactRecord | null>;
+  getArtifactStorageReferences(
+    id: string,
+    owner: string,
+  ): Promise<ArtifactStorageReferences | null>;
   deleteArtifact(id: string, owner: string): Promise<boolean>;
   deleteExpiredArtifacts(
     before: string,
     now: string,
     limit?: number,
-  ): Promise<number>;
+  ): Promise<ArtifactStorageReferences[]>;
   getRevision(id: string): Promise<RevisionRecord | null>;
   listRevisions(artifactId: string, owner: string): Promise<RevisionRecord[]>;
   createRevision(
@@ -142,7 +170,7 @@ export interface StudioRepository {
     revision: RevisionRecord,
     expiresAt: string,
     now: string,
-    html: string,
+    descriptor: string,
   ): Promise<PublicationRecord | null>;
   getActivePublicationForArtifact(
     id: string,

--- a/services/studio-api/test/app.test.ts
+++ b/services/studio-api/test/app.test.ts
@@ -144,6 +144,17 @@ describe("Studio API registration and public HTML", () => {
     );
   });
 
+  it("ignores body-closing text in trailing comments", () => {
+    const source =
+      "<!doctype html><html><head></head><body><main>Widget</main></body><!-- </body> --></html>";
+    const served = injectPublicHtml(source, "ABCDEFGHIJKLMNOPQRST");
+
+    expect(served.indexOf("data-studio-report")).toBeLessThan(
+      served.indexOf("</body>"),
+    );
+    expect(served).toContain("<!-- </body> -->");
+  });
+
   it("imports reviewed seeds into retrieval and uses a selected seed as generation context", async () => {
     const seed = {
       seedId: "fraction-equivalence-diagnostic",

--- a/services/studio-api/test/app.test.ts
+++ b/services/studio-api/test/app.test.ts
@@ -133,6 +133,17 @@ describe("Studio API registration and public HTML", () => {
     expect(source).not.toContain("<base");
   });
 
+  it("injects the report control at the closing body rather than script text", () => {
+    const source =
+      '<!doctype html><html><head></head><body><script>const closing = "</body>";</script></body></html>';
+    const served = injectPublicHtml(source, "ABCDEFGHIJKLMNOPQRST");
+
+    expect(served).toContain('const closing = "</body>";');
+    expect(served.indexOf("data-studio-report")).toBeGreaterThan(
+      served.indexOf("</script>"),
+    );
+  });
+
   it("imports reviewed seeds into retrieval and uses a selected seed as generation context", async () => {
     const seed = {
       seedId: "fraction-equivalence-diagnostic",
@@ -268,6 +279,42 @@ describe("Studio API registration and public HTML", () => {
     };
     expect(remixed.artifact.remixedFromRevisionId).toBe(first.headRevision.id);
     expect(remixed.headRevision.parentRevisionId).toBeNull();
+  });
+
+  it("removes deleted screenshots without racing shared content-addressed sources", async () => {
+    const generated = await app.fetch(
+      authenticated("/v1/artifacts/generate", "POST", creationBrief),
+    );
+    const first = (await generated.json()) as {
+      artifact: { id: string };
+      headRevision: RevisionRecord;
+    };
+    const remixedResponse = await app.fetch(
+      authenticated(`/v1/revisions/${first.headRevision.id}/remix`, "POST", {}),
+    );
+    const remixed = (await remixedResponse.json()) as {
+      artifact: { id: string };
+    };
+    const screenshotKey = await sources.putScreenshot(
+      first.headRevision.id,
+      new Uint8Array([0xff, 0xd8, 0xff, 0xd9]),
+    );
+    await repository.setScreenshot(
+      first.headRevision.id,
+      repository.artifacts.get(first.artifact.id)!.ownerHash,
+      screenshotKey,
+    );
+
+    expect(
+      (await app.fetch(authenticated(`/v1/artifacts/${first.artifact.id}`, "DELETE"))).status,
+    ).toBe(204);
+    expect(sources.screens.size).toBe(0);
+    expect(sources.sources.size).toBe(1);
+
+    expect(
+      (await app.fetch(authenticated(`/v1/artifacts/${remixed.artifact.id}`, "DELETE"))).status,
+    ).toBe(204);
+    expect(sources.sources.size).toBe(1);
   });
 
   it("round-trips rich metadata, screenshots, and publication envelopes", async () => {

--- a/services/studio-api/test/d1Repository.test.ts
+++ b/services/studio-api/test/d1Repository.test.ts
@@ -236,10 +236,58 @@ describe("D1StudioRepository conditional revision writes", () => {
     await repository.isRevisionRetrievable(revision.id, revision.createdAt);
     await repository.searchRetrieval('"Quokka"', 10, revision.createdAt);
 
-    expect(sql[1]).toContain("UPDATE retrieval_entries SET updated_at");
+    expect(sql[1]).toContain("UPDATE retrieval_entries SET descriptor=");
+    expect(sql[1]).toContain("design_card_json");
     expect(sql[3]).toContain("p.expires_at>?2");
     expect(sql[4]).toContain("p.expires_at>?3");
     expect(sql[3]).toContain("r.curated=1");
     expect(sql[4]).toContain("r.curated=1");
+  });
+
+  it("returns screenshot cleanup only for artifacts deleted after the expiry recheck", async () => {
+    const sql: string[] = [];
+    const database = {
+      prepare(text: string) {
+        sql.push(text);
+        const statement = {
+          bind: () => statement,
+          all: () =>
+            Promise.resolve({
+              results: text.startsWith("WITH candidates")
+                ? [
+                    {
+                      id: "expired",
+                      owner_hash: "owner-a",
+                      screenshot_key: "screens/expired.jpg",
+                    },
+                    {
+                      id: "changed",
+                      owner_hash: "owner-b",
+                      screenshot_key: "screens/changed.jpg",
+                    },
+                  ]
+                : [],
+            }),
+        };
+        return statement;
+      },
+      batch(statements: unknown[]) {
+        expect(statements).toHaveLength(2);
+        return Promise.resolve([
+          { meta: { changes: 1 } },
+          { meta: { changes: 0 } },
+        ]);
+      },
+    } as unknown as D1Database;
+
+    await expect(
+      new D1StudioRepository(database).deleteExpiredArtifacts(
+        "2026-01-01T00:00:00Z",
+        "2026-08-02T00:00:00Z",
+      ),
+    ).resolves.toEqual([{ screenshotKeys: ["screens/expired.jpg"] }]);
+    expect(sql[0]).toContain(`owner_hash<>?4`);
+    expect(sql[1]).toContain("updated_at<?3");
+    expect(sql[1]).toContain("p.expires_at>?4");
   });
 });

--- a/services/studio-api/test/moderation.test.ts
+++ b/services/studio-api/test/moderation.test.ts
@@ -9,6 +9,11 @@ describe('deterministic moderation', () => {
       ]));
   });
 
+  it('does not treat numeric JavaScript constants as phone numbers', () => {
+    expect(inspectHtml('<script>const millisecondsPerDay = 86400000;</script>'))
+      .toEqual([]);
+  });
+
   it('blocks direct weapon-building instructions before model moderation', () => {
     expect(inspectText('How to make a bomb: combine these materials and follow these steps.'))
       .toEqual(expect.arrayContaining([

--- a/services/studio-api/test/moderation.test.ts
+++ b/services/studio-api/test/moderation.test.ts
@@ -1,7 +1,14 @@
 import { describe, expect, it } from 'vitest';
-import { inspectText } from '../src/moderation';
+import { inspectHtml, inspectText } from '../src/moderation';
 
 describe('deterministic moderation', () => {
+  it('checks content displayed from inline JavaScript', () => {
+    expect(inspectHtml('<script>const contact = "91234567";</script>'))
+      .toEqual(expect.arrayContaining([
+        expect.objectContaining({ code: 'POSSIBLE_PHONE' }),
+      ]));
+  });
+
   it('blocks direct weapon-building instructions before model moderation', () => {
     expect(inspectText('How to make a bomb: combine these materials and follow these steps.'))
       .toEqual(expect.arrayContaining([

--- a/services/studio-api/test/repository.test.ts
+++ b/services/studio-api/test/repository.test.ts
@@ -233,7 +233,7 @@ describe("MemoryStudioRepository artifact model", () => {
     });
     expect(
       await repository.deleteExpiredArtifacts("2026-01-01T00:00:00Z", now),
-    ).toBe(0);
+    ).toEqual([]);
     expect(await repository.isRevisionRetrievable(seed.revision.id, now)).toBe(
       true,
     );
@@ -271,13 +271,20 @@ describe("MemoryStudioRepository artifact model", () => {
     await repository.updateArtifactMetadata(
       teacher.artifact.id,
       teacher.artifact.ownerHash,
-      { ...teacher.artifact, title: "Decimal Quokka" },
+      {
+        ...teacher.artifact,
+        title: "Decimal Quokka",
+        summary: "Place-value regrouping practice",
+      },
       now,
     );
     expect(await repository.searchRetrieval('"Quokka"', 10, now)).toHaveLength(
       1,
     );
     expect(await repository.searchRetrieval('"Polygon"', 10, now)).toEqual([]);
+    expect(
+      await repository.searchRetrieval('"regrouping"', 10, now),
+    ).toHaveLength(1);
 
     await repository.revokePublication("teacher-slug", "owner-a", now);
     expect(

--- a/services/studio-api/test/repository.test.ts
+++ b/services/studio-api/test/repository.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { MemoryStudioRepository } from "../src/storage/memoryRepository";
 import {
   CURATED_SEED_OWNER,
+  retrievalDescriptor,
   type ArtifactRecord,
   type RevisionRecord,
 } from "../src/storage/repository";
@@ -44,6 +45,17 @@ function records(id = "artifact-1", ownerHash = "owner-a") {
 }
 
 describe("MemoryStudioRepository artifact model", () => {
+  it("keeps private creation briefs out of retrieval descriptors", () => {
+    const { artifact } = records();
+    artifact.creationBrief = "Private source notes about a named student";
+
+    const descriptor = retrievalDescriptor(artifact, '{"layout":"cards"}');
+
+    expect(descriptor).toContain("Compare fractions");
+    expect(descriptor).toContain("cards");
+    expect(descriptor).not.toContain(artifact.creationBrief);
+  });
+
   it("enforces quota boundaries and class-code capacity", async () => {
     const repository = new MemoryStudioRepository();
     expect(


### PR DESCRIPTION
Follow-up to #72 for high-confidence iPad recovery defects found by delayed automated review and independently verified against merged master.

This change:
- opens workshop access on first run and after registration/token failures
- preserves successful widgets when one remote restore item fails
- allows deletion of local projects whose server recovery copy has expired
- removes local image files when deleting a project

Verification:
- `npm run ipad:prepare`
- generic iOS Simulator build with code signing disabled: passed
- unit-test target compiled successfully, but execution was blocked twice by the installed iOS 26.5 simulator failing to launch the test runner with Mach error -308, including after a simulator reboot
- `git diff --check`

**Do not auto-merge; this follow-up requires review.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Remix actions now use the dedicated remix workflow.
  * Studio projects migrate automatically from the legacy storage location.
  * Asset references are recognized in HTML and CSS content.
  * Restoration reports recovery status and continues after individual failures.

* **Bug Fixes**
  * Improved handling of registration-required access errors with clearer registration prompts.
  * Workshop access refreshes correctly based on device credentials.
  * Expired or revoked remote artifacts can be removed without blocking deletion.
  * Missing artifacts are identified more clearly.
  * Preview updates now load reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->