### PR TITLE
chore: release 0.10.15

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "classroom-widgets",
-  "version": "0.10.14",
+  "version": "0.10.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "classroom-widgets",
-      "version": "0.10.14",
+      "version": "0.10.15",
       "workspaces": [
         "packages/shared",
         "packages/teacher",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "classroom-widgets",
-  "version": "0.10.14",
+  "version": "0.10.15",
   "private": true,
   "workspaces": [
     "packages/shared",


### PR DESCRIPTION
## Summary
- bump the root release version to 0.10.15
- keep package and lockfile release metadata aligned

## Verification
- package.json version is 0.10.15
- package-lock.json root versions are 0.10.15
- `git diff --check`

The release contains the Task Cue native titlebar fix merged in #81.
