### PR TITLE
Speed up the macOS dashboard without UI changes

### DIFF
--- a/packages/macos-dashboard/Sources/ClassroomWidgetsDashboard/AppDelegate.swift
+++ b/packages/macos-dashboard/Sources/ClassroomWidgetsDashboard/AppDelegate.swift
@@ -3,7 +3,7 @@ import Carbon
 import SwiftUI
 
 @MainActor
-final class AppDelegate: NSObject, NSApplicationDelegate {
+final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     private var controller: DashboardWindowController?
     private var terminationPending = false
     private var terminationApproved = false
@@ -14,7 +14,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         launchAtLoginManager: launchAtLoginManager,
         onShortcutsChanged: { [weak self] in
             self?.registerHotKeys()
-            self?.updateStatusMenu()
         },
         onWindowBehaviorChanged: { [weak self] in
             self?.controller?.applySettings()
@@ -47,12 +46,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         setupMainMenu()
 
         let controller = DashboardWindowController()
-        controller.onVisibilityChanged = { [weak self] _ in
-            self?.updateStatusMenu()
-        }
-        controller.onCompactWidgetOptionsChanged = { [weak self] _ in
-            self?.updateStatusMenu()
-        }
         self.controller = controller
         setupStatusItem()
         registerHotKeys()
@@ -68,6 +61,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationWillTerminate(_ notification: Notification) {
+        controller?.flushPersistedState()
         hotKeys.removeAll()
     }
 
@@ -145,8 +139,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let statusItem = NSStatusBar.system.statusItem(withLength: 26)
         statusItem.button?.image = DashboardMenuBarIcon.make(size: 21)
         statusItem.button?.imagePosition = .imageOnly
+        let menu = NSMenu()
+        menu.delegate = self
+        statusItem.menu = menu
         self.statusItem = statusItem
-        updateStatusMenu()
     }
 
     private func syncStatusItemVisibility() {
@@ -155,8 +151,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         if shouldShow {
             if statusItem == nil {
                 setupStatusItem()
-            } else {
-                updateStatusMenu()
             }
             return
         }
@@ -167,8 +161,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         statusItem = nil
     }
 
-    private func updateStatusMenu() {
-        let menu = NSMenu()
+    func menuNeedsUpdate(_ menu: NSMenu) {
+        rebuildStatusMenu(into: menu)
+    }
+
+    private func rebuildStatusMenu(into menu: NSMenu) {
+        menu.removeAllItems()
 
         let toggleTitle = controller?.isDashboardVisible == true ? "Hide Dashboard" : "Show Dashboard"
         let toggleItem = NSMenuItem(title: toggleTitle, action: #selector(toggleDashboard), keyEquivalent: "")
@@ -238,8 +236,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let quitItem = NSMenuItem(title: "Quit Classroom Widgets", action: #selector(quitApp), keyEquivalent: "q")
         quitItem.target = self
         menu.addItem(quitItem)
-
-        statusItem?.menu = menu
     }
 
     private func applyShortcut(to item: NSMenuItem, keyCode: Int, modifiers: Int) {
@@ -265,7 +261,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             reservedShortcuts: []
         ) { [weak self] in
             self?.controller?.toggleDashboard()
-            self?.updateStatusMenu()
         }
 
         let launcherKeyCode = shortcutKeyCode(for: DashboardSettingKeys.launcherShortcutKeyCode, fallback: DashboardDefaults.launcherShortcutKeyCode)
@@ -277,7 +272,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             reservedShortcuts: [(toggleKeyCode, toggleModifiers)]
         ) { [weak self] in
             self?.controller?.showWidgetLauncher()
-            self?.updateStatusMenu()
         }
 
         let settingsKeyCode = shortcutKeyCode(for: DashboardSettingKeys.settingsShortcutKeyCode, fallback: DashboardDefaults.settingsShortcutKeyCode)
@@ -292,7 +286,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             ]
         ) { [weak self] in
             self?.settingsWindowCoordinator.show()
-            self?.updateStatusMenu()
         }
     }
 
