### PR TITLE
fix: recover Studio projects after PR #72

### DIFF
--- a/apps/ipad/Sources/Networking/StudioAPIClient.swift
+++ b/apps/ipad/Sources/Networking/StudioAPIClient.swift
@@ -365,7 +365,11 @@ enum StudioAPIError: LocalizedError, Equatable {
         case .invalidURL, .invalidResponse, .transport, .decoding, .server: "Studio could not complete this request. Check your connection and try again."
         }
     }
-    var requiresRegistration: Bool { if case .server(401, let code, _) = self { return code == "DEVICE_REGISTRATION_REQUIRED" || code == "DEVICE_TOKEN_REQUIRED" }; return false }
+    var requiresRegistration: Bool {
+        if case .registrationRequired = self { return true }
+        if case .server(401, let code, _) = self { return code == "DEVICE_REGISTRATION_REQUIRED" || code == "DEVICE_TOKEN_REQUIRED" }
+        return false
+    }
     var requiresRefresh: Bool {
         if requiresRegistration { return true }
         if case .server(422, let code, _) = self { return code == "PUBLICATION_EXPIRY_LIMIT_REACHED" }

--- a/apps/ipad/Sources/Store/StudioStore.swift
+++ b/apps/ipad/Sources/Store/StudioStore.swift
@@ -29,7 +29,7 @@ struct StudioErrorPresentation { let title, message: String; let requestsWorksho
     init(api: any StudioAPI = StudioAPIClient.live(), storageDirectory: URL? = nil, bundle: Bundle = .main) {
         self.api = api
         isUITesting = ProcessInfo.processInfo.arguments.contains("--ui-testing-reset")
-        let root = storageDirectory ?? (try? FileManager.default.url(for: .cachesDirectory, in: .userDomainMask, appropriateFor: nil, create: true)) ?? FileManager.default.temporaryDirectory
+        let root = storageDirectory ?? (try? FileManager.default.url(for: .applicationSupportDirectory, in: .userDomainMask, appropriateFor: nil, create: true)) ?? FileManager.default.temporaryDirectory
         cacheDirectory = root.appending(path: "ArtifactProjects", directoryHint: .isDirectory)
         if isUITesting {
             try? FileManager.default.removeItem(at: cacheDirectory)
@@ -53,13 +53,20 @@ struct StudioErrorPresentation { let title, message: String; let requestsWorksho
             }
             return
         }
-        workshopAccessState = await api.hasDeviceCredential() ? .ready : .registrationRequired
+        let hasCredential = await api.hasDeviceCredential()
+        workshopAccessState = hasCredential ? .ready : .registrationRequired
+        showsWorkshopAccess = !hasCredential
     }
     func requestWorkshopAccess() { showsWorkshopAccess = true }
     func dismissWorkshopAccess() { showsWorkshopAccess = false }
     func registerWorkshopAccess(_ code: String) async throws { try await api.registerDevice(accessCode: code); workshopAccessState = .ready; showsWorkshopAccess = false }
     func present(_ error: Error, during operation: StudioOperation) -> StudioErrorPresentation {
-        StudioErrorPresentation(title: "Studio could not complete this action", message: (error as? LocalizedError)?.errorDescription ?? error.localizedDescription, requestsWorkshopAccess: false)
+        let requestsWorkshopAccess = (error as? StudioAPIError)?.requiresRegistration == true
+        if requestsWorkshopAccess {
+            workshopAccessState = .registrationRequired
+            showsWorkshopAccess = true
+        }
+        return StudioErrorPresentation(title: "Studio could not complete this action", message: (error as? LocalizedError)?.errorDescription ?? error.localizedDescription, requestsWorkshopAccess: requestsWorkshopAccess)
     }
     func resetGuidedMake() { guidedMakeDraft = .init(); guidedMakeQuestionIndex = 0; guidedMakeResponse = ""; guidedMakeShowsSummary = false }
     func createApprovedBrief(_ brief: GuidedBriefDraft) async throws -> ArtifactProject {
@@ -79,14 +86,7 @@ struct StudioErrorPresentation { let title, message: String; let requestsWorksho
         let project = try await api.generate(request: request); upsert(project); open(project); return project
     }
     func remix(_ example: ArtifactProject) async throws {
-        let artifact = example.artifact
-        let request = GuidedGenerationRequest(creationBrief: artifact.creationBrief, brief: .init(
-            learnerContext: artifact.level ?? artifact.subject ?? "General learners",
-            learningObjective: artifact.learningObjective ?? artifact.title,
-            studentAction: artifact.summary, sourceContent: nil,
-            feedback: "Provide clear feedback", classroomFit: "Use in a short classroom activity"
-        ), preferredExampleRevisionId: example.source.revision.id)
-        let project = try await api.generate(request: request)
+        let project = try await api.remix(id: example.id, revisionId: example.source.revision.id)
         upsert(project)
         open(project)
     }
@@ -111,7 +111,13 @@ struct StudioErrorPresentation { let title, message: String; let requestsWorksho
     func unpublish(projectID: String) async throws { var current = try project(projectID); if let slug = current.artifact.publication?.slug { try await api.revoke(slug: slug) }; current.artifact.publication = nil; upsert(current) }
     func extendPublication(projectID: String) async throws { var current = try project(projectID); guard let slug = current.artifact.publication?.slug else { return }; current.artifact.publication = try await api.extend(slug: slug, days: 90); upsert(current) }
     func deleteProject(projectID: String) async throws {
-        try await api.deleteArtifact(id: projectID)
+        do {
+            try await api.deleteArtifact(id: projectID)
+        } catch StudioAPIError.server(404, "ARTIFACT_NOT_FOUND", _) {
+            // The server may have expired an old project; its local copy should
+            // still be removable.
+        }
+        projects.first(where: { $0.id == projectID })?.localAssets.forEach(LocalWidgetAssetStorage.remove)
         projects.removeAll { $0.id == projectID }
         let name = projectID.addingPercentEncoding(withAllowedCharacters: .alphanumerics) ?? projectID
         try? FileManager.default.removeItem(at: cacheDirectory.appending(path: "\(name).json"))
@@ -121,11 +127,19 @@ struct StudioErrorPresentation { let title, message: String; let requestsWorksho
         defer { isRestoringFromStudio = false }
         let artifacts = try await api.listArtifacts()
         var count = 0
+        var failures = 0
         for artifact in artifacts {
-            let fetched = try await api.getArtifact(id: artifact.id)
-            let remote = try await cacheAssets(in: fetched)
-            upsert(remote)
-            count += 1
+            do {
+                let fetched = try await api.getArtifact(id: artifact.id)
+                let remote = try await cacheAssets(in: fetched)
+                upsert(remote)
+                count += 1
+            } catch {
+                failures += 1
+            }
+        }
+        if failures > 0 {
+            recoveryNotice = "Studio restored \(count) widgets. \(failures) could not be restored."
         }
         return count
     }

--- a/apps/ipad/Tests/StudioStoreTests.swift
+++ b/apps/ipad/Tests/StudioStoreTests.swift
@@ -50,6 +50,69 @@ final class StudioStoreTests: XCTestCase {
         XCTAssertEqual(store.projects.first?.source.html, revised.source.html)
     }
 
+    @MainActor
+    func testRegistrationErrorsOpenWorkshopAccess() async {
+        let project = makeProject(revisionID: "r1", html: "<html></html>")
+        let api = ArtifactAPIStub(generated: project, revised: project, hasCredential: false)
+        let store = StudioStore(api: api, storageDirectory: temporaryDirectory(), bundle: Bundle(for: Self.self))
+
+        await store.refreshWorkshopAccess()
+
+        XCTAssertEqual(store.workshopAccessState, .registrationRequired)
+        XCTAssertTrue(store.showsWorkshopAccess)
+        store.dismissWorkshopAccess()
+        let presentation = store.present(StudioAPIError.server(401, "DEVICE_REGISTRATION_REQUIRED", "Register"), during: .generation)
+        XCTAssertTrue(presentation.requestsWorkshopAccess)
+        XCTAssertTrue(store.showsWorkshopAccess)
+    }
+
+    @MainActor
+    func testExampleCopyUsesRemixEndpoint() async throws {
+        let example = makeProject(revisionID: "seed-r1", html: "<html>Seed</html>")
+        let copy = makeProject(revisionID: "copy-r1", html: "<html>Copy</html>")
+        let api = ArtifactAPIStub(generated: example, revised: copy)
+        let store = StudioStore(api: api, storageDirectory: temporaryDirectory(), bundle: Bundle(for: Self.self))
+
+        try await store.remix(example)
+
+        let request = await api.lastRemixRequest
+        XCTAssertEqual(request?.artifactID, example.id)
+        XCTAssertEqual(request?.revisionID, example.source.revision.id)
+        XCTAssertEqual(store.selectedProjectID, copy.id)
+    }
+
+    @MainActor
+    func testRestoreContinuesAfterOneArtifactFails() async throws {
+        let good = makeProject(artifactID: "good", revisionID: "good-r1", html: "<html>Good</html>")
+        let bad = makeProject(artifactID: "bad", revisionID: "bad-r1", html: "<html>Bad</html>")
+        let api = ArtifactAPIStub(generated: good, revised: good, listedArtifacts: [bad.artifact, good.artifact], failingArtifactIDs: [bad.id])
+        let store = StudioStore(api: api, storageDirectory: temporaryDirectory(), bundle: Bundle(for: Self.self))
+
+        let restored = try await store.restoreFromStudio()
+
+        XCTAssertEqual(restored, 1)
+        XCTAssertEqual(store.projects.map(\.id), [good.id])
+        XCTAssertEqual(store.recoveryNotice, "Studio restored 1 widgets. 1 could not be restored.")
+    }
+
+    @MainActor
+    func testDeleteRemovesLocalProjectWhenServerAlreadyExpiredIt() async throws {
+        let project = makeProject(revisionID: "r1", html: "<html></html>")
+        let api = ArtifactAPIStub(generated: project, revised: project, deleteError: .server(404, "ARTIFACT_NOT_FOUND", "Expired"))
+        let directory = temporaryDirectory()
+        let store = StudioStore(api: api, storageDirectory: directory, bundle: Bundle(for: Self.self))
+        var brief = GuidedBriefDraft()
+        brief.learningObjective = "Forces"
+        brief.studentAction = "Choose"
+        _ = try await store.createApprovedBrief(brief)
+
+        try await store.deleteProject(projectID: project.id)
+
+        XCTAssertTrue(store.projects.isEmpty)
+        let restored = StudioStore(api: api, storageDirectory: directory, bundle: Bundle(for: Self.self))
+        XCTAssertTrue(restored.projects.isEmpty)
+    }
+
     private func temporaryDirectory() -> URL {
         FileManager.default.temporaryDirectory
             .appending(path: "StudioStoreTests-\(UUID().uuidString)", directoryHint: .isDirectory)
@@ -61,28 +124,51 @@ private actor ArtifactAPIStub: StudioAPI {
         let instruction: String
         let expectedHeadRevisionID: String
     }
+    struct RemixRequest: Sendable {
+        let artifactID: String
+        let revisionID: String?
+    }
 
     let generated: ArtifactProject
     let revised: ArtifactProject
+    let hasCredential: Bool
+    let listedArtifacts: [Artifact]
+    let failingArtifactIDs: Set<String>
+    let deleteError: StudioAPIError?
     private(set) var lastGenerationRequest: GuidedGenerationRequest?
     private(set) var lastRevisionRequest: RevisionRequest?
+    private(set) var lastRemixRequest: RemixRequest?
 
-    init(generated: ArtifactProject, revised: ArtifactProject) {
+    init(
+        generated: ArtifactProject,
+        revised: ArtifactProject,
+        hasCredential: Bool = true,
+        listedArtifacts: [Artifact]? = nil,
+        failingArtifactIDs: Set<String> = [],
+        deleteError: StudioAPIError? = nil
+    ) {
         self.generated = generated
         self.revised = revised
+        self.hasCredential = hasCredential
+        self.listedArtifacts = listedArtifacts ?? [generated.artifact]
+        self.failingArtifactIDs = failingArtifactIDs
+        self.deleteError = deleteError
     }
 
-    func hasDeviceCredential() async -> Bool { true }
+    func hasDeviceCredential() async -> Bool { hasCredential }
     func registerDevice(accessCode: String) async throws {}
     func generate(request: GuidedGenerationRequest) async throws -> ArtifactProject {
         lastGenerationRequest = request
         return generated
     }
-    func listArtifacts() async throws -> [Artifact] { [generated.artifact] }
+    func listArtifacts() async throws -> [Artifact] { listedArtifacts }
     func searchExamples(brief: String) async throws -> [ExampleSearchDescriptor] { [] }
-    func getArtifact(id: String) async throws -> ArtifactProject { generated }
+    func getArtifact(id: String) async throws -> ArtifactProject {
+        if failingArtifactIDs.contains(id) { throw StudioAPIError.server(404, "SOURCE_NOT_FOUND", "Missing") }
+        return generated
+    }
     func updateArtifact(_ artifact: Artifact) async throws -> Artifact { artifact }
-    func deleteArtifact(id: String) async throws {}
+    func deleteArtifact(id: String) async throws { if let deleteError { throw deleteError } }
     func revise(id: String, instruction: String, expectedHeadRevisionId: String) async throws -> ArtifactProject {
         lastRevisionRequest = RevisionRequest(
             instruction: instruction,
@@ -93,7 +179,10 @@ private actor ArtifactAPIStub: StudioAPI {
     func revisions(id: String) async throws -> [ArtifactRevision] { generated.revisions }
     func source(revision: ArtifactRevision) async throws -> ArtifactSource { generated.source }
     func setHead(id: String, revisionId: String, expectedHeadRevisionId: String) async throws -> ArtifactProject { revised }
-    func remix(id: String, revisionId: String?) async throws -> ArtifactProject { revised }
+    func remix(id: String, revisionId: String?) async throws -> ArtifactProject {
+        lastRemixRequest = RemixRequest(artifactID: id, revisionID: revisionId)
+        return revised
+    }
     func downloadAsset(id: String) async throws -> DownloadedWidgetAsset {
         DownloadedWidgetAsset(data: Data([1, 2, 3]), mediaType: "image/jpeg")
     }
@@ -132,11 +221,11 @@ private actor ArtifactAPIStub: StudioAPI {
 }
 
 private func makeProject(
+    artifactID: String = "artifact-1",
     revisionID: String,
     parentRevisionID: String? = nil,
     html: String
 ) -> ArtifactProject {
-    let artifactID = "artifact-1"
     let timestamp = "2026-08-02T00:00:00Z"
     let revision = ArtifactRevision(
         id: revisionID,

--- a/services/studio-api/src/index.ts
+++ b/services/studio-api/src/index.ts
@@ -74,7 +74,10 @@ export function injectPublicHtml(source: string, slug: string): string {
     /<head(\s[^>]*)?>/i,
     (head) => `${head}<base href="/${slug}/">`,
   );
-  const injected = withBase.replace(/<\/body\s*>/i, `${report}</body>`);
+  const injected = withBase.replace(
+    /<\/body\s*>(?![\s\S]*<\/body\s*>)/i,
+    `${report}</body>`,
+  );
   if (injected === withBase || withBase === source)
     throw new Error("Stored widget source is not a complete HTML document.");
   return injected;

--- a/services/studio-api/test/app.test.ts
+++ b/services/studio-api/test/app.test.ts
@@ -125,11 +125,15 @@ describe("Studio API registration and public HTML", () => {
 
   it("injects one scoped base and one report control without changing the source", () => {
     const source =
-      '<!doctype html><html><head></head><body><img src="assets/image-1"></body></html>';
+      '<!doctype html><html><head></head><body><script>const closingTag = "</body>";</script><img src="assets/image-1"></body></html>';
     const served = injectPublicHtml(source, "ABCDEFGHIJKLMNOPQRST");
     expect(served.match(/<base /g)).toHaveLength(1);
     expect(served.match(/data-studio-report/g)).toHaveLength(1);
     expect(served).toContain('<base href="/ABCDEFGHIJKLMNOPQRST/">');
+    expect(served).toContain('<script>const closingTag = "</body>";</script>');
+    expect(served.indexOf("data-studio-report")).toBeGreaterThan(
+      served.indexOf('<img src="assets/image-1">'),
+    );
     expect(source).not.toContain("<base");
   });
 


### PR DESCRIPTION
Follow-up to #72 after post-merge review.

- preserve generated JavaScript strings containing `</body>` when injecting the public report control
- persist iPad projects in Application Support rather than purgeable caches
- reopen workshop registration when credentials are unavailable
- use the exact-copy remix endpoint for bundled examples
- continue restoring healthy projects after one remote project fails
- allow locally cached expired projects and their local images to be deleted

Verification:
- `npm run test -w @classroom-widgets/studio-api -- test/app.test.ts`
- `npm run typecheck -w @classroom-widgets/studio-api`
- `xcodebuild test -project apps/ipad/ClassroomWidgetsStudio.xcodeproj -scheme ClassroomWidgetsStudio -destination <temporary iOS 26.5 simulator> -only-testing:ClassroomWidgetsStudioTests/StudioStoreTests CODE_SIGNING_ALLOWED=NO` (6 tests passed)