### PR TITLE
Fix regressions from today's audit remediations

### DIFF
--- a/packages/teacher/src/app/App.test.tsx
+++ b/packages/teacher/src/app/App.test.tsx
@@ -303,4 +303,17 @@ describe('App double-Cmd-press voice activation', () => {
 
     expect((window as any).getVoiceControlActive()).toBe(false);
   });
+
+  it('does not treat a held Cmd key-repeat as a double press', async () => {
+    render(<App />);
+
+    await waitFor(() => {
+      expect(typeof (window as any).getVoiceControlActive).toBe('function');
+    });
+
+    pressCmd();
+    fireEvent.keyDown(document, { key: 'Meta', metaKey: true, repeat: true });
+
+    expect((window as any).getVoiceControlActive()).toBe(false);
+  });
 });

--- a/packages/teacher/src/app/App.tsx
+++ b/packages/teacher/src/app/App.tsx
@@ -203,7 +203,8 @@ function App() {
       if (voiceControlEnabled &&
           (e.metaKey || e.ctrlKey) &&
           (e.key === 'Meta' || e.key === 'Control' || e.key === 'OS') &&
-          !e.altKey && !e.shiftKey) {
+          !e.altKey && !e.shiftKey &&
+          !e.repeat) {
         const now = Date.now();
 
         if (commandPressRef.current && (now - commandPressRef.current.pressedAt) < 500) {
@@ -237,6 +238,7 @@ function App() {
       document.removeEventListener('keydown', handleKeyDown);
       if (commandPressRef.current) {
         clearTimeout(commandPressRef.current.timeoutId);
+        commandPressRef.current = null;
       }
     };
   }, [

--- a/packages/teacher/src/features/voiceControl/components/VoiceInterface.test.tsx
+++ b/packages/teacher/src/features/voiceControl/components/VoiceInterface.test.tsx
@@ -212,6 +212,77 @@ describe('VoiceInterface', () => {
     expect(screen.getByRole('button', { name: /Try Again/i })).toBeInTheDocument();
   });
 
+  it('ignores a command that settles after the processing timeout', async () => {
+    let resolveCommand: (value: VoiceCommandResponse) => void = () => {};
+    const onTranscriptComplete = vi.fn().mockReturnValue(
+      new Promise<VoiceCommandResponse>((resolve) => {
+        resolveCommand = resolve;
+      })
+    );
+    const onClose = vi.fn();
+
+    render(
+      <VoiceInterface isOpen onClose={onClose} onTranscriptComplete={onTranscriptComplete} />
+    );
+
+    await armMicrophone();
+    await speak();
+    expect(screen.getByText('Processing command...')).toBeInTheDocument();
+
+    await act(async () => {
+      vi.advanceTimersByTime(PROCESSING_TIMEOUT_MS);
+    });
+    expect(screen.getByRole('button', { name: /Try Again/i })).toBeInTheDocument();
+
+    await act(async () => {
+      resolveCommand(buildResponse());
+    });
+    await flush();
+
+    expect(screen.getByRole('button', { name: /Try Again/i })).toBeInTheDocument();
+    expect(screen.queryByText('Created a poll')).not.toBeInTheDocument();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('does not auto-close from a command that finishes after the user has retried', async () => {
+    let resolveFirst: (value: VoiceCommandResponse) => void = () => {};
+    const onTranscriptComplete = vi.fn()
+      .mockImplementationOnce(() => new Promise<VoiceCommandResponse>((resolve) => {
+        resolveFirst = resolve;
+      }))
+      .mockReturnValue(new Promise<VoiceCommandResponse>(() => {}));
+    const onClose = vi.fn();
+
+    render(
+      <VoiceInterface isOpen onClose={onClose} onTranscriptComplete={onTranscriptComplete} />
+    );
+
+    await armMicrophone();
+    await speak();
+
+    await act(async () => {
+      vi.advanceTimersByTime(PROCESSING_TIMEOUT_MS);
+    });
+    expect(screen.getByRole('button', { name: /Try Again/i })).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /Try Again/i }));
+    });
+    await armMicrophone();
+    await speak('trigger the randomiser');
+
+    await act(async () => {
+      resolveFirst(buildResponse());
+    });
+    await flush();
+    await act(async () => {
+      vi.advanceTimersByTime(3000);
+    });
+
+    expect(onClose).not.toHaveBeenCalled();
+    expect(screen.getByText('Processing command...')).toBeInTheDocument();
+  });
+
   it('starts clean after close and reopen, so a repeated phrase is processed again', async () => {
     const onTranscriptComplete = vi
       .fn<(transcript: string) => Promise<VoiceCommandResponse>>()

--- a/packages/teacher/src/features/voiceControl/components/VoiceInterface.tsx
+++ b/packages/teacher/src/features/voiceControl/components/VoiceInterface.tsx
@@ -32,6 +32,9 @@ const VoiceInterface: React.FC<VoiceInterfaceProps> = ({
   const processedRequestIdsRef = useRef<Set<string>>(new Set());
   const isOpenRef = useRef<boolean>(isOpen);
   const timeoutIdsRef = useRef<number[]>([]);
+  // Bumped when a command is started, timed out, retried, or closed so a late
+  // settle from an earlier request cannot flip the UI or auto-close it.
+  const processingGenerationRef = useRef(0);
 
   const {
     isListening,
@@ -68,23 +71,29 @@ const VoiceInterface: React.FC<VoiceInterfaceProps> = ({
   }, [isOpen, clearScheduledActions]);
 
   // Define handlers before useEffects
+  const invalidateInFlightCommand = useCallback(() => {
+    processingGenerationRef.current += 1;
+    isProcessingRef.current = false;
+  }, []);
+
   const handleClose = useCallback(() => {
     clearScheduledActions();
+    invalidateInFlightCommand();
     stopRecording();
     resetState();
     setParsedCommand(null);
     setProcessedTranscript(null);
-    isProcessingRef.current = false;
     processedRequestIdsRef.current.clear();
     setVoiceState('idle');
     onClose();
-  }, [clearScheduledActions, stopRecording, resetState, onClose]);
+  }, [clearScheduledActions, invalidateInFlightCommand, stopRecording, resetState, onClose]);
 
   const handleRetry = useCallback(() => {
+    clearScheduledActions();
+    invalidateInFlightCommand();
     resetState();
     setParsedCommand(null);
     setProcessedTranscript(null);
-    isProcessingRef.current = false;
     // Retrying re-records from scratch, so a repeat of the same phrase is a new
     // request. Without this the dedup guard swallows it and the UI sticks on
     // 'processing' forever.
@@ -95,7 +104,7 @@ const VoiceInterface: React.FC<VoiceInterfaceProps> = ({
       startRecording();
       setVoiceState('listening');
     }, 300);
-  }, [resetState, startRecording, scheduleAction]);
+  }, [clearScheduledActions, invalidateInFlightCommand, resetState, startRecording, scheduleAction]);
 
   // Auto-start recording when interface opens
   useEffect(() => {
@@ -176,12 +185,14 @@ const VoiceInterface: React.FC<VoiceInterfaceProps> = ({
     }
 
     processedRequestIdsRef.current.add(transcript);
+    const requestId = ++processingGenerationRef.current;
     isProcessingRef.current = true;
     setVoiceState('processing');
     playFeedback('processing');
 
     onTranscriptComplete(transcript)
       .then((response) => {
+        if (requestId !== processingGenerationRef.current) return;
         setParsedCommand(response);
         setProcessedTranscript(transcript);
         const isError = response.feedback.type === 'error' || response.feedback.type === 'not_understood' || !response.success;
@@ -201,18 +212,22 @@ const VoiceInterface: React.FC<VoiceInterfaceProps> = ({
             window.speechSynthesis.speak(utterance);
           }
 
-          // Auto-close after 3 seconds
-          setTimeout(() => {
+          // Auto-close after 3 seconds. Use scheduleAction so close/retry
+          // cancels it instead of firing handleClose on a later session.
+          scheduleAction(() => {
             handleClose();
           }, 3000);
         }
       })
       .catch((err) => {
+        if (requestId !== processingGenerationRef.current) return;
         debug.error('Command processing failed:', err);
         setVoiceState('error');
       })
       .finally(() => {
-        isProcessingRef.current = false;
+        if (requestId === processingGenerationRef.current) {
+          isProcessingRef.current = false;
+        }
       });
   }, [transcript, isGathering, isListening, isOpen, voiceState, confidence, onTranscriptComplete, handleClose, playFeedback, scheduleAction, startRecording]);
 
@@ -225,6 +240,7 @@ const VoiceInterface: React.FC<VoiceInterfaceProps> = ({
 
     const timeoutId = window.setTimeout(() => {
       debug('⏱️ Voice command processing timed out - forcing error state');
+      processingGenerationRef.current += 1;
       isProcessingRef.current = false;
       setVoiceState('error');
     }, PROCESSING_TIMEOUT_MS);

--- a/packages/teacher/src/features/widgets/imageDisplay/imageDisplay.test.tsx
+++ b/packages/teacher/src/features/widgets/imageDisplay/imageDisplay.test.tsx
@@ -250,6 +250,23 @@ describe('ImageDisplay', () => {
     expect(screen.getByText('Add an image')).toBeInTheDocument();
   });
 
+  test('shows an error when an external key cannot be loaded from storage', async () => {
+    vi.mocked(loadImage).mockImplementation(async (key: string) => (
+      key === 'first-key' ? `data:image/png;base64,${key}` : null
+    ));
+
+    const { rerender } = render(
+      <ImageDisplay widgetId="widget-1" savedState={{ imageKey: 'first-key' }} />
+    );
+
+    expect(await screen.findByAltText('Display')).toHaveAttribute('src', 'data:image/png;base64,first-key');
+
+    rerender(<ImageDisplay widgetId="widget-1" savedState={{ imageKey: 'missing-key' }} />);
+
+    expect(await screen.findByText('Unable to load image. Please try again.')).toBeInTheDocument();
+    expect(screen.queryByAltText('Display')).not.toBeInTheDocument();
+  });
+
   test('aborts active file reader and ignores file load callbacks after unmount', () => {
     const { container, unmount } = render(<ImageDisplay widgetId="widget-1" onStateChange={vi.fn()} />);
     const input = container.querySelector('input[type="file"]') as HTMLInputElement;

--- a/packages/teacher/src/features/widgets/imageDisplay/imageDisplay.tsx
+++ b/packages/teacher/src/features/widgets/imageDisplay/imageDisplay.tsx
@@ -111,8 +111,16 @@ const ImageDisplay: React.FC<ImageDisplayProps> = ({ widgetId, savedState, onSta
     void loadImage(persistedImageKey)
       .then(url => {
         if (!isCurrentImageChange(changeId)) return;
-        setError(null);
-        setImageUrl(url);
+        if (url) {
+          setError(null);
+          setImageUrl(url);
+        } else {
+          // A missing IndexedDB blob is a load failure, not an empty widget.
+          // Clearing the error here left compact-panel / workspace switches
+          // showing a blank image with no explanation.
+          setImageUrl(null);
+          setError(STORAGE_LOAD_ERROR);
+        }
       })
       .catch(() => {
         if (isCurrentImageChange(changeId)) setError(STORAGE_LOAD_ERROR);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Review of cowdinosaur's 19 August 2026 audit remediations (29 non-merge commits, already on `master` as `97496d6..4c5de3f`), plus fixes for the three regressions that look real.

## Scope reviewed

Teacher widgets/state (T1–T11, SH2-B, T4-B, T7, T8, T9), session/socket models (S1-A, S2-A/B/C, T5), and the student app (ST1-A, ST2-B, SH4-A). Mechanical extracts that preserve prior control flow are called out as clean below.

## Fixes in this PR

These are the introduced bugs worth patching:

1. **T9-A voice watchdog** — the new 20s processing timeout forced the UI to error but left the in-flight `onTranscriptComplete` promise live. A late resolve still flipped the UI to success and auto-closed (raw `setTimeout`, not cancelled by retry/close). Commands are now generation-gated; timeout/retry/close invalidate the in-flight request; auto-close uses `scheduleAction`.
2. **T11-B double-Cmd ref** — moving tracking into a ref made OS key-repeat of Meta/Control a double-press (the old `useState` version usually missed repeats until after paint). Listener teardown also cleared the timer without nulling the ref, so a re-bind within 500ms could treat the next single press as a double. Repeats are ignored and the ref is cleared on cleanup.
3. **T7-B image resync** — an external `imageKey` change treated `loadImage(...) === null` as a successful empty image (`setError(null); setImageUrl(url)`). Mount still requires a truthy URL. Missing IndexedDB blobs (compact panel / workspace switch) now show the existing load error.

## Other findings (not patched)

- **SH2-B residual, low** — `useWidgetState` still adopts an older parent snapshot (`A1`) that arrives after a newer local write (`A2`), because it compares against the last agreed value only. Nested echo/rebuild is fixed; an intermediate in-flight write can still be clobbered on a slow host. Same class of hole as before, narrower now.
- **S1-A, low** — host handlers still call `resolveHostRoom` before `validators.widgetId`. A missing id can bind to a session-level room, then the validator bails before mutate/broadcast. Behaviour-preserving vs the old lookup-after-validate order, not user-visible.

## Clean / no functional regression found

WidgetWrapper machine (T4-B), hover-delay extract (T4-C), renderer/list merge (T2-A/C), zoom `isScaling` (T2-B), sticker `useWidgetState` (T7-A/B), timer union (T8-A) and helper extracts (T8-B/C), workspace snapshot/collections (T1), landing-page wrappers (T11-A), `resolveHostRoom` / room-key / list-room CRUD (S1-A, S2-A/B/C), student room-type table (ST1-A), drop-zone `accepts` removal (ST2-B), question colour tokens (SH4-A). T5's `createSession` → `recovered` cleanup path matches the old ref+`sessionCode` effect trigger.

## Test plan

- `npx vitest run src/features/voiceControl/components/VoiceInterface.test.tsx src/app/App.test.tsx src/features/widgets/imageDisplay/imageDisplay.test.tsx` in `packages/teacher`
- Double-Cmd still opens voice; holding Cmd does not
- Voice timeout then a late command resolve stays on the error/retry UI
- Switching an image widget to a key missing from IndexedDB shows "Unable to load image" rather than a blank drop zone

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0197e-28a9-729d-b7a2-be5b9116693d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0197e-28a9-729d-b7a2-be5b9116693d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented repeated Command/Ctrl key presses from triggering voice activation more than once.
  * Prevented outdated voice-command results from appearing after timeouts, retries, or closing the voice interface.
  * Improved handling of missing persisted images by displaying a load error and removing the unavailable image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->