### PR TITLE
fix(macos): restore fixed-panel titlebar input

### DIFF
--- a/packages/macos-dashboard/Sources/ClassroomWidgetsDashboard/WidgetPanelCoordinator.swift
+++ b/packages/macos-dashboard/Sources/ClassroomWidgetsDashboard/WidgetPanelCoordinator.swift
@@ -442,9 +442,7 @@ private final class WidgetPanelController: NSWindowController, NSWindowDelegate,
         messageHandler = webContext.messageHandler
 
         let initialContentRect = NSRect(origin: .zero, size: descriptor.preferredContentSize.cgSize)
-        let styleMask: NSWindow.StyleMask = descriptor.isResizable
-            ? [.titled, .closable, .resizable]
-            : [.titled, .closable]
+        let styleMask: NSWindow.StyleMask = [.titled, .closable, .resizable]
         let panel = WidgetPanel(
             contentRect: initialContentRect,
             styleMask: styleMask,
@@ -461,10 +459,7 @@ private final class WidgetPanelController: NSWindowController, NSWindowDelegate,
         panel.acceptsMouseMovedEvents = true
         panel.isReleasedWhenClosed = false
         panel.collectionBehavior = Self.collectionBehavior(joinsAllSpaces: keepOnAllSpaces)
-        panel.contentMinSize = descriptor.minimumContentSize.cgSize
-        if let maximumContentSize = descriptor.maximumContentSize?.cgSize {
-            panel.contentMaxSize = maximumContentSize
-        }
+        Self.applySizeConstraints(for: descriptor, to: panel)
         panel.contentAspectRatio = Self.contentAspectRatio(for: descriptor)
         panel.contentView = NSView()
         webView.frame = panel.contentView?.bounds ?? .zero
@@ -512,27 +507,9 @@ private final class WidgetPanelController: NSWindowController, NSWindowDelegate,
         if previous.title != descriptor.title {
             window?.title = descriptor.title
         }
-        if previous.minimumContentSize.width != descriptor.minimumContentSize.width
-            || previous.minimumContentSize.height != descriptor.minimumContentSize.height {
-            window?.contentMinSize = descriptor.minimumContentSize.cgSize
-        }
-        let previousMax = previous.maximumContentSize
-        let nextMax = descriptor.maximumContentSize
-        if previousMax?.width != nextMax?.width || previousMax?.height != nextMax?.height {
-            window?.contentMaxSize = nextMax?.cgSize ?? NSSize(
-                width: CGFloat.greatestFiniteMagnitude,
-                height: CGFloat.greatestFiniteMagnitude
-            )
-        }
+        Self.applySizeConstraints(for: descriptor, to: window)
         if previous.aspectRatio != descriptor.aspectRatio {
             window?.contentAspectRatio = Self.contentAspectRatio(for: descriptor)
-        }
-        if previous.isResizable != descriptor.isResizable, let window {
-            if descriptor.isResizable {
-                window.styleMask.insert(.resizable)
-            } else {
-                window.styleMask.remove(.resizable)
-            }
         }
     }
 
@@ -975,6 +952,20 @@ private final class WidgetPanelController: NSWindowController, NSWindowDelegate,
               let layout = WidgetPanelLayout(rawValue: rawLayout)
         else { return }
         onLayoutRequested?(layout)
+    }
+
+    private static func applySizeConstraints(for descriptor: WidgetPanelDescriptor, to window: NSWindow?) {
+        guard let window else { return }
+        window.contentMinSize = descriptor.isResizable
+            ? descriptor.minimumContentSize.cgSize
+            : descriptor.preferredContentSize.cgSize
+        window.contentMaxSize = descriptor.isResizable
+            ? descriptor.maximumContentSize?.cgSize ?? NSSize(
+                width: CGFloat.greatestFiniteMagnitude,
+                height: CGFloat.greatestFiniteMagnitude
+            )
+            : descriptor.preferredContentSize.cgSize
+        window.standardWindowButton(.zoomButton)?.isEnabled = descriptor.isResizable
     }
 
     private static func collectionBehavior(joinsAllSpaces: Bool) -> NSWindow.CollectionBehavior {


### PR DESCRIPTION
## Summary
- keep compact macOS panels AppKit-resizable so their titlebar remains an input surface
- preserve fixed-size widget behavior by pinning non-resizable panels to their preferred size
- leave existing min/max constraints in place for resizable widgets

## Root cause
Task Cue was the only current compact widget configured without the `.resizable` style mask. On macOS 26, that panel's titlebar region fell through to the window below. Adding `.resizable` restored native titlebar hit-testing; equal min/max constraints retain Task Cue's fixed size.

## Verification
- Physical validation on yjmbpro4: Task Cue traffic lights and titlebar drag work in the signed app
- `npm run test:build-config`
- `npm test -- --run` (42 files, 446 tests)
- `npm run build`
- `npm run build -w @classroom-widgets/teacher` on yjmbpro4
- `swift build --package-path packages/macos-dashboard -c release` on yjmbpro4
- Signed app passed `codesign --verify --deep --strict` and Gatekeeper
