### PR TITLE
Fix leftover stale-state races from the 19 Aug remediations

### DIFF
--- a/packages/shared/hooks/useWidgetState.ts
+++ b/packages/shared/hooks/useWidgetState.ts
@@ -44,6 +44,10 @@ export function useWidgetState<T>({
   // The last savedState the resync effect looked at, so a parent that rebuilds
   // the prop on every render reads as unchanged rather than as a new value.
   const seenSavedRef = useRef<T | undefined>(savedState);
+  // Local writes the parent has not yet echoed, oldest first. A persist that
+  // lands out of order (A1 while local is already A2) is an echo of an earlier
+  // write, not an external change, and must not clobber A2.
+  const inFlightRef = useRef<T[]>([]);
 
   const setState = useCallback((nextState: React.SetStateAction<T>, notifyParent = true) => {
     setStateInternal((prevState) => {
@@ -52,6 +56,7 @@ export function useWidgetState<T>({
         : nextState;
       if (notifyParent) {
         agreedRef.current = resolvedState;
+        inFlightRef.current = [...inFlightRef.current, resolvedState];
         onStateChange?.(resolvedState);
       }
       return resolvedState;
@@ -69,8 +74,18 @@ export function useWidgetState<T>({
     // The parent's value did not actually change, only its reference.
     if (deepEqual(savedState, seenSavedRef.current)) return;
     seenSavedRef.current = savedState;
-    // The parent is echoing the update we just handed it.
-    if (deepEqual(savedState, agreedRef.current)) return;
+    // The parent is echoing the latest update we handed it.
+    if (deepEqual(savedState, agreedRef.current)) {
+      inFlightRef.current = [];
+      return;
+    }
+    const echoedIndex = inFlightRef.current.findIndex(pending => deepEqual(pending, savedState));
+    if (echoedIndex !== -1) {
+      // Stale echo of an earlier in-flight write. Keep the newer local value.
+      inFlightRef.current = inFlightRef.current.slice(echoedIndex + 1);
+      return;
+    }
+    inFlightRef.current = [];
     agreedRef.current = savedState;
     setState(savedState, false);
   }, [savedState, setState]);

--- a/packages/teacher/src/app/App.test.tsx
+++ b/packages/teacher/src/app/App.test.tsx
@@ -316,4 +316,24 @@ describe('App double-Cmd-press voice activation', () => {
 
     expect((window as any).getVoiceControlActive()).toBe(false);
   });
+
+  it('does not treat Cmd after Cmd+K as a double press', async () => {
+    const openLauncher = vi.fn();
+    window.openClassroomWidgetLauncher = openLauncher;
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(typeof (window as any).getVoiceControlActive).toBe('function');
+    });
+
+    pressCmd();
+    fireEvent.keyDown(document, { key: 'k', metaKey: true });
+    pressCmd();
+
+    expect(openLauncher).toHaveBeenCalled();
+    expect((window as any).getVoiceControlActive()).toBe(false);
+
+    delete window.openClassroomWidgetLauncher;
+  });
 });

--- a/packages/teacher/src/app/App.tsx
+++ b/packages/teacher/src/app/App.tsx
@@ -169,6 +169,20 @@ function App() {
         return;
       }
 
+      // A Cmd/Ctrl chord is not a lone modifier press. Drop any pending
+      // double-Cmd window so Cmd+K then another Cmd cannot also start voice.
+      if (
+        (e.metaKey || e.ctrlKey) &&
+        e.key !== 'Meta' &&
+        e.key !== 'Control' &&
+        e.key !== 'OS'
+      ) {
+        if (commandPressRef.current) {
+          clearTimeout(commandPressRef.current.timeoutId);
+          commandPressRef.current = null;
+        }
+      }
+
       // Open widget launcher with Cmd/Ctrl + K (handle this first to avoid triggering voice control)
       if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
         e.preventDefault();

--- a/packages/teacher/src/contexts/SessionContext.tsx
+++ b/packages/teacher/src/contexts/SessionContext.tsx
@@ -516,6 +516,7 @@ export const SessionProvider: React.FC<SessionProviderProps> = ({ children }) =>
       WidgetType.LINK_SHARE,
       WidgetType.HANDOUT,
       WidgetType.FILL_BLANK,
+      WidgetType.CODE_FILL_BLANK,
       WidgetType.SORTING,
       WidgetType.SEQUENCING,
       WidgetType.MATCHING

--- a/packages/teacher/src/features/voiceControl/components/VoiceInterface.test.tsx
+++ b/packages/teacher/src/features/voiceControl/components/VoiceInterface.test.tsx
@@ -18,6 +18,7 @@ const recorder = vi.hoisted(() => {
 
   let snapshot = emptyState;
   let isRecording = false;
+  let preserveProcessingOnReset = false;
   const subscribers = new Set<() => void>();
 
   const publish = (next: typeof emptyState) => {
@@ -35,6 +36,7 @@ const recorder = vi.hoisted(() => {
     getSnapshot: () => snapshot,
     reset: () => {
       isRecording = false;
+      preserveProcessingOnReset = false;
       publish(emptyState);
     },
     // Mirrors useVoiceRecording.startRecording: begins gathering input.
@@ -49,10 +51,17 @@ const recorder = vi.hoisted(() => {
       isRecording = false;
       publish({ ...snapshot, isListening: false, isGathering: false, isProcessing: true });
     },
+    // After the 20s watchdog the real recorder can still have isProcessing
+    // true; retry's resetState may not clear it before 'activating' commits.
+    preserveProcessingOnReset: (value: boolean) => {
+      preserveProcessingOnReset = value;
+    },
     // Mirrors useVoiceRecording.resetState.
     resetState: () => {
       isRecording = false;
-      publish(emptyState);
+      publish(preserveProcessingOnReset
+        ? { ...emptyState, isProcessing: true }
+        : emptyState);
     },
     // Mirrors recognition.onend with a captured transcript.
     finishWithTranscript: (transcript: string, confidence = 0.9) => {
@@ -130,6 +139,7 @@ describe('VoiceInterface', () => {
 
   afterEach(() => {
     vi.useRealTimers();
+    vi.unstubAllGlobals();
     vi.clearAllMocks();
   });
 
@@ -317,5 +327,97 @@ describe('VoiceInterface', () => {
     expect(onTranscriptComplete).toHaveBeenCalledTimes(2);
     expect(screen.queryByText('Processing command...')).not.toBeInTheDocument();
     expect(screen.getByText('Created a poll')).toBeInTheDocument();
+  });
+
+  it('does not auto-close from a command that settles after the parent closes without handleClose', async () => {
+    let resolveCommand: (value: VoiceCommandResponse) => void = () => {};
+    const onTranscriptComplete = vi.fn().mockReturnValue(
+      new Promise<VoiceCommandResponse>((resolve) => {
+        resolveCommand = resolve;
+      })
+    );
+    const onClose = vi.fn();
+    const speakUtterance = vi.fn();
+    const cancelSpeech = vi.fn();
+    vi.stubGlobal('speechSynthesis', { speak: speakUtterance, cancel: cancelSpeech });
+
+    const { rerender } = render(
+      <VoiceInterface isOpen onClose={onClose} onTranscriptComplete={onTranscriptComplete} />
+    );
+
+    await armMicrophone();
+    await speak();
+    expect(screen.getByText('Processing command...')).toBeInTheDocument();
+
+    rerender(
+      <VoiceInterface isOpen={false} onClose={onClose} onTranscriptComplete={onTranscriptComplete} />
+    );
+
+    await act(async () => {
+      resolveCommand(buildResponse({
+        feedback: { message: 'Created a poll', type: 'success', shouldSpeak: true }
+      }));
+    });
+    await flush();
+    await act(async () => {
+      vi.advanceTimersByTime(3000);
+    });
+
+    expect(onClose).not.toHaveBeenCalled();
+    expect(speakUtterance).not.toHaveBeenCalled();
+
+    rerender(
+      <VoiceInterface isOpen onClose={onClose} onTranscriptComplete={onTranscriptComplete} />
+    );
+    await act(async () => {
+      vi.advanceTimersByTime(3000);
+    });
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('re-arms listening for a low-quality transcript instead of sticking on processing', async () => {
+    const onTranscriptComplete = vi.fn().mockResolvedValue(buildResponse());
+
+    render(
+      <VoiceInterface isOpen onClose={vi.fn()} onTranscriptComplete={onTranscriptComplete} />
+    );
+
+    await armMicrophone();
+    await speak('hi');
+
+    expect(onTranscriptComplete).not.toHaveBeenCalled();
+    expect(screen.queryByText('Processing command...')).not.toBeInTheDocument();
+
+    await act(async () => {
+      vi.advanceTimersByTime(500);
+    });
+    expect(screen.getByText('Listening...')).toBeInTheDocument();
+  });
+
+  it('does not snap back to processing when retrying after a timeout while the recorder is still processing', async () => {
+    const onTranscriptComplete = vi.fn().mockReturnValue(new Promise<VoiceCommandResponse>(() => {}));
+
+    render(
+      <VoiceInterface isOpen onClose={vi.fn()} onTranscriptComplete={onTranscriptComplete} />
+    );
+
+    await armMicrophone();
+    await speak();
+    await act(async () => {
+      vi.advanceTimersByTime(PROCESSING_TIMEOUT_MS);
+    });
+    expect(screen.getByRole('button', { name: /Try Again/i })).toBeInTheDocument();
+
+    recorder.preserveProcessingOnReset(true);
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /Try Again/i }));
+    });
+
+    expect(screen.queryByText('Processing command...')).not.toBeInTheDocument();
+    expect(screen.getByText('Activating microphone...')).toBeInTheDocument();
+
+    await armMicrophone();
+    expect(screen.getByText('Listening...')).toBeInTheDocument();
   });
 });

--- a/packages/teacher/src/features/voiceControl/components/VoiceInterface.tsx
+++ b/packages/teacher/src/features/voiceControl/components/VoiceInterface.tsx
@@ -69,6 +69,12 @@ const VoiceInterface: React.FC<VoiceInterfaceProps> = ({
     }
   }, []);
 
+  const invalidateInFlightCommand = useCallback(() => {
+    processingGenerationRef.current += 1;
+    isProcessingRef.current = false;
+    cancelSpeech();
+  }, [cancelSpeech]);
+
   // Keep the open flag current during render so a then() that runs after the
   // parent flips isOpen (and before the isOpen effect) still sees the close.
   isOpenRef.current = isOpen;
@@ -85,13 +91,6 @@ const VoiceInterface: React.FC<VoiceInterfaceProps> = ({
       cancelSpeech();
     }
   }, [isOpen, clearScheduledActions, cancelSpeech]);
-
-  // Define handlers before useEffects
-  const invalidateInFlightCommand = useCallback(() => {
-    processingGenerationRef.current += 1;
-    isProcessingRef.current = false;
-    cancelSpeech();
-  }, [cancelSpeech]);
 
   const handleClose = useCallback(() => {
     clearScheduledActions();
@@ -147,14 +146,12 @@ const VoiceInterface: React.FC<VoiceInterfaceProps> = ({
     // Cleanup on unmount
     return () => {
       debug('🧹 Voice interface unmounting - releasing microphone resources');
-      processingGenerationRef.current += 1;
-      isProcessingRef.current = false;
+      invalidateInFlightCommand();
       clearScheduledActions();
-      cancelSpeech();
       stopRecording();
       resetState();
     };
-  }, [isOpen, clearScheduledActions, cancelSpeech, stopRecording, resetState]);
+  }, [isOpen, clearScheduledActions, invalidateInFlightCommand, stopRecording, resetState]);
 
   // Handle keyboard shortcuts
   useEffect(() => {
@@ -260,13 +257,12 @@ const VoiceInterface: React.FC<VoiceInterfaceProps> = ({
 
     const timeoutId = window.setTimeout(() => {
       debug('⏱️ Voice command processing timed out - forcing error state');
-      processingGenerationRef.current += 1;
-      isProcessingRef.current = false;
+      invalidateInFlightCommand();
       setVoiceState('error');
     }, PROCESSING_TIMEOUT_MS);
 
     return () => window.clearTimeout(timeoutId);
-  }, [isOpen, voiceState]);
+  }, [invalidateInFlightCommand, isOpen, voiceState]);
 
   // State transitions
   useEffect(() => {

--- a/packages/teacher/src/features/voiceControl/components/VoiceInterface.tsx
+++ b/packages/teacher/src/features/voiceControl/components/VoiceInterface.tsx
@@ -63,18 +63,35 @@ const VoiceInterface: React.FC<VoiceInterfaceProps> = ({
     timeoutIdsRef.current.push(timeoutId);
   }, []);
 
+  const cancelSpeech = useCallback(() => {
+    if (typeof window !== 'undefined' && 'speechSynthesis' in window) {
+      window.speechSynthesis.cancel();
+    }
+  }, []);
+
+  // Keep the open flag current during render so a then() that runs after the
+  // parent flips isOpen (and before the isOpen effect) still sees the close.
+  isOpenRef.current = isOpen;
+  const wasOpenRef = useRef(isOpen);
+  if (wasOpenRef.current && !isOpen) {
+    processingGenerationRef.current += 1;
+    isProcessingRef.current = false;
+  }
+  wasOpenRef.current = isOpen;
+
   useEffect(() => {
-    isOpenRef.current = isOpen;
     if (!isOpen) {
       clearScheduledActions();
+      cancelSpeech();
     }
-  }, [isOpen, clearScheduledActions]);
+  }, [isOpen, clearScheduledActions, cancelSpeech]);
 
   // Define handlers before useEffects
   const invalidateInFlightCommand = useCallback(() => {
     processingGenerationRef.current += 1;
     isProcessingRef.current = false;
-  }, []);
+    cancelSpeech();
+  }, [cancelSpeech]);
 
   const handleClose = useCallback(() => {
     clearScheduledActions();
@@ -130,11 +147,14 @@ const VoiceInterface: React.FC<VoiceInterfaceProps> = ({
     // Cleanup on unmount
     return () => {
       debug('🧹 Voice interface unmounting - releasing microphone resources');
+      processingGenerationRef.current += 1;
+      isProcessingRef.current = false;
       clearScheduledActions();
+      cancelSpeech();
       stopRecording();
       resetState();
     };
-  }, [isOpen, clearScheduledActions, stopRecording, resetState]);
+  }, [isOpen, clearScheduledActions, cancelSpeech, stopRecording, resetState]);
 
   // Handle keyboard shortcuts
   useEffect(() => {
@@ -192,7 +212,7 @@ const VoiceInterface: React.FC<VoiceInterfaceProps> = ({
 
     onTranscriptComplete(transcript)
       .then((response) => {
-        if (requestId !== processingGenerationRef.current) return;
+        if (requestId !== processingGenerationRef.current || !isOpenRef.current) return;
         setParsedCommand(response);
         setProcessedTranscript(transcript);
         const isError = response.feedback.type === 'error' || response.feedback.type === 'not_understood' || !response.success;
@@ -220,7 +240,7 @@ const VoiceInterface: React.FC<VoiceInterfaceProps> = ({
         }
       })
       .catch((err) => {
-        if (requestId !== processingGenerationRef.current) return;
+        if (requestId !== processingGenerationRef.current || !isOpenRef.current) return;
         debug.error('Command processing failed:', err);
         setVoiceState('error');
       })
@@ -260,7 +280,11 @@ const VoiceInterface: React.FC<VoiceInterfaceProps> = ({
       setVoiceState('listening');
       // Play feedback sound when we start listening
       playFeedback('listening');
-    } else if (isProcessing) {
+    } else if (isProcessing && voiceState !== 'activating') {
+      // Recorder isProcessing stays true after a finished utterance (and after
+      // the 20s watchdog, which does not reset the recorder). Activating is
+      // retry / low-quality re-arm; snapping back to processing here would
+      // hide listening UI until the watchdog fired again.
       setVoiceState('processing');
     }
   }, [isListening, isProcessing, isGathering, voiceState, error, playFeedback]);

--- a/packages/teacher/src/features/widgets/imageDisplay/imageDisplay.test.tsx
+++ b/packages/teacher/src/features/widgets/imageDisplay/imageDisplay.test.tsx
@@ -267,6 +267,33 @@ describe('ImageDisplay', () => {
     expect(screen.queryByAltText('Display')).not.toBeInTheDocument();
   });
 
+  test('clears the previous image when an external key load throws', async () => {
+    vi.mocked(loadImage).mockImplementation(async (key: string) => {
+      if (key === 'first-key') return `data:image/png;base64,${key}`;
+      throw new Error('idb unavailable');
+    });
+
+    const { rerender } = render(
+      <ImageDisplay widgetId="widget-1" savedState={{ imageKey: 'first-key' }} />
+    );
+
+    expect(await screen.findByAltText('Display')).toHaveAttribute('src', 'data:image/png;base64,first-key');
+
+    rerender(<ImageDisplay widgetId="widget-1" savedState={{ imageKey: 'broken-key' }} />);
+
+    expect(await screen.findByText('Unable to load image. Please try again.')).toBeInTheDocument();
+    expect(screen.queryByAltText('Display')).not.toBeInTheDocument();
+  });
+
+  test('shows an error when the initial saved image is missing from storage', async () => {
+    vi.mocked(loadImage).mockResolvedValueOnce(null);
+
+    render(<ImageDisplay savedState={{ imageKey: 'stored-image' }} />);
+
+    expect(await screen.findByText('Unable to load image. Please try again.')).toBeInTheDocument();
+    expect(screen.queryByAltText('Display')).not.toBeInTheDocument();
+  });
+
   test('aborts active file reader and ignores file load callbacks after unmount', () => {
     const { container, unmount } = render(<ImageDisplay widgetId="widget-1" onStateChange={vi.fn()} />);
     const input = container.querySelector('input[type="file"]') as HTMLInputElement;

--- a/packages/teacher/src/features/widgets/imageDisplay/imageDisplay.tsx
+++ b/packages/teacher/src/features/widgets/imageDisplay/imageDisplay.tsx
@@ -52,21 +52,32 @@ const ImageDisplay: React.FC<ImageDisplayProps> = ({ widgetId, savedState, onSta
 
   const isCurrentImageChange = (changeId: number) => imageChangeIdRef.current === changeId;
 
+  const applyLoadedImage = (changeId: number, url: string | null) => {
+    if (!isCurrentImageChange(changeId)) return;
+    if (url) {
+      setError(null);
+      setImageUrl(url);
+    } else {
+      // A missing IndexedDB blob is a load failure, not an empty widget.
+      setImageUrl(null);
+      setError(STORAGE_LOAD_ERROR);
+    }
+  };
+
+  const applyImageLoadError = (changeId: number) => {
+    if (!isCurrentImageChange(changeId)) return;
+    setImageUrl(null);
+    setError(STORAGE_LOAD_ERROR);
+  };
+
   // Load image from IndexedDB on mount
   useEffect(() => {
     const changeId = imageChangeIdRef.current;
     const key = savedState?.imageKey;
     if (key) {
       void loadImage(key)
-        .then(url => {
-          if (url && isCurrentImageChange(changeId)) {
-            setError(null);
-            setImageUrl(url);
-          }
-        })
-        .catch(() => {
-          if (isCurrentImageChange(changeId)) setError(STORAGE_LOAD_ERROR);
-        });
+        .then(url => applyLoadedImage(changeId, url))
+        .catch(() => applyImageLoadError(changeId));
     } else if (savedState?.imageUrl) {
       // Migrate legacy base64 imageUrl to IndexedDB
       const newKey = widgetId ? `image-${widgetId}` : `image-${Date.now()}`;
@@ -109,22 +120,8 @@ const ImageDisplay: React.FC<ImageDisplayProps> = ({ widgetId, savedState, onSta
     }
 
     void loadImage(persistedImageKey)
-      .then(url => {
-        if (!isCurrentImageChange(changeId)) return;
-        if (url) {
-          setError(null);
-          setImageUrl(url);
-        } else {
-          // A missing IndexedDB blob is a load failure, not an empty widget.
-          // Clearing the error here left compact-panel / workspace switches
-          // showing a blank image with no explanation.
-          setImageUrl(null);
-          setError(STORAGE_LOAD_ERROR);
-        }
-      })
-      .catch(() => {
-        if (isCurrentImageChange(changeId)) setError(STORAGE_LOAD_ERROR);
-      });
+      .then(url => applyLoadedImage(changeId, url))
+      .catch(() => applyImageLoadError(changeId));
   }, [persistedImageKey]);
 
   // Update image and notify parent

--- a/packages/teacher/src/features/widgets/shared/useWidgetState.test.tsx
+++ b/packages/teacher/src/features/widgets/shared/useWidgetState.test.tsx
@@ -144,6 +144,51 @@ describe('useWidgetState savedState resync', () => {
     expect(result.current.state.board[4]).toBe('X');
   });
 
+  it('does not clobber a second local write when the parent echoes the first persist', () => {
+    const { result, rerender } = renderWidget(makeState());
+
+    const firstWrite = withMove(0, 'X');
+    const secondWrite = makeState({
+      board: ['X', 'O', null, null, null, null, null, null, null],
+      currentPlayer: 'X'
+    });
+
+    act(() => {
+      result.current.setState(firstWrite);
+    });
+    act(() => {
+      result.current.setState(secondWrite);
+    });
+    expect(result.current.state).toEqual(secondWrite);
+
+    // The first persist lands after the second local write. Adopting it would
+    // roll the widget back from A2 to A1.
+    rerender({ savedState: firstWrite });
+
+    expect(result.current.state).toEqual(secondWrite);
+    expect(result.current.state.board[1]).toBe('O');
+  });
+
+  it('still adopts a genuine external change after two local writes', () => {
+    const { result, rerender } = renderWidget(makeState());
+
+    act(() => {
+      result.current.setState(withMove(0, 'X'));
+    });
+    act(() => {
+      result.current.setState(withMove(4, 'O'));
+    });
+
+    const external = makeState({
+      board: ['X', 'O', null, null, null, null, null, null, null],
+      currentPlayer: 'X',
+      score: { X: 1, O: 2 }
+    });
+    rerender({ savedState: external });
+
+    expect(result.current.state).toEqual(external);
+  });
+
   it('keeps an in-flight local update when the lagging savedState is also rebuilt', () => {
     const { result, rerender } = renderWidget(makeState());
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to the merged [PR #76](https://github.com/tinkertanker/classroom-widgets/pull/76). Four independent adversarial reviews of cowdinosaur’s 19 August remediations and the landed fix agreed on remaining stale-state holes.

## Reviewers

- Correctness (widget/session/voice traces)
- Diff-scoped security/correctness audit
- Maintainability (generation/invalidate ownership, shared image apply path)
- Race-condition / stale-state hunt

## Fixes

1. **Voice** — Parent `isOpen={false}` without `handleClose` no longer lets a late command succeed, speak, or auto-close. Timeout no longer snaps retry/low-quality `'activating'` back to processing. Watchdog and unmount use the same invalidate helper.
2. **Images** — Missing or throwing IndexedDB loads (mount and resync) clear the previous pixels and show the load error.
3. **`useWidgetState`** — A late persist of local write A1 no longer clobbers a newer local write A2.
4. **Double-Cmd** — Cmd+K / any Cmd chord cancels the pending double-Cmd window, so a chord then another Cmd cannot also start voice.
5. **Session recover** — `CODE_FILL_BLANK` is included in post-recovery room cleanup, so those student rooms are no longer closed two seconds after a successful rejoin.

## Out of scope

Canvas↔column unmount still closes networked rooms after 100ms. That unmount `closeRoom` path is older than this remediation pile and needs a product decision (close only on widget delete vs keep rooms across layout switch).

## Test plan

- `npm run test -- src/features/voiceControl/components/VoiceInterface.test.tsx src/app/App.test.tsx src/features/widgets/imageDisplay/imageDisplay.test.tsx src/features/widgets/shared/useWidgetState.test.tsx src/contexts/SessionContext.test.tsx` in `packages/teacher` (55 passed)
- Cmd, Cmd+K, Cmd must not open voice
- Timeout then retry must stay on activating/listening, not “Processing command…”
- Workspace switch to a missing image key shows the load error, not the previous picture

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0197e-28a9-729d-b7a2-be5b9116693d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0197e-28a9-729d-b7a2-be5b9116693d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