@@ -331,12 +324,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     @objc private func toggleDashboard() {
         controller?.toggleDashboard()
-        updateStatusMenu()
     }
 
     @objc private func showWidgetLauncher() {
         controller?.showWidgetLauncher()
-        updateStatusMenu()
     }
 
     @objc private func reloadDashboard() {
@@ -345,7 +336,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     @objc private func addCompactWidget(_ sender: NSMenuItem) {
         controller?.addCompactWidget(sender.tag)
-        updateStatusMenu()
     }
 
     @objc private func closeFrontWindow() {
@@ -359,7 +349,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         if keyWindow is DashboardWindow {
             if controller?.isDashboardVisible == true {
                 controller?.toggleDashboard()
-                updateStatusMenu()
             } else {
                 // Already hiding (window lingers briefly for the exit
                 // animation) — nothing to close.
@@ -394,7 +383,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         } catch {
             presentError(error, title: "Launch at Login Failed")
         }
-        updateStatusMenu()
     }
 
     @objc private func quitApp() {

--- a/packages/macos-dashboard/Sources/ClassroomWidgetsDashboard/DashboardMenuBarIcon.swift
+++ b/packages/macos-dashboard/Sources/ClassroomWidgetsDashboard/DashboardMenuBarIcon.swift
@@ -1,7 +1,16 @@
 import AppKit
 
 enum DashboardMenuBarIcon {
+    private static let statusItemIcon = makeImage(size: 21)
+
     static func make(size: CGFloat = 18) -> NSImage {
+        if size == 21 {
+            return statusItemIcon
+        }
+        return makeImage(size: size)
+    }
+
+    private static func makeImage(size: CGFloat) -> NSImage {
         let image = NSImage(size: NSSize(width: size, height: size), flipped: false) { rect in
             NSColor.labelColor.setFill()
             let symbolScale = 0.8

--- a/packages/macos-dashboard/Sources/ClassroomWidgetsDashboard/DashboardWebViewSupport.swift
+++ b/packages/macos-dashboard/Sources/ClassroomWidgetsDashboard/DashboardWebViewSupport.swift
@@ -1,0 +1,51 @@
+import Foundation
+import WebKit
+
+enum DashboardWebKitShared {
+    static let schemeHandler = StaticFileSchemeHandler(webRoot: WebRootResolver.resolve())
+    static let panelProcessPool = WKProcessPool()
+}
+
+enum ClassroomWebViewTuning {
+    static func apply(to webView: WKWebView) {
+        webView.allowsBackForwardNavigationGestures = false
+        webView.allowsLinkPreview = false
+    }
+}
+
+@MainActor
+final class DebouncedDefaultsWriter {
+    private var pending: [String: String] = [:]
+    private var generation = 0
+    private let delayNanoseconds: UInt64
+
+    init(delayNanoseconds: UInt64 = 300_000_000) {
+        self.delayNanoseconds = delayNanoseconds
+    }
+
+    func set(_ value: String, forKey key: String) {
+        pending[key] = value
+        generation += 1
+        let scheduledGeneration = generation
+        let delay = delayNanoseconds
+        Task { @MainActor [weak self] in
+            try? await Task.sleep(nanoseconds: delay)
+            guard let self, self.generation == scheduledGeneration else { return }
+            self.flush()
+        }
+    }
+
+    func setImmediately(_ value: String, forKey key: String) {
+        pending[key] = value
+        flush()
+    }
+
+    func flush() {
+        generation += 1
+        guard !pending.isEmpty else { return }
+        let values = pending
+        pending.removeAll()
+        let defaults = UserDefaults.standard
+        values.forEach { defaults.set($0.value, forKey: $0.key) }
+    }
+}

--- a/packages/macos-dashboard/Sources/ClassroomWidgetsDashboard/DashboardWindowController.swift
+++ b/packages/macos-dashboard/Sources/ClassroomWidgetsDashboard/DashboardWindowController.swift
@@ -537,13 +537,16 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
 
     private func abortCompactTransition() {
         pendingWidgetLauncherOpen = false
+        widgetLauncherOpenAttemptInFlight = false
         // Preparing a handoff marks each panel bridge as closing, so recreate
         // the compact surfaces rather than re-showing those inert web views.
         widgetPanelCoordinator.enterCanvas()
         isChangingWindowMode = false
         resetHostWriteTracking()
         // Launcher prepare and window-mode requests update the webview before
-        // this handoff finishes; restore the still-compact host mode there too.
+        // this handoff finishes; restore the still-compact host mode there too
+        // and drop any launchpad the bridge already opened or queued.
+        cancelWebWidgetLauncher()
         setWebWindowMode(windowMode)
         let hasCompactPanels = widgetPanelCoordinator.enterCompact()
         guard dashboardVisible else {
@@ -1371,6 +1374,20 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
         return NSScreen.screens.contains { $0.visibleFrame.intersects(frame) }
     }
 
+    private func cancelWebWidgetLauncher() {
+        webView.evaluateJavaScript(
+            """
+            (() => {
+              if (window.cancelClassroomWidgetLauncher) {
+                window.cancelClassroomWidgetLauncher();
+                return true;
+              }
+              return false;
+            })()
+            """
+        )
+    }
+
     private func openWidgetLauncher(retriesRemaining: Int = 5) {
         guard pendingWidgetLauncherOpen, !widgetLauncherOpenAttemptInFlight else { return }
         widgetLauncherOpenAttemptInFlight = true
@@ -1388,6 +1405,10 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
             self.widgetLauncherOpenAttemptInFlight = false
             if result as? Bool == true {
                 self.pendingWidgetLauncherOpen = false
+                if self.windowMode == .compact && !self.isChangingWindowMode {
+                    self.cancelWebWidgetLauncher()
+                    self.setWebWindowMode(.compact)
+                }
                 return
             }
             guard retriesRemaining > 0 else {

--- a/packages/macos-dashboard/Sources/ClassroomWidgetsDashboard/DashboardWindowController.swift
+++ b/packages/macos-dashboard/Sources/ClassroomWidgetsDashboard/DashboardWindowController.swift
@@ -536,11 +536,15 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
     }
 
     private func abortCompactTransition() {
+        pendingWidgetLauncherOpen = false
         // Preparing a handoff marks each panel bridge as closing, so recreate
         // the compact surfaces rather than re-showing those inert web views.
         widgetPanelCoordinator.enterCanvas()
         isChangingWindowMode = false
         resetHostWriteTracking()
+        // Launcher prepare and window-mode requests update the webview before
+        // this handoff finishes; restore the still-compact host mode there too.
+        setWebWindowMode(windowMode)
         let hasCompactPanels = widgetPanelCoordinator.enterCompact()
         guard dashboardVisible else {
             widgetPanelCoordinator.hideAll()

--- a/packages/macos-dashboard/Sources/ClassroomWidgetsDashboard/DashboardWindowController.swift
+++ b/packages/macos-dashboard/Sources/ClassroomWidgetsDashboard/DashboardWindowController.swift
@@ -49,6 +49,7 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
     private var pendingHostWriteFailed = false
     private var hostWriteGeneration = 0
     private var pendingHostWriteWaiters: [(@MainActor (Bool) -> Void)] = []
+    private let frameDefaultsWriter = DebouncedDefaultsWriter()
 
     var isDashboardVisible: Bool { dashboardVisible }
     var onVisibilityChanged: (@MainActor (Bool) -> Void)?
@@ -62,9 +63,10 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
 
         let configuration = WKWebViewConfiguration()
         configuration.setURLSchemeHandler(
-            StaticFileSchemeHandler(webRoot: WebRootResolver.resolve()),
+            DashboardWebKitShared.schemeHandler,
             forURLScheme: dashboardURLScheme
         )
+        DashboardWebKitShared.schemeHandler.prewarmCriticalAssets()
         configuration.userContentController.addUserScript(WKUserScript(
             source: "window.__CLASSROOM_WIDGETS_MACOS__ = true;",
             injectionTime: .atDocumentStart,
@@ -74,6 +76,7 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
         widgetPanelCoordinator = WidgetPanelCoordinator(compactPresentationActive: initiallyVisible)
 
         webView = WKWebView(frame: .zero, configuration: configuration)
+        ClassroomWebViewTuning.apply(to: webView)
         // This is intentionally an opaque, bounded AppKit window.  The
         // previous transparent, display-sized window made input routing depend
         // on asynchronous DOM hit regions.
@@ -185,10 +188,7 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
     }
 
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
-        setWebDashboardVisible(dashboardVisible)
-        setWebWindowMode(windowMode)
-        setWebBackgroundOpacity(compactBackgroundOpacity)
-        setWebWindowChromeVisible(compactChromeVisible || windowMode == .canvas)
+        pushWebDashboardState()
 
         if pendingWidgetLauncherOpen && !widgetLauncherOpenAttemptInFlight {
             openWidgetLauncher()
@@ -333,7 +333,13 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
         }
     }
 
+    func flushPersistedState() {
+        persistFrame(for: windowMode, immediately: true)
+        widgetPanelCoordinator.flushPersistedFrames()
+    }
+
     func prepareForTermination() async -> Bool {
+        flushPersistedState()
         guard !isChangingWindowMode else { return false }
         guard windowMode == .compact else { return true }
 
@@ -436,7 +442,7 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
     }
 
     private func completeWindowModeChange(_ mode: DashboardWindowMode) {
-        persistFrame(for: windowMode)
+        persistFrame(for: windowMode, immediately: true)
         windowMode = mode
         configureWindow(for: mode)
         restoreFrame(for: mode)
@@ -480,7 +486,7 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
                     self.retryCanvasTransition(pendingChanges, retriesRemaining: retriesRemaining - 1)
                     return
                 }
-                self.persistFrame(for: self.windowMode)
+                self.persistFrame(for: self.windowMode, immediately: true)
                 self.windowMode = .canvas
                 self.configureWindow(for: .canvas)
                 self.restoreFrame(for: .canvas)
@@ -927,7 +933,8 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
         compactNavigationBar.frame = navigationBarFrame
         centreTrafficLights(in: navigationBarFrame, contentView: contentView)
 
-        let trafficLightsRightEdge = trafficLights
+        let buttons = trafficLights
+        let trafficLightsRightEdge = buttons
             .map { $0.convert($0.bounds, to: contentView).maxX }
             .max() ?? 70
         let leftInset = trafficLightsRightEdge + 12
@@ -1044,14 +1051,14 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
         let buttons = trafficLights
         let reduceMotion = NSWorkspace.shared.accessibilityDisplayShouldReduceMotion
 
-        for button in buttons {
-            button.isHidden = false
-            if reduceMotion {
-                button.alphaValue = visible ? 1 : 0
-            } else {
-                NSAnimationContext.runAnimationGroup { context in
-                    context.duration = 0.16
-                    button.animator().alphaValue = visible ? 1 : 0
+        if reduceMotion {
+            buttons.forEach { $0.isHidden = false; $0.alphaValue = visible ? 1 : 0 }
+        } else {
+            NSAnimationContext.runAnimationGroup { context in
+                context.duration = 0.16
+                buttons.forEach {
+                    $0.isHidden = false
+                    $0.animator().alphaValue = visible ? 1 : 0
                 }
             }
         }
@@ -1246,9 +1253,65 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
         }
     }
 
-    private func persistFrame(for mode: DashboardWindowMode) {
+    private func persistFrame(for mode: DashboardWindowMode, immediately: Bool = false) {
         guard let window, !window.styleMask.contains(.fullScreen) else { return }
-        UserDefaults.standard.set(NSStringFromRect(window.frame), forKey: Self.frameDefaultsKey(for: mode))
+        let encodedFrame = NSStringFromRect(window.frame)
+        let key = Self.frameDefaultsKey(for: mode)
+        if immediately {
+            frameDefaultsWriter.setImmediately(encodedFrame, forKey: key)
+        } else {
+            frameDefaultsWriter.set(encodedFrame, forKey: key)
+        }
+    }
+
+    private func pushWebDashboardState() {
+        visibilityPushGeneration += 1
+        modePushGeneration += 1
+        backgroundOpacityPushGeneration += 1
+        chromeVisibilityPushGeneration += 1
+        let generation = visibilityPushGeneration
+        let visible = dashboardVisible
+        let mode = windowMode.rawValue
+        let opacity = compactBackgroundOpacity
+        let chromeVisible = compactChromeVisible || windowMode == .canvas
+        webView.callAsyncJavaScript(
+            """
+            return (() => {
+              const dashboard = window.classroomDashboard;
+              if (!dashboard?.setVisible || !dashboard?.setWindowMode || !dashboard?.getWindowMode
+                  || !dashboard?.setBackgroundOpacity || !dashboard?.setWindowChromeVisible) {
+                return false;
+              }
+              dashboard.setVisible(visible);
+              dashboard.setWindowMode(mode);
+              if (dashboard.getWindowMode() !== mode) return false;
+              dashboard.setBackgroundOpacity(opacity);
+              dashboard.setWindowChromeVisible(chromeVisible);
+              return true;
+            })()
+            """,
+            arguments: [
+                "visible": visible,
+                "mode": mode,
+                "opacity": opacity,
+                "chromeVisible": chromeVisible
+            ],
+            in: nil,
+            in: .page
+        ) { [weak self] result in
+            guard let self else { return }
+            guard self.visibilityPushGeneration == generation else { return }
+            if case let .success(value) = result, value as? Bool == true {
+                return
+            }
+            Task { @MainActor in
+                try? await Task.sleep(nanoseconds: 150_000_000)
+                self.setWebDashboardVisible(visible)
+                self.setWebWindowMode(self.windowMode)
+                self.setWebBackgroundOpacity(opacity)
+                self.setWebWindowChromeVisible(chromeVisible)
+            }
+        }
     }
 
     private func restoreFrame(for mode: DashboardWindowMode) {

--- a/packages/macos-dashboard/Sources/ClassroomWidgetsDashboard/StaticFileSchemeHandler.swift
+++ b/packages/macos-dashboard/Sources/ClassroomWidgetsDashboard/StaticFileSchemeHandler.swift
@@ -62,25 +62,44 @@ final class StaticFileSchemeHandler: NSObject, WKURLSchemeHandler {
         let root = webRoot
         ioQueue.async { [weak self] in
             guard let self else { return }
-            let index = root.appendingPathComponent("index.html")
-            _ = try? self.loadPayload(for: index.standardizedFileURL)
+            let index = root.appendingPathComponent("index.html").standardizedFileURL
+            guard let htmlPayload = try? self.loadPayload(for: index),
+                  let html = String(data: htmlPayload.data, encoding: .utf8) else {
+                return
+            }
 
-            let assets = root.appendingPathComponent("assets", isDirectory: true)
-            let fileManager = FileManager.default
-            guard let enumerator = fileManager.enumerator(
-                at: assets,
-                includingPropertiesForKeys: [.isRegularFileKey],
-                options: [.skipsHiddenFiles]
-            ) else { return }
-
-            for case let fileURL as URL in enumerator {
-                let ext = fileURL.pathExtension.lowercased()
-                guard ext == "js" || ext == "mjs" || ext == "css" else { continue }
-                let standardized = fileURL.standardizedFileURL
-                guard self.isInsideWebRoot(standardized) else { continue }
-                _ = try? self.loadPayload(for: standardized)
+            for path in Self.referencedEntryAssets(in: html) {
+                let relativePath = path.split(separator: "/").map(String.init).joined(separator: "/")
+                let fileURL = root.appendingPathComponent(relativePath).standardizedFileURL
+                guard self.isInsideWebRoot(fileURL) else { continue }
+                _ = try? self.loadPayload(for: fileURL)
             }
         }
+    }
+
+    private static let entryAssetReferenceRegex = try! NSRegularExpression(
+        pattern: #"(?:src|href)=["'](/[^"']+)["']"#
+    )
+
+    static func referencedEntryAssets(in html: String) -> [String] {
+        let nsHTML = html as NSString
+        let range = NSRange(location: 0, length: nsHTML.length)
+        let matches = entryAssetReferenceRegex.matches(in: html, options: [], range: range)
+        var seen = Set<String>()
+        var paths: [String] = []
+
+        for match in matches {
+            guard match.numberOfRanges > 1 else { continue }
+            let path = nsHTML.substring(with: match.range(at: 1))
+            if path.hasPrefix("//") { continue }
+            let ext = (path as NSString).pathExtension.lowercased()
+            guard ext == "js" || ext == "mjs" || ext == "css" else { continue }
+            if seen.insert(path).inserted {
+                paths.append(path)
+            }
+        }
+
+        return paths
     }
 
     private func fileURL(for requestURL: URL) -> URL? {

--- a/packages/macos-dashboard/Sources/ClassroomWidgetsDashboard/StaticFileSchemeHandler.swift
+++ b/packages/macos-dashboard/Sources/ClassroomWidgetsDashboard/StaticFileSchemeHandler.swift
@@ -3,8 +3,12 @@ import Foundation
 
 final class StaticFileSchemeHandler: NSObject, WKURLSchemeHandler {
     private let webRoot: URL
+    private let lock = NSLock()
+    private let ioQueue = DispatchQueue(label: "classroom-widgets.static-files", qos: .userInitiated)
     private var cache: [URL: (data: Data, mimeType: String)] = [:]
+    private var resolvedPaths: [String: URL] = [:]
     private var stoppedTasks = Set<ObjectIdentifier>()
+    private var didStartPrewarm = false
 
     init(webRoot: URL) {
         self.webRoot = webRoot.resolvingSymlinksInPath().standardizedFileURL
@@ -22,41 +26,82 @@ final class StaticFileSchemeHandler: NSObject, WKURLSchemeHandler {
         }
 
         let taskID = ObjectIdentifier(urlSchemeTask)
-        stoppedTasks.remove(taskID)
+        markStarted(taskID)
 
-        do {
-            let payload = try payload(for: fileURL)
-            guard !isStopped(taskID) else { return }
+        if let cached = cachedPayload(for: fileURL) {
+            complete(task: urlSchemeTask, taskID: taskID, requestURL: requestURL, payload: cached)
+            return
+        }
 
-            let response = URLResponse(
-                url: requestURL,
-                mimeType: payload.mimeType,
-                expectedContentLength: payload.data.count,
-                textEncodingName: nil
-            )
-            urlSchemeTask.didReceive(response)
-            urlSchemeTask.didReceive(payload.data)
-            urlSchemeTask.didFinish()
-        } catch {
-            guard !isStopped(taskID) else { return }
-            urlSchemeTask.didFailWithError(error)
+        ioQueue.async { [weak self] in
+            guard let self else { return }
+            do {
+                let payload = try self.loadPayload(for: fileURL)
+                self.complete(task: urlSchemeTask, taskID: taskID, requestURL: requestURL, payload: payload)
+            } catch {
+                self.fail(task: urlSchemeTask, taskID: taskID, error: error)
+            }
         }
     }
 
     func webView(_ webView: WKWebView, stop urlSchemeTask: WKURLSchemeTask) {
-        let taskID = ObjectIdentifier(urlSchemeTask)
-        stoppedTasks.insert(taskID)
+        lock.lock()
+        stoppedTasks.insert(ObjectIdentifier(urlSchemeTask))
+        lock.unlock()
+    }
+
+    func prewarmCriticalAssets() {
+        lock.lock()
+        if didStartPrewarm {
+            lock.unlock()
+            return
+        }
+        didStartPrewarm = true
+        lock.unlock()
+
+        let root = webRoot
+        ioQueue.async { [weak self] in
+            guard let self else { return }
+            let index = root.appendingPathComponent("index.html")
+            _ = try? self.loadPayload(for: index.standardizedFileURL)
+
+            let assets = root.appendingPathComponent("assets", isDirectory: true)
+            let fileManager = FileManager.default
+            guard let enumerator = fileManager.enumerator(
+                at: assets,
+                includingPropertiesForKeys: [.isRegularFileKey],
+                options: [.skipsHiddenFiles]
+            ) else { return }
+
+            for case let fileURL as URL in enumerator {
+                let ext = fileURL.pathExtension.lowercased()
+                guard ext == "js" || ext == "mjs" || ext == "css" else { continue }
+                let standardized = fileURL.standardizedFileURL
+                guard self.isInsideWebRoot(standardized) else { continue }
+                _ = try? self.loadPayload(for: standardized)
+            }
+        }
     }
 
     private func fileURL(for requestURL: URL) -> URL? {
         let rawPath = requestURL.path == "/" ? "/index.html" : requestURL.path
         let relativePath = rawPath.split(separator: "/").map(String.init).joined(separator: "/")
-        let fileURL = webRoot.appendingPathComponent(relativePath).resolvingSymlinksInPath().standardizedFileURL
 
+        lock.lock()
+        if let cached = resolvedPaths[relativePath] {
+            lock.unlock()
+            return cached
+        }
+        lock.unlock()
+
+        let fileURL = webRoot.appendingPathComponent(relativePath).standardizedFileURL
         guard isInsideWebRoot(fileURL) else {
             return nil
         }
 
+        lock.lock()
+        resolvedPaths[relativePath] = fileURL
+        lock.unlock()
         return fileURL
     }
 
@@ -71,31 +116,95 @@ final class StaticFileSchemeHandler: NSObject, WKURLSchemeHandler {
         return zip(rootComponents, fileComponents).allSatisfy(==)
     }
 
-    private func payload(for fileURL: URL) throws -> (data: Data, mimeType: String) {
-        if let cached = cache[fileURL] {
+    private func cachedPayload(for fileURL: URL) -> (data: Data, mimeType: String)? {
+        lock.lock()
+        let cached = cache[fileURL]
+        lock.unlock()
+        return cached
+    }
+
+    private func loadPayload(for fileURL: URL) throws -> (data: Data, mimeType: String) {
+        if let cached = cachedPayload(for: fileURL) {
             return cached
         }
 
         let payload = (
-            data: try Data(contentsOf: fileURL),
+            data: try Data(contentsOf: fileURL, options: .mappedIfSafe),
             mimeType: mimeType(for: fileURL.pathExtension)
         )
+
+        lock.lock()
         cache[fileURL] = payload
+        lock.unlock()
         return payload
     }
 
+    private func markStarted(_ taskID: ObjectIdentifier) {
+        lock.lock()
+        stoppedTasks.remove(taskID)
+        lock.unlock()
+    }
+
     private func isStopped(_ taskID: ObjectIdentifier) -> Bool {
-        stoppedTasks.remove(taskID) != nil
+        lock.lock()
+        let stopped = stoppedTasks.remove(taskID) != nil
+        lock.unlock()
+        return stopped
+    }
+
+    private func complete(
+        task: WKURLSchemeTask,
+        taskID: ObjectIdentifier,
+        requestURL: URL,
+        payload: (data: Data, mimeType: String)
+    ) {
+        guard !isStopped(taskID) else { return }
+
+        let response = HTTPURLResponse(
+            url: requestURL,
+            statusCode: 200,
+            httpVersion: "HTTP/1.1",
+            headerFields: [
+                "Content-Type": payload.mimeType,
+                "Content-Length": "\(payload.data.count)",
+                "Cache-Control": cacheControl(for: requestURL)
+            ]
+        ) ?? URLResponse(
+            url: requestURL,
+            mimeType: payload.mimeType,
+            expectedContentLength: payload.data.count,
+            textEncodingName: nil
+        )
+
+        task.didReceive(response)
+        task.didReceive(payload.data)
+        task.didFinish()
+    }
+
+    private func fail(task: WKURLSchemeTask, taskID: ObjectIdentifier, error: Error) {
+        guard !isStopped(taskID) else { return }
+        task.didFailWithError(error)
+    }
+
+    private func cacheControl(for requestURL: URL) -> String {
+        let name = requestURL.lastPathComponent
+        if name == "index.html" || requestURL.path == "/" {
+            return "no-cache"
+        }
+        if requestURL.path.contains("/assets/") {
+            return "public, max-age=31536000, immutable"
+        }
+        return "public, max-age=86400"
     }
 
     private func mimeType(for pathExtension: String) -> String {
         switch pathExtension.lowercased() {
         case "html":
-            return "text/html"
+            return "text/html; charset=utf-8"
         case "js", "mjs":
-            return "text/javascript"
+            return "text/javascript; charset=utf-8"
         case "css":
-            return "text/css"
+            return "text/css; charset=utf-8"
         case "svg":
             return "image/svg+xml"
         case "png":

--- a/packages/macos-dashboard/Sources/ClassroomWidgetsDashboard/StaticFileSchemeHandler.swift
+++ b/packages/macos-dashboard/Sources/ClassroomWidgetsDashboard/StaticFileSchemeHandler.swift
@@ -158,6 +158,13 @@ final class StaticFileSchemeHandler: NSObject, WKURLSchemeHandler {
         requestURL: URL,
         payload: (data: Data, mimeType: String)
     ) {
+        guard Thread.isMainThread else {
+            DispatchQueue.main.async { [weak self] in
+                self?.complete(task: task, taskID: taskID, requestURL: requestURL, payload: payload)
+            }
+            return
+        }
+
         guard !isStopped(taskID) else { return }
 
         let response = HTTPURLResponse(
@@ -182,6 +189,13 @@ final class StaticFileSchemeHandler: NSObject, WKURLSchemeHandler {
     }
 
     private func fail(task: WKURLSchemeTask, taskID: ObjectIdentifier, error: Error) {
+        guard Thread.isMainThread else {
+            DispatchQueue.main.async { [weak self] in
+                self?.fail(task: task, taskID: taskID, error: error)
+            }
+            return
+        }
+
         guard !isStopped(taskID) else { return }
         task.didFailWithError(error)
     }

--- a/packages/macos-dashboard/Sources/ClassroomWidgetsDashboard/WebRootResolver.swift
+++ b/packages/macos-dashboard/Sources/ClassroomWidgetsDashboard/WebRootResolver.swift
@@ -1,7 +1,13 @@
 import Foundation
 
 enum WebRootResolver {
+    private static let resolvedRoot = resolveOnce()
+
     static func resolve() -> URL {
+        resolvedRoot
+    }
+
+    private static func resolveOnce() -> URL {
         if let override = ProcessInfo.processInfo.environment["CLASSROOM_WIDGETS_WEB_ROOT"], !override.isEmpty {
             return URL(fileURLWithPath: override, isDirectory: true)
         }

--- a/packages/macos-dashboard/Sources/ClassroomWidgetsDashboard/WidgetPanelCoordinator.swift
+++ b/packages/macos-dashboard/Sources/ClassroomWidgetsDashboard/WidgetPanelCoordinator.swift
@@ -104,6 +104,8 @@ final class WidgetPanelCoordinator: NSObject {
     private var widgetCreationOptions: [CompactWidgetOption] = []
     private var panelBackgroundOpacity = 1.0
     private var panelsJoinAllSpaces = true
+    private var lastLayoutSignature: String?
+    private let frameDefaultsWriter = DebouncedDefaultsWriter()
 
     init(compactPresentationActive: Bool = true) {
         self.compactPresentationActive = compactPresentationActive
@@ -166,7 +168,13 @@ final class WidgetPanelCoordinator: NSObject {
         }
 
         if layout != .freeform {
-            arrange(layout)
+            let layoutSignature = snapshot.widgets
+                .map { "\($0.id):\($0.preferredContentSize.width)x\($0.preferredContentSize.height)" }
+                .joined(separator: "|")
+            if layoutSignature != lastLayoutSignature {
+                lastLayoutSignature = layoutSignature
+                arrange(layout)
+            }
         }
         return true
     }
@@ -188,8 +196,13 @@ final class WidgetPanelCoordinator: NSObject {
     /// panel web views avoids duplicate timers, audio and state writers.
     func enterCanvas() {
         compactPresentationActive = false
+        lastLayoutSignature = nil
         panelControllers.values.forEach { $0.closePermanently() }
         panelControllers.removeAll()
+    }
+
+    func flushPersistedFrames() {
+        frameDefaultsWriter.flush()
     }
 
     func prepareToEnterCanvas(completion: @escaping @MainActor ([WidgetPanelStateChange], Bool) -> Void) {
@@ -366,7 +379,7 @@ final class WidgetPanelCoordinator: NSObject {
     }
 
     private func persist(frame: NSRect, for widgetID: String) {
-        UserDefaults.standard.set(NSStringFromRect(frame), forKey: frameDefaultsKey(for: widgetID))
+        frameDefaultsWriter.set(NSStringFromRect(frame), forKey: frameDefaultsKey(for: widgetID))
     }
 
     private func storedFrame(for widgetID: String) -> NSRect? {
@@ -530,17 +543,28 @@ private final class WidgetPanelController: NSWindowController, NSWindowDelegate,
 
     func apply(descriptor: WidgetPanelDescriptor) {
         guard descriptor.id == widgetID else { return }
+        let previous = self.descriptor
         self.descriptor = descriptor
-        window?.title = descriptor.title
-        window?.contentMinSize = descriptor.minimumContentSize.cgSize
-        window?.contentMaxSize = descriptor.maximumContentSize?.cgSize ?? NSSize(
-            width: CGFloat.greatestFiniteMagnitude,
-            height: CGFloat.greatestFiniteMagnitude
-        )
-        window?.contentAspectRatio = Self.contentAspectRatio(for: descriptor)
-        if let window {
-            let shouldBeResizable = descriptor.isResizable
-            if shouldBeResizable {
+        if previous.title != descriptor.title {
+            window?.title = descriptor.title
+        }
+        if previous.minimumContentSize.width != descriptor.minimumContentSize.width
+            || previous.minimumContentSize.height != descriptor.minimumContentSize.height {
+            window?.contentMinSize = descriptor.minimumContentSize.cgSize
+        }
+        let previousMax = previous.maximumContentSize
+        let nextMax = descriptor.maximumContentSize
+        if previousMax?.width != nextMax?.width || previousMax?.height != nextMax?.height {
+            window?.contentMaxSize = nextMax?.cgSize ?? NSSize(
+                width: CGFloat.greatestFiniteMagnitude,
+                height: CGFloat.greatestFiniteMagnitude
+            )
+        }
+        if previous.aspectRatio != descriptor.aspectRatio {
+            window?.contentAspectRatio = Self.contentAspectRatio(for: descriptor)
+        }
+        if previous.isResizable != descriptor.isResizable, let window {
+            if descriptor.isResizable {
                 window.styleMask.insert(.resizable)
             } else {
                 window.styleMask.remove(.resizable)
@@ -549,10 +573,14 @@ private final class WidgetPanelController: NSWindowController, NSWindowDelegate,
     }
 
     func applyPresentationSettings(backgroundOpacity: Double, keepOnAllSpaces: Bool) {
-        self.backgroundOpacity = min(max(backgroundOpacity, 0), 1)
+        let nextOpacity = min(max(backgroundOpacity, 0), 1)
+        let opacityChanged = self.backgroundOpacity != nextOpacity
+        self.backgroundOpacity = nextOpacity
         window?.backgroundColor = .clear
         window?.collectionBehavior = Self.collectionBehavior(joinsAllSpaces: keepOnAllSpaces)
-        setWebBackgroundOpacity()
+        if opacityChanged {
+            setWebBackgroundOpacity()
+        }
     }
 
     func setWidgetCreationOptions(_ options: [CompactWidgetOption]) {
@@ -667,7 +695,18 @@ private final class WidgetPanelController: NSWindowController, NSWindowDelegate,
         )
     }
 
-    func push(snapshot: [String: Any]) {
+    func push(snapshot: [String: Any], force: Bool = false) {
+        let revision = (snapshot["revision"] as? NSNumber)?.intValue
+        let stateRevision = (snapshot["stateRevision"] as? NSNumber)?.intValue
+        if !force,
+           revision != nil,
+           revision == lastPushedRevision,
+           stateRevision == lastPushedStateRevision {
+            currentSnapshot = snapshot
+            return
+        }
+        lastPushedRevision = revision
+        lastPushedStateRevision = stateRevision
         currentSnapshot = snapshot
         webView.callAsyncJavaScript(
             """
@@ -724,7 +763,7 @@ private final class WidgetPanelController: NSWindowController, NSWindowDelegate,
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
         setWebBackgroundOpacity()
         guard let snapshot = currentSnapshot else { return }
-        push(snapshot: snapshot)
+        push(snapshot: snapshot, force: true)
     }
 
     func webViewWebContentProcessDidTerminate(_ webView: WKWebView) {
@@ -767,6 +806,9 @@ private final class WidgetPanelController: NSWindowController, NSWindowDelegate,
     }
 
     private var currentSnapshot: [String: Any]?
+    private var lastPushedRevision: Int?
+    private var lastPushedStateRevision: Int?
+    private var lastTrackingRevealHeight: CGFloat = -1
 
     private func setWebBackgroundOpacity() {
         webView.evaluateJavaScript(
@@ -775,6 +817,8 @@ private final class WidgetPanelController: NSWindowController, NSWindowDelegate,
     }
 
     private func loadWidget() {
+        lastPushedRevision = nil
+        lastPushedStateRevision = nil
         var components = URLComponents()
         components.scheme = dashboardURLScheme
         components.host = "app"
@@ -847,10 +891,14 @@ private final class WidgetPanelController: NSWindowController, NSWindowDelegate,
 
     private func updateChromeTrackingArea() {
         guard let frameView = chromeTrackingView else { return }
+        let revealHeight = min(frameView.bounds.height, max(44, frameView.bounds.height - (window?.contentLayoutRect.maxY ?? 0) + 12))
+        if chromeTrackingArea != nil, abs(revealHeight - lastTrackingRevealHeight) < 0.5 {
+            return
+        }
+        lastTrackingRevealHeight = revealHeight
         if let chromeTrackingArea {
             frameView.removeTrackingArea(chromeTrackingArea)
         }
-        let revealHeight = min(frameView.bounds.height, max(44, frameView.bounds.height - (window?.contentLayoutRect.maxY ?? 0) + 12))
         let area = NSTrackingArea(
             rect: NSRect(x: 0, y: frameView.bounds.maxY - revealHeight, width: frameView.bounds.width, height: revealHeight),
             options: [.mouseEnteredAndExited, .activeAlways],
@@ -999,12 +1047,12 @@ private final class NonInteractiveVisualEffectView: NSVisualEffectView {
 
 @MainActor
 private final class WidgetPanelWebViewFactory {
-    private let webRoot = WebRootResolver.resolve()
-
     func makeWebView(widgetID: String) -> (webView: WKWebView, messageHandler: WidgetPanelScriptMessageHandler) {
         let configuration = WKWebViewConfiguration()
         configuration.websiteDataStore = .nonPersistent()
-        configuration.setURLSchemeHandler(StaticFileSchemeHandler(webRoot: webRoot), forURLScheme: dashboardURLScheme)
+        configuration.processPool = DashboardWebKitShared.panelProcessPool
+        configuration.allowsAirPlayForMediaPlayback = false
+        configuration.setURLSchemeHandler(DashboardWebKitShared.schemeHandler, forURLScheme: dashboardURLScheme)
 
         let userContentController = WKUserContentController()
         userContentController.addUserScript(WKUserScript(
@@ -1017,6 +1065,7 @@ private final class WidgetPanelWebViewFactory {
         configuration.userContentController = userContentController
 
         let webView = WKWebView(frame: .zero, configuration: configuration)
+        ClassroomWebViewTuning.apply(to: webView)
         webView.setValue(false, forKey: "drawsBackground")
         return (webView, messageHandler)
     }

--- a/packages/macos-dashboard/Sources/ClassroomWidgetsDashboard/WidgetPanelCoordinator.swift
+++ b/packages/macos-dashboard/Sources/ClassroomWidgetsDashboard/WidgetPanelCoordinator.swift
@@ -508,7 +508,7 @@ private final class WidgetPanelController: NSWindowController, NSWindowDelegate,
 
         messageHandler.onReady = { [weak self] ready in
             if let snapshot = self?.currentSnapshot {
-                self?.push(snapshot: snapshot)
+                self?.push(snapshot: snapshot, force: true)
             }
             self?.onReady?(ready)
         }

--- a/packages/shared/hooks/useHudProximity.tsx
+++ b/packages/shared/hooks/useHudProximity.tsx
@@ -26,7 +26,7 @@ function distanceToRect(
   return Math.sqrt(dx * dx + dy * dy);
 }
 
-export function useHudProximity() {
+export function useHudProximity(active = true) {
   const [isNear, setIsNear] = useState<ProximityState>({
     topLeft: true,
     topRight: true,
@@ -84,6 +84,10 @@ export function useHudProximity() {
   }, []);
 
   useEffect(() => {
+    if (!active) {
+      return;
+    }
+
     const handleMouseMove = (e: MouseEvent) => {
       // Throttle updates to ~60fps
       const now = performance.now();
@@ -122,7 +126,7 @@ export function useHudProximity() {
         cancelAnimationFrame(rafRef.current);
       }
     };
-  }, [updateProximity]);
+  }, [active, updateProximity]);
 
   // Function to register HUD elements
   const registerHudElement = useCallback((
@@ -156,8 +160,14 @@ interface HudProximityContextType {
 
 const HudProximityContext = createContext<HudProximityContextType | null>(null);
 
-export function HudProximityProvider({ children }: { children: ReactNode }) {
-  const { isNear, registerHudElement } = useHudProximity();
+export function HudProximityProvider({
+  children,
+  active = true
+}: {
+  children: ReactNode;
+  active?: boolean;
+}) {
+  const { isNear, registerHudElement } = useHudProximity(active);
 
   return (
     <HudProximityContext.Provider value={{ isNear, registerHudElement }}>

--- a/packages/teacher/src/app/App.test.tsx
+++ b/packages/teacher/src/app/App.test.tsx
@@ -151,6 +151,32 @@ describe('App narrow layout', () => {
     });
   });
 
+  it('restores compact UI when native aborts after launcher prepare requests canvas', async () => {
+    const postMessage = vi.fn();
+    window.history.replaceState({}, '', '/?dashboard=1&mode=compact');
+    window.webkit = { messageHandlers: { classroomDashboard: { postMessage } } };
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(typeof window.openClassroomWidgetLauncher).toBe('function');
+      expect(typeof window.classroomDashboard?.setWindowMode).toBe('function');
+    });
+
+    act(() => {
+      window.openClassroomWidgetLauncher?.();
+    });
+
+    expect(document.documentElement).toHaveClass('desktop-dashboard-canvas');
+
+    act(() => {
+      window.classroomDashboard?.setWindowMode('compact');
+    });
+
+    expect(document.documentElement).toHaveClass('desktop-dashboard-compact');
+    expect(document.documentElement).not.toHaveClass('desktop-dashboard-canvas');
+  });
+
   it('keeps compact mode as a panel host without changing the saved canvas layout', async () => {
     window.history.replaceState({}, '', '/?dashboard=1&mode=compact');
     setWindowWidth(500);

--- a/packages/teacher/src/app/App.test.tsx
+++ b/packages/teacher/src/app/App.test.tsx
@@ -6,7 +6,7 @@ import App from './App';
 import { useWorkspaceStore } from '../store/workspaceStore.simple';
 import { widgetRegistry } from '../services/WidgetRegistry';
 import { WidgetType } from '@shared/types';
-import { resetWidgetLauncherForTests } from '../features/desktop/widgetLauncher';
+import { registerWidgetLauncherOpener, resetWidgetLauncherForTests } from '../features/desktop/widgetLauncher';
 
 vi.mock('./App.css', () => ({}));
 vi.mock('../sounds/trash-crumple.mp3', () => ({ default: 'trash-crumple.mp3' }));
@@ -116,6 +116,7 @@ describe('App narrow layout', () => {
     cleanup();
     resetWidgetLauncherForTests();
     delete window.openClassroomWidgetLauncher;
+    delete window.cancelClassroomWidgetLauncher;
     delete window.webkit;
     vi.clearAllMocks();
   });
@@ -160,6 +161,7 @@ describe('App narrow layout', () => {
 
     await waitFor(() => {
       expect(typeof window.openClassroomWidgetLauncher).toBe('function');
+      expect(typeof window.cancelClassroomWidgetLauncher).toBe('function');
       expect(typeof window.classroomDashboard?.setWindowMode).toBe('function');
     });
 
@@ -170,9 +172,14 @@ describe('App narrow layout', () => {
     expect(document.documentElement).toHaveClass('desktop-dashboard-canvas');
 
     act(() => {
+      window.cancelClassroomWidgetLauncher?.();
       window.classroomDashboard?.setWindowMode('compact');
     });
 
+    const open = vi.fn();
+    registerWidgetLauncherOpener(open);
+
+    expect(open).not.toHaveBeenCalled();
     expect(document.documentElement).toHaveClass('desktop-dashboard-compact');
     expect(document.documentElement).not.toHaveClass('desktop-dashboard-canvas');
   });
@@ -310,6 +317,7 @@ describe('App double-Cmd-press voice activation', () => {
     cleanup();
     resetWidgetLauncherForTests();
     delete window.openClassroomWidgetLauncher;
+    delete window.cancelClassroomWidgetLauncher;
     vi.useRealTimers();
     vi.clearAllMocks();
   });

--- a/packages/teacher/src/app/App.test.tsx
+++ b/packages/teacher/src/app/App.test.tsx
@@ -5,6 +5,7 @@ import App from './App';
 import { useWorkspaceStore } from '../store/workspaceStore.simple';
 import { widgetRegistry } from '../services/WidgetRegistry';
 import { WidgetType } from '@shared/types';
+import { resetWidgetLauncherForTests } from '../features/desktop/widgetLauncher';
 
 vi.mock('./App.css', () => ({}));
 vi.mock('../sounds/trash-crumple.mp3', () => ({ default: 'trash-crumple.mp3' }));
@@ -112,6 +113,8 @@ describe('App narrow layout', () => {
 
   afterEach(() => {
     cleanup();
+    resetWidgetLauncherForTests();
+    delete window.openClassroomWidgetLauncher;
     delete window.webkit;
     vi.clearAllMocks();
   });
@@ -122,6 +125,26 @@ describe('App narrow layout', () => {
     await waitFor(() => {
       expect(useWorkspaceStore.getState().layoutFormat).toBe('column');
       expect(screen.getByTestId('column-board')).toBeInTheDocument();
+    });
+  });
+
+  it('keeps the widget launcher bridge registered while compact mode hides the toolbar', async () => {
+    const postMessage = vi.fn();
+    window.history.replaceState({}, '', '/?dashboard=1&mode=compact');
+    window.webkit = { messageHandlers: { classroomDashboard: { postMessage } } };
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(typeof window.openClassroomWidgetLauncher).toBe('function');
+    });
+    expect(screen.queryByTestId('bottom-bar')).not.toBeInTheDocument();
+
+    window.openClassroomWidgetLauncher?.();
+
+    expect(postMessage).toHaveBeenCalledWith({
+      type: 'window-mode-requested',
+      mode: 'canvas'
     });
   });
 
@@ -256,6 +279,8 @@ describe('App double-Cmd-press voice activation', () => {
 
   afterEach(() => {
     cleanup();
+    resetWidgetLauncherForTests();
+    delete window.openClassroomWidgetLauncher;
     vi.useRealTimers();
     vi.clearAllMocks();
   });
@@ -318,14 +343,15 @@ describe('App double-Cmd-press voice activation', () => {
   });
 
   it('does not treat Cmd after Cmd+K as a double press', async () => {
-    const openLauncher = vi.fn();
-    window.openClassroomWidgetLauncher = openLauncher;
-
     render(<App />);
 
     await waitFor(() => {
+      expect(typeof window.openClassroomWidgetLauncher).toBe('function');
       expect(typeof (window as any).getVoiceControlActive).toBe('function');
     });
+
+    const openLauncher = vi.fn();
+    window.openClassroomWidgetLauncher = openLauncher;
 
     pressCmd();
     fireEvent.keyDown(document, { key: 'k', metaKey: true });
@@ -333,7 +359,5 @@ describe('App double-Cmd-press voice activation', () => {
 
     expect(openLauncher).toHaveBeenCalled();
     expect((window as any).getVoiceControlActive()).toBe(false);
-
-    delete window.openClassroomWidgetLauncher;
   });
 });

--- a/packages/teacher/src/app/App.test.tsx
+++ b/packages/teacher/src/app/App.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render, screen, waitFor, cleanup, fireEvent } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
 import App from './App';
 import { useWorkspaceStore } from '../store/workspaceStore.simple';
 import { widgetRegistry } from '../services/WidgetRegistry';
@@ -140,7 +141,9 @@ describe('App narrow layout', () => {
     });
     expect(screen.queryByTestId('bottom-bar')).not.toBeInTheDocument();
 
-    window.openClassroomWidgetLauncher?.();
+    act(() => {
+      window.openClassroomWidgetLauncher?.();
+    });
 
     expect(postMessage).toHaveBeenCalledWith({
       type: 'window-mode-requested',

--- a/packages/teacher/src/app/App.tsx
+++ b/packages/teacher/src/app/App.tsx
@@ -24,6 +24,7 @@ import { APP_VERSION } from '../version';
 import { useDesktopDashboardMode } from '../features/desktop/useDesktopDashboardMode';
 import DesktopWindowControls from '../features/desktop/DesktopWindowControls';
 import CompactPanelHost from '../features/desktop/CompactPanelHost';
+import { bindWindowWidgetLauncher } from '../features/desktop/widgetLauncher';
 
 import { ConfettiProvider } from '../contexts/ConfettiContext';
 
@@ -67,6 +68,18 @@ function App() {
   // Voice control state
   const [isVoiceControlActive, setIsVoiceControlActive] = useState(false);
   const commandPressRef = useRef<{ pressedAt: number; timeoutId: ReturnType<typeof setTimeout> } | null>(null);
+  const prepareWidgetLauncherRef = useRef(() => {});
+  prepareWidgetLauncherRef.current = () => {
+    if (!isDashboardMode) {
+      return;
+    }
+    if (windowMode !== 'canvas') {
+      requestWindowMode('canvas');
+    }
+    if (!isDashboardVisible) {
+      setDashboardVisible(true);
+    }
+  };
   
   // Note: Session code management is now handled by the networked widgets themselves
   // via the useNetworkedWidget hook. They will set/clear the session code as needed.
@@ -153,6 +166,10 @@ function App() {
     };
   }, []);
   
+  useEffect(() => bindWindowWidgetLauncher(() => {
+    prepareWidgetLauncherRef.current();
+  }), []);
+
   // Keyboard shortcuts
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {

--- a/packages/teacher/src/app/App.tsx
+++ b/packages/teacher/src/app/App.tsx
@@ -5,7 +5,7 @@ import './App.css';
 import { ModalProvider } from '../contexts/ModalContext';
 import { SocketProvider } from '../contexts/SocketProvider';
 import { SessionProvider } from '../contexts/SessionContext';
-import { useWorkspace, useServerConnection } from '@shared/hooks/useWorkspace';
+import { useWorkspace } from '@shared/hooks/useWorkspace';
 import { MIN_SCREEN_WIDTH, NARROW_SCREEN_WIDTH } from '@shared/constants/screenConstants';
 import { STICKER_MODE_CHANGE_EVENT } from '@shared/constants/events';
 import { useWorkspaceStore } from '../store/workspaceStore.simple';
@@ -17,7 +17,6 @@ import NarrowModeExitButton from '../features/hud/components/NarrowModeExitButto
 import { CanvasWidgetList, ColumnWidgetList } from '../features/board/components/WidgetList';
 import GlobalErrorBoundary from '@shared/components/GlobalErrorBoundary';
 import SmallScreenWarning from '@shared/components/SmallScreenWarning';
-import VoiceInterface from '../features/voiceControl/components/VoiceInterface';
 import { HudProximityProvider } from '@shared/hooks/useHudProximity';
 import { WidgetType, WidgetCategory } from '@shared/types';
 import { widgetRegistry } from '../services/WidgetRegistry';
@@ -28,24 +27,16 @@ import CompactPanelHost from '../features/desktop/CompactPanelHost';
 
 import { ConfettiProvider } from '../contexts/ConfettiContext';
 
-// Audio import for trash sound
-import trashSound from '../sounds/trash-crumple.mp3';
-const trashAudio = new Audio(trashSound);
+const VoiceInterface = React.lazy(() => import('../features/voiceControl/components/VoiceInterface'));
 
 
 
 
 function App() {
   const { theme, scale } = useWorkspace();
-  const { url, setServerStatus } = useServerConnection();
-  const sessionCode = useWorkspaceStore((state) => state.sessionCode);
-  const setSessionCode = useWorkspaceStore((state) => state.setSessionCode);
-  // Removed: widgets subscription moved to WidgetList component
   const addWidget = useWorkspaceStore((state) => state.addWidget);
   const updateWidgetState = useWorkspaceStore((state) => state.updateWidgetState);
   const resizeWidget = useWorkspaceStore((state) => state.resizeWidget);
-  const scrollPosition = useWorkspaceStore((state) => state.scrollPosition);
-  // Removed: focusedWidgetId subscription - use getState() where needed
   const setFocusedWidget = useWorkspaceStore((state) => state.setFocusedWidget);
   const layoutFormat = useWorkspaceStore((state) => state.layoutFormat);
   const setLayoutFormat = useWorkspaceStore((state) => state.setLayoutFormat);
@@ -57,7 +48,6 @@ function App() {
   // Use a ref to stash the layout before narrow mode.
   const layoutBeforeNarrowRef = useRef<'canvas' | 'column' | null>(null);
   const stickerStateRef = useRef<{ mode: boolean; type: string | null }>({ mode: false, type: null });
-  const [isInitialized, setIsInitialized] = React.useState(false);
   const [stickerMode, setStickerMode] = useState(false);
   const [selectedStickerType, setSelectedStickerType] = useState<string | null>(null);
   const [screenTooSmall, setScreenTooSmall] = useState(
@@ -148,8 +138,14 @@ function App() {
 
   // Trash sound effect
   useEffect(() => {
+    let trashAudioPromise: Promise<HTMLAudioElement> | null = null;
     (window as any).playTrashSound = () => {
-      trashAudio.play().catch(err => console.error('Error playing trash sound:', err));
+      if (!trashAudioPromise) {
+        trashAudioPromise = import('../sounds/trash-crumple.mp3').then((module) => new Audio(module.default));
+      }
+      trashAudioPromise.then((audio) => {
+        audio.play().catch(err => console.error('Error playing trash sound:', err));
+      });
     };
     
     return () => {
@@ -587,7 +583,7 @@ function App() {
           <SessionProvider>
             <ConfettiProvider>
               <ModalProvider>
-              <HudProximityProvider>
+              <HudProximityProvider active={!isDashboardMode || (windowMode === 'canvas' && isDashboardVisible)}>
                 <div
                   className={`h-screen bg-[#f7f5f2] dark:bg-warm-gray-900 overflow-hidden relative ${
                     isDashboardMode ? `desktop-dashboard-root desktop-dashboard-root-${windowMode}` : ''
@@ -608,6 +604,7 @@ function App() {
           )}
           
           {/* Top Controls */}
+          {(!isDashboardMode || (windowMode === 'canvas' && isDashboardVisible)) && (
           <div data-dashboard-chrome="true">
             <TopControls
               onSwitchToCompact={isDashboardMode && windowMode === 'canvas'
@@ -615,6 +612,7 @@ function App() {
                 : undefined}
             />
           </div>
+          )}
           
           {/* Sticker Mode Banner */}
           {stickerMode && (
@@ -657,6 +655,8 @@ function App() {
           </div>
           
           {/* Toolbar at bottom */}
+          {(!isDashboardMode || (windowMode === 'canvas' && isDashboardVisible)) && (
+          <>
           <div className="toolbar-container">
             <BottomBar onToggleLayout={handleToggleLayoutNarrow} />
           </div>
@@ -672,13 +672,19 @@ function App() {
             layoutFormat={layoutFormat}
             onToggleLayout={handleToggleLayoutNarrow}
           />
+          </>
+          )}
 
           {/* Voice Control Interface */}
-          <VoiceInterface
-            isOpen={isVoiceControlActive}
-            onClose={() => setIsVoiceControlActive(false)}
-            onTranscriptComplete={handleVoiceCommand}
-          />
+          {(voiceControlEnabled || isVoiceControlActive) && (
+            <React.Suspense fallback={null}>
+              <VoiceInterface
+                isOpen={isVoiceControlActive}
+                onClose={() => setIsVoiceControlActive(false)}
+                onTranscriptComplete={handleVoiceCommand}
+              />
+            </React.Suspense>
+          )}
               </div>
               </HudProximityProvider>
             </ModalProvider>

--- a/packages/teacher/src/contexts/SessionContext.tsx
+++ b/packages/teacher/src/contexts/SessionContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useEffect, useState, useCallback, useRef } from 'react';
+import React, { createContext, useContext, useEffect, useState, useCallback, useMemo, useRef } from 'react';
 import { useSocket } from '../hooks/useSocket';
 import { useWorkspaceStore } from '../store/workspaceStore.simple';
 import { debug } from '@shared/utils/debug';
@@ -770,7 +770,7 @@ export const SessionProvider: React.FC<SessionProviderProps> = ({ children }) =>
     return recoveryData.get(widgetId) || null;
   }, [recoveryData]);
   
-  const value: SessionContextValue = {
+  const value = useMemo<SessionContextValue>(() => ({
     // Session state
     sessionCode,
     sessionCreatedAt,
@@ -802,7 +802,25 @@ export const SessionProvider: React.FC<SessionProviderProps> = ({ children }) =>
     
     // Error state
     error
-  };
+  }), [
+    sessionCode,
+    sessionCreatedAt,
+    socket,
+    connectionPhase,
+    isConnected,
+    isRecovering,
+    serverUrl,
+    studentAppUrl,
+    activeRooms,
+    createSession,
+    recoverSession,
+    closeSession,
+    createRoom,
+    closeRoom,
+    updateRoomState,
+    getWidgetRecoveryData,
+    error
+  ]);
   
   return (
     <SessionContext.Provider value={value}>

--- a/packages/teacher/src/features/desktop/CompactPanelHost.test.tsx
+++ b/packages/teacher/src/features/desktop/CompactPanelHost.test.tsx
@@ -149,6 +149,29 @@ describe('CompactPanelHost', () => {
     });
   });
 
+  it('does not republish inventory when only a non-compact widget changes', async () => {
+    render(<CompactPanelHost />);
+    await waitFor(() => expect(postMessage).toHaveBeenCalledTimes(1));
+
+    act(() => {
+      useWorkspaceStore.setState({
+        widgets: [
+          ...useWorkspaceStore.getState().widgets,
+          { id: 'poll-1', type: WidgetType.POLL, position: { x: 0, y: 0 }, size: { width: 400, height: 400 }, zIndex: 1 }
+        ],
+        widgetStates: new Map([
+          ['timer-1', { timer: { time: 10 } }],
+          ['poll-1', { votes: [1] }]
+        ])
+      });
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(postMessage).toHaveBeenCalledTimes(1);
+  });
+
   it('preserves an unchanged widget revision when another widget changes', async () => {
     useWorkspaceStore.setState({
       widgets: [

--- a/packages/teacher/src/features/desktop/CompactPanelHost.test.tsx
+++ b/packages/teacher/src/features/desktop/CompactPanelHost.test.tsx
@@ -186,7 +186,8 @@ describe('CompactPanelHost', () => {
     render(<CompactPanelHost />);
     await waitFor(() => expect(postMessage).toHaveBeenCalledTimes(1));
     const firstInventory = postMessage.mock.calls[0][0];
-    const timerRevision = firstInventory.widgets.find((widget: { widgetId: string }) => widget.widgetId === 'timer-1').revision;
+    const timerSnapshot = firstInventory.widgets.find((widget: { widgetId: string }) => widget.widgetId === 'timer-1');
+    const qrSnapshot = firstInventory.widgets.find((widget: { widgetId: string }) => widget.widgetId === 'qr-1');
 
     act(() => {
       useWorkspaceStore.setState({ widgetStates: new Map([
@@ -197,8 +198,12 @@ describe('CompactPanelHost', () => {
 
     await waitFor(() => expect(postMessage).toHaveBeenCalledTimes(2));
     const secondInventory = postMessage.mock.calls[1][0];
-    expect(secondInventory.widgets.find((widget: { widgetId: string }) => widget.widgetId === 'timer-1').revision).toBe(timerRevision);
-    expect(secondInventory.widgets.find((widget: { widgetId: string }) => widget.widgetId === 'qr-1').revision).toBeGreaterThan(timerRevision);
+    const secondTimer = secondInventory.widgets.find((widget: { widgetId: string }) => widget.widgetId === 'timer-1');
+    const secondQr = secondInventory.widgets.find((widget: { widgetId: string }) => widget.widgetId === 'qr-1');
+    expect(secondTimer.revision).toBe(timerSnapshot.revision);
+    expect(secondTimer.stateRevision).toBe(timerSnapshot.stateRevision);
+    expect(secondQr.revision).toBe(qrSnapshot.revision);
+    expect(secondQr.stateRevision).toBeGreaterThan(qrSnapshot.stateRevision);
   });
 
   it('starts a new host instance when the dashboard host reloads', async () => {

--- a/packages/teacher/src/features/desktop/CompactPanelHost.tsx
+++ b/packages/teacher/src/features/desktop/CompactPanelHost.tsx
@@ -157,7 +157,7 @@ const CompactPanelHost = ({ dashboardTheme = 'light', windowMode = 'compact' }: 
       type: 'widget-panels-changed',
       schemaVersion: 1,
       hostInstanceId: hostInstanceIdRef.current,
-      inventoryRevision: revision,
+      inventoryRevision: nextRevision,
       windowMode,
       widgets: publishedSnapshots,
       compactWidgetOptions

--- a/packages/teacher/src/features/desktop/CompactPanelHost.tsx
+++ b/packages/teacher/src/features/desktop/CompactPanelHost.tsx
@@ -21,6 +21,9 @@ declare global {
 
 const asJsonValue = (value: unknown): JsonValue | null => {
   if (value === undefined) return null;
+  if (typeof structuredClone === 'function') {
+    return structuredClone(value) as JsonValue;
+  }
   return JSON.parse(JSON.stringify(value)) as JsonValue;
 };
 
@@ -46,11 +49,12 @@ const CompactPanelHost = ({ dashboardTheme = 'light', windowMode = 'compact' }: 
     stateSignature: string;
   }>());
   const hostInstanceIdRef = useRef(createHostInstanceId());
+  const lastPostedFingerprintRef = useRef<string | null>(null);
   const workspace = useWorkspaceStore(useShallow((state) => ({
     currentWorkspaceId: state.currentWorkspaceId,
     widgets: state.widgets,
     widgetStates: state.widgetStates,
-    savedCollections: state.savedCollections
+    randomiserLists: state.savedCollections.randomiserLists
   })));
 
   const compactWidgetOptions = useMemo<CompactWidgetOption[]>(() => (
@@ -96,15 +100,14 @@ const CompactPanelHost = ({ dashboardTheme = 'light', windowMode = 'compact' }: 
         state: asJsonValue(workspace.widgetStates.get(widget.id)),
         theme: dashboardTheme,
         savedRandomiserLists: widget.type === WidgetType.RANDOMISER
-          ? Object.values(workspace.savedCollections.randomiserLists).sort((a, b) => b.updatedAt - a.updatedAt)
+          ? Object.values(workspace.randomiserLists).sort((a, b) => b.updatedAt - a.updatedAt)
           : []
       } satisfies CompactWidgetSnapshot];
     });
   }, [dashboardTheme, workspace]);
 
   useEffect(() => {
-    const revision = revisionRef.current + 1;
-    revisionRef.current = revision;
+    const nextRevision = revisionRef.current + 1;
     const nextWidgetRevisions = new Map<string, {
       revision: number;
       signature: string;
@@ -112,19 +115,43 @@ const CompactPanelHost = ({ dashboardTheme = 'light', windowMode = 'compact' }: 
       stateSignature: string;
     }>();
     const publishedSnapshots = snapshots.map((snapshot) => {
-      const signature = JSON.stringify(snapshot);
+      const metadataSignature = JSON.stringify({
+        workspaceId: snapshot.workspaceId,
+        widgetType: snapshot.widgetType,
+        title: snapshot.title,
+        preferredSize: snapshot.preferredSize,
+        minimumSize: snapshot.minimumSize,
+        maximumSize: snapshot.maximumSize,
+        isResizable: snapshot.isResizable,
+        maintainsAspectRatio: snapshot.maintainsAspectRatio,
+        theme: snapshot.theme,
+        savedRandomiserLists: snapshot.savedRandomiserLists
+      });
       const stateSignature = JSON.stringify(snapshot.state);
       const previous = widgetRevisionsRef.current.get(snapshot.widgetId);
-      const widgetRevision = previous?.signature === signature ? previous.revision : revision;
-      const stateRevision = previous?.stateSignature === stateSignature ? previous.stateRevision : revision;
+      const widgetRevision = previous?.signature === metadataSignature ? previous.revision : nextRevision;
+      const stateRevision = previous?.stateSignature === stateSignature ? previous.stateRevision : nextRevision;
       nextWidgetRevisions.set(snapshot.widgetId, {
         revision: widgetRevision,
-        signature,
+        signature: metadataSignature,
         stateRevision,
         stateSignature
       });
       return { ...snapshot, revision: widgetRevision, stateRevision };
     });
+    const fingerprint = [
+      windowMode,
+      hostInstanceIdRef.current,
+      compactWidgetOptions.map((option) => `${option.widgetType}:${option.title}`).join(','),
+      publishedSnapshots.map((snapshot) => (
+        `${snapshot.widgetId}:${snapshot.revision}:${snapshot.stateRevision}`
+      )).join(',')
+    ].join('|');
+    if (fingerprint === lastPostedFingerprintRef.current) {
+      return;
+    }
+    lastPostedFingerprintRef.current = fingerprint;
+    revisionRef.current = nextRevision;
     widgetRevisionsRef.current = nextWidgetRevisions;
     const inventory: CompactWidgetPanelInventory = {
       type: 'widget-panels-changed',
@@ -148,6 +175,7 @@ const CompactPanelHost = ({ dashboardTheme = 'light', windowMode = 'compact' }: 
         const previous = widgetRevisionsRef.current.get(change.widgetId);
         if (!change.flush && previous?.stateRevision !== change.baseRevision) return false;
         const stateSignature = JSON.stringify(change.state);
+        if (previous?.stateSignature === stateSignature) return true;
         widgetRevisionsRef.current.set(change.widgetId, {
           revision: previous?.revision ?? change.baseRevision,
           signature: previous?.signature ?? '',

--- a/packages/teacher/src/features/desktop/CompactWidgetApp.test.tsx
+++ b/packages/teacher/src/features/desktop/CompactWidgetApp.test.tsx
@@ -8,6 +8,8 @@ import { parseBackgroundOpacityFromSearch } from '@shared/utils/dashboardMode';
 import CompactWidgetApp from './CompactWidgetApp';
 import { widgetRegistry } from '../../services/WidgetRegistry';
 
+vi.mock('../../app/App.css', () => ({}));
+
 vi.mock('../../services/WidgetRegistry', () => ({
   widgetRegistry: { get: vi.fn() }
 }));

--- a/packages/teacher/src/features/desktop/CompactWidgetApp.test.tsx
+++ b/packages/teacher/src/features/desktop/CompactWidgetApp.test.tsx
@@ -216,6 +216,48 @@ describe('CompactWidgetApp', () => {
     )).toHaveLength(stateChangeCount);
   });
 
+  it('applies a host echo that keeps metadata revision and advances stateRevision', async () => {
+    const StateProbe = ({ savedState }: ProbeWidgetProps) => (
+      <div data-testid="saved-state">{JSON.stringify(savedState)}</div>
+    );
+    vi.mocked(widgetRegistry.get).mockReturnValue(panelConfig(StateProbe));
+    render(<CompactWidgetApp />);
+
+    act(() => {
+      window.classroomWidgetPanel?.receiveSnapshot(snapshot({ elapsed: 0 }, 1, 1));
+    });
+    expect(await screen.findByTestId('saved-state')).toHaveTextContent('{"elapsed":0}');
+
+    act(() => {
+      window.classroomWidgetPanel?.receiveSnapshot(snapshot({ elapsed: 10 }, 1, 2));
+    });
+    expect(await screen.findByTestId('saved-state')).toHaveTextContent('{"elapsed":10}');
+  });
+
+  it('clears an in-flight edit when the host acks with a stateRevision-only snapshot', async () => {
+    const EditingProbe = ({ onStateChange }: ProbeWidgetProps) => (
+      <>
+        <button type="button" onClick={() => onStateChange?.({ elapsed: 1 })}>First</button>
+        <button type="button" onClick={() => onStateChange?.({ elapsed: 2 })}>Second</button>
+      </>
+    );
+    vi.mocked(widgetRegistry.get).mockReturnValue(panelConfig(EditingProbe));
+    render(<CompactWidgetApp />);
+    act(() => window.classroomWidgetPanel?.receiveSnapshot(snapshot({ elapsed: 0 }, 1, 1)));
+
+    fireEvent.click(await screen.findByRole('button', { name: 'First' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Second' }));
+    expect(panelPostMessage.mock.calls.filter(([message]) => message.type === 'panel-state-change')).toEqual([
+      [expect.objectContaining({ baseRevision: 1, state: { elapsed: 1 } })]
+    ]);
+
+    act(() => window.classroomWidgetPanel?.receiveSnapshot(snapshot({ elapsed: 1 }, 1, 2)));
+    expect(panelPostMessage.mock.calls.filter(([message]) => message.type === 'panel-state-change')).toEqual([
+      [expect.objectContaining({ baseRevision: 1, state: { elapsed: 1 } })],
+      [expect.objectContaining({ baseRevision: 2, state: { elapsed: 2 } })]
+    ]);
+  });
+
   it('ignores snapshots that arrive out of revision order', async () => {
     const StateProbe = ({ savedState }: ProbeWidgetProps) => (
       <div data-testid="saved-state">{JSON.stringify(savedState)}</div>

--- a/packages/teacher/src/features/desktop/CompactWidgetApp.tsx
+++ b/packages/teacher/src/features/desktop/CompactWidgetApp.tsx
@@ -1,4 +1,5 @@
 import React, { Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import '../../app/App.css';
 import type {
   CompactWidgetPanelBridge,
   CompactWidgetSnapshot,

--- a/packages/teacher/src/features/desktop/CompactWidgetApp.tsx
+++ b/packages/teacher/src/features/desktop/CompactWidgetApp.tsx
@@ -54,10 +54,11 @@ const CompactWidgetApp = () => {
     window.classroomWidgetPanel = {
       receiveSnapshot: (nextSnapshot) => {
         if (nextSnapshot.schemaVersion !== 1 || nextSnapshot.widgetId !== requestedWidgetId) return;
-        if (nextSnapshot.revision <= (snapshotRef.current?.revision ?? -1)) return;
-        randomiserListListenersRef.current.forEach((listener) => listener(nextSnapshot.savedRandomiserLists));
         const currentSnapshot = snapshotRef.current;
+        const metadataAdvanced = nextSnapshot.revision > (currentSnapshot?.revision ?? -1);
         const stateRevisionAdvanced = nextSnapshot.stateRevision > (currentSnapshot?.stateRevision ?? -1);
+        if (!metadataAdvanced && !stateRevisionAdvanced) return;
+        randomiserListListenersRef.current.forEach((listener) => listener(nextSnapshot.savedRandomiserLists));
         if (!stateRevisionAdvanced && inFlightStateRef.current !== null) {
           const optimisticState = queuedStateRef.current ?? inFlightStateRef.current;
           const metadataSnapshot = {

--- a/packages/teacher/src/features/desktop/useDesktopDashboardMode.ts
+++ b/packages/teacher/src/features/desktop/useDesktopDashboardMode.ts
@@ -115,11 +115,6 @@ export function useDesktopDashboardMode() {
     );
     document.documentElement.style.setProperty('--desktop-dashboard-background-opacity', String(backgroundOpacity));
 
-    window.webkit?.messageHandlers?.classroomDashboard?.postMessage({
-      type: 'visibility-changed',
-      visible: isDashboardVisible
-    });
-
     return () => {
       document.documentElement.classList.remove(
         'desktop-dashboard-mode',
@@ -134,6 +129,15 @@ export function useDesktopDashboardMode() {
       document.documentElement.style.removeProperty('--desktop-dashboard-background-opacity');
     };
   }, [backgroundOpacity, compactLayout, isDashboardMode, isDashboardVisible, windowChromeVisible, windowMode]);
+
+  useEffect(() => {
+    if (!isDashboardMode) return;
+
+    window.webkit?.messageHandlers?.classroomDashboard?.postMessage({
+      type: 'visibility-changed',
+      visible: isDashboardVisible
+    });
+  }, [isDashboardMode, isDashboardVisible]);
 
   useEffect(() => {
     if (!isDashboardMode) return;

--- a/packages/teacher/src/features/desktop/widgetLauncher.test.ts
+++ b/packages/teacher/src/features/desktop/widgetLauncher.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  bindWindowWidgetLauncher,
+  openWidgetLauncher,
+  registerWidgetLauncherOpener,
+  resetWidgetLauncherForTests
+} from './widgetLauncher';
+
+describe('widgetLauncher', () => {
+  afterEach(() => {
+    resetWidgetLauncherForTests();
+    delete window.openClassroomWidgetLauncher;
+  });
+
+  it('opens immediately when an opener is already registered', () => {
+    const open = vi.fn();
+    const unregister = registerWidgetLauncherOpener(open);
+
+    openWidgetLauncher();
+
+    expect(open).toHaveBeenCalledTimes(1);
+    unregister();
+  });
+
+  it('flushes a pending open when the opener mounts later', () => {
+    const open = vi.fn();
+
+    openWidgetLauncher();
+    expect(open).not.toHaveBeenCalled();
+
+    registerWidgetLauncherOpener(open);
+    expect(open).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call an opener after it unregisters', () => {
+    const open = vi.fn();
+    const unregister = registerWidgetLauncherOpener(open);
+
+    unregister();
+    openWidgetLauncher();
+
+    expect(open).not.toHaveBeenCalled();
+  });
+
+  it('binds a window bridge that prepares then opens', () => {
+    const prepare = vi.fn();
+    const open = vi.fn();
+    const unbind = bindWindowWidgetLauncher(prepare);
+    registerWidgetLauncherOpener(open);
+
+    window.openClassroomWidgetLauncher?.();
+
+    expect(prepare).toHaveBeenCalledTimes(1);
+    expect(open).toHaveBeenCalledTimes(1);
+    unbind();
+    expect(window.openClassroomWidgetLauncher).toBeUndefined();
+  });
+});

--- a/packages/teacher/src/features/desktop/widgetLauncher.test.ts
+++ b/packages/teacher/src/features/desktop/widgetLauncher.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   bindWindowWidgetLauncher,
+  cancelWidgetLauncher,
   openWidgetLauncher,
   registerWidgetLauncherOpener,
   resetWidgetLauncherForTests
@@ -10,6 +11,7 @@ describe('widgetLauncher', () => {
   afterEach(() => {
     resetWidgetLauncherForTests();
     delete window.openClassroomWidgetLauncher;
+    delete window.cancelClassroomWidgetLauncher;
   });
 
   it('opens immediately when an opener is already registered', () => {
@@ -54,5 +56,40 @@ describe('widgetLauncher', () => {
     expect(open).toHaveBeenCalledTimes(1);
     unbind();
     expect(window.openClassroomWidgetLauncher).toBeUndefined();
+    expect(window.cancelClassroomWidgetLauncher).toBeUndefined();
+  });
+
+  it('does not flush a cancelled pending open when the opener mounts later', () => {
+    const open = vi.fn();
+
+    openWidgetLauncher();
+    cancelWidgetLauncher();
+    registerWidgetLauncherOpener(open);
+
+    expect(open).not.toHaveBeenCalled();
+  });
+
+  it('closes an already opened launchpad when cancelled', () => {
+    const open = vi.fn();
+    const close = vi.fn();
+    registerWidgetLauncherOpener(open, close);
+
+    openWidgetLauncher();
+    cancelWidgetLauncher();
+
+    expect(open).toHaveBeenCalledTimes(1);
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  it('binds a window cancel that drops a queued launchpad', () => {
+    const open = vi.fn();
+    const unbind = bindWindowWidgetLauncher();
+
+    window.openClassroomWidgetLauncher?.();
+    window.cancelClassroomWidgetLauncher?.();
+    registerWidgetLauncherOpener(open);
+
+    expect(open).not.toHaveBeenCalled();
+    unbind();
   });
 });

--- a/packages/teacher/src/features/desktop/widgetLauncher.ts
+++ b/packages/teacher/src/features/desktop/widgetLauncher.ts
@@ -1,0 +1,54 @@
+declare global {
+  interface Window {
+    openClassroomWidgetLauncher?: () => void;
+  }
+}
+
+type WidgetLauncherOpener = () => void;
+
+let opener: WidgetLauncherOpener | null = null;
+let pendingOpen = false;
+
+export function registerWidgetLauncherOpener(nextOpener: WidgetLauncherOpener): () => void {
+  opener = nextOpener;
+  if (pendingOpen) {
+    pendingOpen = false;
+    nextOpener();
+  }
+
+  return () => {
+    if (opener === nextOpener) {
+      opener = null;
+    }
+  };
+}
+
+export function openWidgetLauncher(): void {
+  if (opener) {
+    opener();
+    pendingOpen = false;
+    return;
+  }
+
+  pendingOpen = true;
+}
+
+export function bindWindowWidgetLauncher(prepare?: () => void): () => void {
+  const bound = () => {
+    prepare?.();
+    openWidgetLauncher();
+  };
+
+  window.openClassroomWidgetLauncher = bound;
+
+  return () => {
+    if (window.openClassroomWidgetLauncher === bound) {
+      delete window.openClassroomWidgetLauncher;
+    }
+  };
+}
+
+export function resetWidgetLauncherForTests(): void {
+  opener = null;
+  pendingOpen = false;
+}

--- a/packages/teacher/src/features/desktop/widgetLauncher.ts
+++ b/packages/teacher/src/features/desktop/widgetLauncher.ts
@@ -1,16 +1,22 @@
 declare global {
   interface Window {
     openClassroomWidgetLauncher?: () => void;
+    cancelClassroomWidgetLauncher?: () => void;
   }
 }
 
 type WidgetLauncherOpener = () => void;
 
 let opener: WidgetLauncherOpener | null = null;
+let closer: WidgetLauncherOpener | null = null;
 let pendingOpen = false;
 
-export function registerWidgetLauncherOpener(nextOpener: WidgetLauncherOpener): () => void {
+export function registerWidgetLauncherOpener(
+  nextOpener: WidgetLauncherOpener,
+  nextCloser?: WidgetLauncherOpener
+): () => void {
   opener = nextOpener;
+  closer = nextCloser ?? null;
   if (pendingOpen) {
     pendingOpen = false;
     nextOpener();
@@ -19,6 +25,9 @@ export function registerWidgetLauncherOpener(nextOpener: WidgetLauncherOpener): 
   return () => {
     if (opener === nextOpener) {
       opener = null;
+      if (closer === nextCloser) {
+        closer = null;
+      }
     }
   };
 }
@@ -33,6 +42,11 @@ export function openWidgetLauncher(): void {
   pendingOpen = true;
 }
 
+export function cancelWidgetLauncher(): void {
+  pendingOpen = false;
+  closer?.();
+}
+
 export function bindWindowWidgetLauncher(prepare?: () => void): () => void {
   const bound = () => {
     prepare?.();
@@ -40,15 +54,20 @@ export function bindWindowWidgetLauncher(prepare?: () => void): () => void {
   };
 
   window.openClassroomWidgetLauncher = bound;
+  window.cancelClassroomWidgetLauncher = cancelWidgetLauncher;
 
   return () => {
     if (window.openClassroomWidgetLauncher === bound) {
       delete window.openClassroomWidgetLauncher;
+    }
+    if (window.cancelClassroomWidgetLauncher === cancelWidgetLauncher) {
+      delete window.cancelClassroomWidgetLauncher;
     }
   };
 }
 
 export function resetWidgetLauncherForTests(): void {
   opener = null;
+  closer = null;
   pendingOpen = false;
 }

--- a/packages/teacher/src/features/hud/components/BottomBar.tsx
+++ b/packages/teacher/src/features/hud/components/BottomBar.tsx
@@ -20,12 +20,7 @@ import { useWorkspaceStore } from '../../../store/workspaceStore.simple';
 import { useHudProximityContext } from '@shared/hooks/useHudProximity';
 import { hudProximity } from '@shared/utils/styles';
 import { STICKER_MODE_CHANGE_EVENT } from '@shared/constants/events';
-
-declare global {
-  interface Window {
-    openClassroomWidgetLauncher?: () => void;
-  }
-}
+import { registerWidgetLauncherOpener } from '../../desktop/widgetLauncher';
 
 // Default recent widgets if none are set
 const defaultRecentWidgets = [
@@ -134,15 +129,10 @@ const BottomBar: React.FC<BottomBarProps> = ({ onToggleLayout }) => {
     });
   }, [handleAddWidget, hideModal, showModal, stickerMode]);
 
-  useEffect(() => {
-    window.openClassroomWidgetLauncher = handleShowMoreWidgets;
-
-    return () => {
-      if (window.openClassroomWidgetLauncher === handleShowMoreWidgets) {
-        delete window.openClassroomWidgetLauncher;
-      }
-    };
-  }, [handleShowMoreWidgets]);
+  useEffect(
+    () => registerWidgetLauncherOpener(handleShowMoreWidgets),
+    [handleShowMoreWidgets]
+  );
 
   const handleShowStickers = () => {
     showModal({

--- a/packages/teacher/src/features/hud/components/BottomBar.tsx
+++ b/packages/teacher/src/features/hud/components/BottomBar.tsx
@@ -130,8 +130,8 @@ const BottomBar: React.FC<BottomBarProps> = ({ onToggleLayout }) => {
   }, [handleAddWidget, hideModal, showModal, stickerMode]);
 
   useEffect(
-    () => registerWidgetLauncherOpener(handleShowMoreWidgets),
-    [handleShowMoreWidgets]
+    () => registerWidgetLauncherOpener(handleShowMoreWidgets, hideModal),
+    [handleShowMoreWidgets, hideModal]
   );
 
   const handleShowStickers = () => {

--- a/packages/teacher/src/features/widgets/qrcode/qrcode.tsx
+++ b/packages/teacher/src/features/widgets/qrcode/qrcode.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
-import QRCode from 'qrcode';
 import { WidgetInput } from '@shared/components/WidgetInput';
 import { widgetContainer } from '@shared/utils/styles';
 import { useWidgetState } from '@shared/hooks/useWidgetState';
@@ -31,16 +30,20 @@ function QRCodeWidget({ savedState, onStateChange }: QRCodeWidgetProps) {
     if (url && canvas) {
       const container = qrContainerRef.current;
       const availableSize = Math.min(container?.clientWidth || 250, container?.clientHeight || 250) - 16;
+      const targetWidth = Math.max(120, Math.floor(availableSize));
 
-      QRCode.toCanvas(canvas, url, {
-        width: Math.max(120, Math.floor(availableSize)),
-        margin: 1,
-        color: {
-          dark: '#1f2937',  // warm-gray-800
-          light: '#ffffff'
-        }
-      }, (error) => {
-        if (error) console.error('Error generating QR code:', error);
+      void import('qrcode').then(({ default: QRCode }) => {
+        if (canvasRef.current !== canvas) return;
+        QRCode.toCanvas(canvas, url, {
+          width: targetWidth,
+          margin: 1,
+          color: {
+            dark: '#1f2937',  // warm-gray-800
+            light: '#ffffff'
+          }
+        }, (error) => {
+          if (error) console.error('Error generating QR code:', error);
+        });
       });
     } else if (canvas) {
       const ctx = canvas.getContext('2d');

--- a/packages/teacher/src/index.tsx
+++ b/packages/teacher/src/index.tsx
@@ -1,24 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
-import { HelmetProvider } from 'react-helmet-async';
 import './index.css';
-import App from './app/App';
-import About from './pages/About';
-import WidgetsHub from './pages/WidgetsHub';
-import PollPage from './pages/widgets/PollPage';
-import QuestionsPage from './pages/widgets/QuestionsPage';
-import FeedbackPage from './pages/widgets/FeedbackPage';
-import HandoutPage from './pages/widgets/HandoutPage';
-import TimerPage from './pages/widgets/TimerPage';
-import RandomiserPage from './pages/widgets/RandomiserPage';
-import ListPage from './pages/widgets/ListPage';
-import TaskCuePage from './pages/widgets/TaskCuePage';
-import TrafficLightPage from './pages/widgets/TrafficLightPage';
-import TextBannerPage from './pages/widgets/TextBannerPage';
-import QrCodePage from './pages/widgets/QrCodePage';
-import SoundEffectsPage from './pages/widgets/SoundEffectsPage';
-import CompactWidgetApp from './features/desktop/CompactWidgetApp';
 
 const isCompactWidgetPanel = new URLSearchParams(window.location.search).get('surface') === 'widget-panel';
 
@@ -41,28 +23,69 @@ if (!rootElement) {
 
 const root = ReactDOM.createRoot(rootElement);
 
-root.render(
-  <React.StrictMode>
-    <HelmetProvider>
-      {isCompactWidgetPanel ? <CompactWidgetApp /> : <BrowserRouter>
-        <Routes>
-          <Route path="/" element={<App />} />
-          <Route path="/about" element={<About />} />
-          <Route path="/widgets" element={<WidgetsHub />} />
-          <Route path="/widgets/poll" element={<PollPage />} />
-          <Route path="/widgets/questions" element={<QuestionsPage />} />
-          <Route path="/widgets/feedback" element={<FeedbackPage />} />
-          <Route path="/widgets/handout" element={<HandoutPage />} />
-          <Route path="/widgets/timer" element={<TimerPage />} />
-          <Route path="/widgets/randomiser" element={<RandomiserPage />} />
-          <Route path="/widgets/list" element={<ListPage />} />
-          <Route path="/widgets/task-cue" element={<TaskCuePage />} />
-          <Route path="/widgets/traffic-light" element={<TrafficLightPage />} />
-          <Route path="/widgets/text-banner" element={<TextBannerPage />} />
-          <Route path="/widgets/qr-code" element={<QrCodePage />} />
-          <Route path="/widgets/sound-effects" element={<SoundEffectsPage />} />
-        </Routes>
-      </BrowserRouter>}
-    </HelmetProvider>
-  </React.StrictMode>
-);
+async function renderApp() {
+  if (isCompactWidgetPanel) {
+    const { default: CompactWidgetApp } = await import('./features/desktop/CompactWidgetApp');
+    root.render(
+      <React.StrictMode>
+        <CompactWidgetApp />
+      </React.StrictMode>
+    );
+    return;
+  }
+
+  const [
+    { default: App },
+    { HelmetProvider },
+    { BrowserRouter, Routes, Route },
+  ] = await Promise.all([
+    import('./app/App'),
+    import('react-helmet-async'),
+    import('react-router-dom'),
+  ]);
+
+  const About = React.lazy(() => import('./pages/About'));
+  const WidgetsHub = React.lazy(() => import('./pages/WidgetsHub'));
+  const PollPage = React.lazy(() => import('./pages/widgets/PollPage'));
+  const QuestionsPage = React.lazy(() => import('./pages/widgets/QuestionsPage'));
+  const FeedbackPage = React.lazy(() => import('./pages/widgets/FeedbackPage'));
+  const HandoutPage = React.lazy(() => import('./pages/widgets/HandoutPage'));
+  const TimerPage = React.lazy(() => import('./pages/widgets/TimerPage'));
+  const RandomiserPage = React.lazy(() => import('./pages/widgets/RandomiserPage'));
+  const ListPage = React.lazy(() => import('./pages/widgets/ListPage'));
+  const TaskCuePage = React.lazy(() => import('./pages/widgets/TaskCuePage'));
+  const TrafficLightPage = React.lazy(() => import('./pages/widgets/TrafficLightPage'));
+  const TextBannerPage = React.lazy(() => import('./pages/widgets/TextBannerPage'));
+  const QrCodePage = React.lazy(() => import('./pages/widgets/QrCodePage'));
+  const SoundEffectsPage = React.lazy(() => import('./pages/widgets/SoundEffectsPage'));
+
+  root.render(
+    <React.StrictMode>
+      <HelmetProvider>
+        <BrowserRouter>
+          <React.Suspense fallback={null}>
+            <Routes>
+              <Route path="/" element={<App />} />
+              <Route path="/about" element={<About />} />
+              <Route path="/widgets" element={<WidgetsHub />} />
+              <Route path="/widgets/poll" element={<PollPage />} />
+              <Route path="/widgets/questions" element={<QuestionsPage />} />
+              <Route path="/widgets/feedback" element={<FeedbackPage />} />
+              <Route path="/widgets/handout" element={<HandoutPage />} />
+              <Route path="/widgets/timer" element={<TimerPage />} />
+              <Route path="/widgets/randomiser" element={<RandomiserPage />} />
+              <Route path="/widgets/list" element={<ListPage />} />
+              <Route path="/widgets/task-cue" element={<TaskCuePage />} />
+              <Route path="/widgets/traffic-light" element={<TrafficLightPage />} />
+              <Route path="/widgets/text-banner" element={<TextBannerPage />} />
+              <Route path="/widgets/qr-code" element={<QrCodePage />} />
+              <Route path="/widgets/sound-effects" element={<SoundEffectsPage />} />
+            </Routes>
+          </React.Suspense>
+        </BrowserRouter>
+      </HelmetProvider>
+    </React.StrictMode>
+  );
+}
+
+void renderApp();

--- a/packages/teacher/src/services/WidgetRegistry.ts
+++ b/packages/teacher/src/services/WidgetRegistry.ts
@@ -62,9 +62,22 @@ const widgetImports = {
 // don't see a "Loading widget..." flash - without blocking the critical path.
 const isCompactWidgetPanel = typeof window !== 'undefined'
   && new URLSearchParams(window.location.search).get('surface') === 'widget-panel';
+const isMacOSDashboard = typeof window !== 'undefined'
+  && Boolean((window as Window & { __CLASSROOM_WIDGETS_MACOS__?: boolean }).__CLASSROOM_WIDGETS_MACOS__);
+const compactPanelWarmImports = [
+  widgetImports.Randomiser,
+  widgetImports.Timer,
+  widgetImports.List,
+  widgetImports.TaskCue,
+  widgetImports.TrafficLight,
+  widgetImports.TextBanner,
+  widgetImports.QRCodeWidget,
+  widgetImports.SoundEffects
+];
 if (typeof window !== 'undefined' && !isCompactWidgetPanel) {
   const warmCaches = () => {
-    Object.values(widgetImports).forEach(fn => {
+    const importsToWarm = isMacOSDashboard ? compactPanelWarmImports : Object.values(widgetImports);
+    importsToWarm.forEach(fn => {
       // Fire and forget; chunk errors are logged but don't bubble
       fn().catch(err => {
         if (import.meta.env?.DEV) console.warn('[WidgetRegistry] preload failed', err);

--- a/packages/teacher/src/store/workspaceStore.simple.test.ts
+++ b/packages/teacher/src/store/workspaceStore.simple.test.ts
@@ -148,6 +148,16 @@ describe('workspace snapshot', () => {
     expect(store().layoutFormat).toBe('canvas');
   });
 
+  it('skips identical widget state updates', async () => {
+    await seedStorage();
+    const timerId = store().addWidget(WidgetType.TIMER, { x: 0, y: 0 });
+    store().updateWidgetState(timerId, { seconds: 42 });
+    const firstStates = store().widgetStates;
+
+    store().updateWidgetState(timerId, { seconds: 42 });
+    expect(store().widgetStates).toBe(firstStates);
+  });
+
   it('round-trips per-workspace state through create, switch and delete', async () => {
     const { idA } = await seedStorage();
 

--- a/packages/teacher/src/store/workspaceStore.simple.test.ts
+++ b/packages/teacher/src/store/workspaceStore.simple.test.ts
@@ -158,6 +158,17 @@ describe('workspace snapshot', () => {
     expect(store().widgetStates).toBe(firstStates);
   });
 
+  it('writes widget state when only a Date field changes', async () => {
+    await seedStorage();
+    const timerId = store().addWidget(WidgetType.TIMER, { x: 0, y: 0 });
+    store().updateWidgetState(timerId, { timestamp: new Date('2026-03-11T14:00:00.000Z') });
+
+    store().updateWidgetState(timerId, { timestamp: new Date('2026-03-11T15:00:00.000Z') });
+
+    const next = store().widgetStates.get(timerId) as { timestamp: Date };
+    expect(next.timestamp.getTime()).toBe(new Date('2026-03-11T15:00:00.000Z').getTime());
+  });
+
   it('round-trips per-workspace state through create, switch and delete', async () => {
     const { idA } = await seedStorage();
 

--- a/packages/teacher/src/store/workspaceStore.simple.ts
+++ b/packages/teacher/src/store/workspaceStore.simple.ts
@@ -37,6 +37,10 @@ function widgetStateEqual(a: unknown, b: unknown): boolean {
   if (Object.is(a, b)) return true;
   if (typeof a !== 'object' || typeof b !== 'object' || a === null || b === null) return false;
 
+  if (a instanceof Date || b instanceof Date) {
+    return a instanceof Date && b instanceof Date && a.getTime() === b.getTime();
+  }
+
   if (Array.isArray(a) || Array.isArray(b)) {
     if (!Array.isArray(a) || !Array.isArray(b) || a.length !== b.length) return false;
     return a.every((item, index) => widgetStateEqual(item, b[index]));

--- a/packages/teacher/src/store/workspaceStore.simple.ts
+++ b/packages/teacher/src/store/workspaceStore.simple.ts
@@ -33,6 +33,24 @@ import {
 } from '@shared/utils/storageMigration';
 import { WorkspaceMetadata } from './workspaceStore';
 
+function widgetStateEqual(a: unknown, b: unknown): boolean {
+  if (Object.is(a, b)) return true;
+  if (typeof a !== 'object' || typeof b !== 'object' || a === null || b === null) return false;
+
+  if (Array.isArray(a) || Array.isArray(b)) {
+    if (!Array.isArray(a) || !Array.isArray(b) || a.length !== b.length) return false;
+    return a.every((item, index) => widgetStateEqual(item, b[index]));
+  }
+
+  const objectA = a as Record<string, unknown>;
+  const objectB = b as Record<string, unknown>;
+  const keysA = Object.keys(objectA);
+  if (keysA.length !== Object.keys(objectB).length) return false;
+  return keysA.every(key =>
+    Object.prototype.hasOwnProperty.call(objectB, key) && widgetStateEqual(objectA[key], objectB[key])
+  );
+}
+
 // Default recent widgets shown in toolbar (most recent first)
 const defaultRecentWidgets = [
   WidgetType.RANDOMISER,
@@ -616,6 +634,10 @@ export const useWorkspaceStore = create<WorkspaceStore>()(
     }));
   },
   updateWidgetState: (widgetId, state) => {
+    const previous = get().widgetStates.get(widgetId);
+    if (widgetStateEqual(previous, state)) {
+      return;
+    }
     set((store) => {
       const newStates = new Map(store.widgetStates);
       newStates.set(widgetId, state);

--- a/packages/teacher/vite.config.js
+++ b/packages/teacher/vite.config.js
@@ -33,7 +33,7 @@ export default defineConfig({
     rollupOptions: {
       output: {
         manualChunks: {
-          'vendor-react': ['react', 'react-dom', 'react-router-dom'],
+          'vendor-react': ['react', 'react-dom', 'react-router-dom', 'react/jsx-runtime'],
           'vendor-rnd': ['react-rnd'],
           'vendor-dnd': ['@dnd-kit/core', '@dnd-kit/sortable', '@dnd-kit/utilities'],
           'vendor-socket': ['socket.io-client'],

--- a/script/build_and_run.sh
+++ b/script/build_and_run.sh
@@ -70,6 +70,7 @@ mkdir -p "$APP_MACOS" "$APP_RESOURCES/Web"
 cp "$EXECUTABLE" "$APP_MACOS/$PRODUCT_NAME"
 chmod +x "$APP_MACOS/$PRODUCT_NAME"
 cp -R "$ROOT_DIR/packages/teacher/build/." "$APP_RESOURCES/Web/"
+find "$APP_RESOURCES/Web" -name '*.map' -delete
 if [ -f "$APP_ICON_PATH" ]; then
   cp "$APP_ICON_PATH" "$APP_RESOURCES/AppIcon.icns"
 fi

--- a/script/build_macos_release.sh
+++ b/script/build_macos_release.sh
@@ -189,6 +189,7 @@ mkdir -p "${APP_MACOS}" "${WEB_RESOURCES}"
 cp "${EXECUTABLE}" "${APP_MACOS}/${PRODUCT_NAME}"
 chmod +x "${APP_MACOS}/${PRODUCT_NAME}"
 cp -R "${ROOT_DIR}/packages/teacher/build/." "${WEB_RESOURCES}/"
+find "${WEB_RESOURCES}" -name '*.map' -delete
 if [ -f "${APP_ICON_PATH}" ]; then
   cp "${APP_ICON_PATH}" "${APP_RESOURCES}/AppIcon.icns"
 fi


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

The macOS dashboard was spending time on first paint, compact-panel edits, and a pair of follow-up bugs that appeared once those paths were split.

Compact panels version chrome and widget state on two counters. The panel app still treated metadata `revision` as a total order, so a Timer or List that accepted one host echo then dropped later state-only writes. `didFinish` could also record a push before `CompactWidgetApp` installed `receiveSnapshot`, and `panel-ready` skipped the retry.

After that landed, review found two more host gaps. Native “Open Widget Launcher” polls `window.openClassroomWidgetLauncher` for 750ms, but compact mode unmounted `BottomBar`, the only writer of that global. And `prewarmCriticalAssets()` read every JS/CSS chunk on the same serial IO queue as demand loads.

## Scope

Dashboard and compact-panel load/edit speedups, plus the correctness fixes those changes exposed.

- `CompactWidgetApp.receiveSnapshot` accepts a snapshot when `revision` or `stateRevision` advances.
- `WidgetPanelController` force-pushes on `panel-ready`.
- Scheme-handler `complete`/`fail` hop to the main thread before talking to `WKURLSchemeTask`.
- `widgetStateEqual` compares `Date` values by `getTime()`.
- `App` owns `window.openClassroomWidgetLauncher` for its lifetime. `BottomBar` only registers the launchpad opener. A compact-mode open requests canvas and flushes when the toolbar remounts.
- Scheme prewarm loads `index.html` plus the same-origin js/mjs/css files it references, not the whole `assets/` tree.
- `abortCompactTransition` pushes the still-compact host mode back to the webview, cancels an already opened or queued launchpad, and clears the native launcher retry.

## Tradeoffs

`panel-ready` reapplies the current snapshot. A panel that already applied it from `didFinish` gets the same pair twice; `receiveSnapshot` drops a pair that did not advance.

Launcher opens that happen before `BottomBar` mounts stay pending until the launchpad registers. A failed compact-to-canvas handoff cancels that pending open.

Prewarm no longer pins lazy widget chunks. Those load on first use.

## Blast radius

Teachers on the macOS dashboard and compact panels. Later panel edits reach the store again. Native Open Widget Launcher and Cmd+K still work when the toolbar is hidden. First paint no longer waits behind a full-bundle disk scan. A failed compact-to-canvas handoff puts the web UI back on compact without leaving Add Widget open.

## Verification

`npx vitest run src/features/desktop/widgetLauncher.test.ts src/app/App.test.tsx` plus the CompactWidgetApp / CompactPanelHost / useDesktopDashboardMode files. Scheme-handler threading, prewarm parsing, abort resync, and the `panel-ready` force path have no XCTest harness in this environment.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a026bf-1f72-7ffd-a04f-144aebeb2e49?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a026bf-1f72-7ffd-a04f-144aebeb2e49&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

