### PR TITLE
Unify widget chrome spacing and add quick banner controls

### DIFF
--- a/packages/macos-dashboard/Sources/ClassroomWidgetsDashboard/WidgetPanelCoordinator.swift
+++ b/packages/macos-dashboard/Sources/ClassroomWidgetsDashboard/WidgetPanelCoordinator.swift
@@ -415,8 +415,9 @@ private final class WidgetPanelController: NSWindowController, NSWindowDelegate,
     var widgetID: String { descriptor.id }
     var isResizable: Bool { descriptor.isResizable }
     var preferredFrameSize: NSSize {
-        guard let window else { return descriptor.preferredContentSize.cgSize }
-        return window.frameRect(forContentRect: NSRect(origin: .zero, size: descriptor.preferredContentSize.cgSize)).size
+        let size = WidgetPanelContentLayout.panelSize(for: descriptor.preferredContentSize.cgSize)
+        guard let window else { return size }
+        return window.frameRect(forContentRect: NSRect(origin: .zero, size: size)).size
     }
 
     init(
@@ -431,7 +432,10 @@ private final class WidgetPanelController: NSWindowController, NSWindowDelegate,
         webView = webContext.webView
         messageHandler = webContext.messageHandler
 
-        let initialContentRect = NSRect(origin: .zero, size: descriptor.preferredContentSize.cgSize)
+        let initialContentRect = NSRect(
+            origin: .zero,
+            size: WidgetPanelContentLayout.panelSize(for: descriptor.preferredContentSize.cgSize)
+        )
         let styleMask: NSWindow.StyleMask = [.titled, .closable, .resizable]
         let panel = WidgetPanel(
             contentRect: initialContentRect,
@@ -450,11 +454,15 @@ private final class WidgetPanelController: NSWindowController, NSWindowDelegate,
         panel.isReleasedWhenClosed = false
         panel.collectionBehavior = Self.collectionBehavior(joinsAllSpaces: keepOnAllSpaces)
         Self.applySizeConstraints(for: descriptor, to: panel)
-        panel.contentAspectRatio = Self.contentAspectRatio(for: descriptor)
-        panel.contentView = NSView()
-        webView.frame = panel.contentView?.bounds ?? .zero
+        let contentView = NSView(frame: initialContentRect)
+        panel.contentView = contentView
+        // NSView is unflipped: keep the web view bottom-aligned with a fixed transparent top margin.
+        webView.frame = NSRect(
+            origin: .zero,
+            size: NSSize(width: contentView.bounds.width, height: contentView.bounds.height - WidgetPanelContentLayout.topGap)
+        )
         webView.autoresizingMask = [.width, .height]
-        panel.contentView?.addSubview(webView)
+        contentView.addSubview(webView)
 
         super.init(window: panel)
         panel.delegate = self
@@ -475,6 +483,7 @@ private final class WidgetPanelController: NSWindowController, NSWindowDelegate,
 
         addCompactAccessories(to: panel)
         installChromeTracking(on: panel)
+        revealChrome()
         scheduleChromeHide()
         loadWidget()
     }
@@ -497,9 +506,6 @@ private final class WidgetPanelController: NSWindowController, NSWindowDelegate,
             window?.title = descriptor.title
         }
         Self.applySizeConstraints(for: descriptor, to: window)
-        if previous.aspectRatio != descriptor.aspectRatio {
-            window?.contentAspectRatio = Self.contentAspectRatio(for: descriptor)
-        }
     }
 
     func applyPresentationSettings(backgroundOpacity: Double, keepOnAllSpaces: Bool) {
@@ -672,9 +678,16 @@ private final class WidgetPanelController: NSWindowController, NSWindowDelegate,
     }
 
     func windowDidResize(_ notification: Notification) {
-        updateChromeTrackingArea()
         guard !isProgrammaticallyChangingFrame, let frame = window?.frame else { return }
         onFrameChanged?(widgetID, frame)
+    }
+
+    func windowWillResize(_ sender: NSWindow, to frameSize: NSSize) -> NSSize {
+        // NSWindow.contentAspectRatio would include the gap and distort the web viewport.
+        let proposed = sender.contentRect(forFrameRect: NSRect(origin: .zero, size: frameSize)).size
+        let current = sender.contentRect(forFrameRect: sender.frame).size
+        let size = WidgetPanelContentLayout.constrainedSize(proposed, current: current, descriptor: descriptor)
+        return sender.frameRect(forContentRect: NSRect(origin: .zero, size: size)).size
     }
 
     func windowDidBecomeKey(_ notification: Notification) {
@@ -692,6 +705,7 @@ private final class WidgetPanelController: NSWindowController, NSWindowDelegate,
 
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
         setWebBackgroundOpacity()
+        setWebChromeVisibility()
         guard let snapshot = currentSnapshot else { return }
         push(snapshot: snapshot, force: true)
     }
@@ -738,7 +752,12 @@ private final class WidgetPanelController: NSWindowController, NSWindowDelegate,
     private var currentSnapshot: [String: Any]?
     private var lastPushedRevision: Int?
     private var lastPushedStateRevision: Int?
-    private var lastTrackingRevealHeight: CGFloat = -1
+
+    private func setWebChromeVisibility() {
+        webView.evaluateJavaScript(
+            "document.documentElement.dataset.widgetChromeVisible = '\(chromeVisible ? "true" : "false")'"
+        )
+    }
 
     private func setWebBackgroundOpacity() {
         webView.evaluateJavaScript(
@@ -817,17 +836,12 @@ private final class WidgetPanelController: NSWindowController, NSWindowDelegate,
 
     private func updateChromeTrackingArea() {
         guard let frameView = chromeTrackingView else { return }
-        let revealHeight = min(frameView.bounds.height, max(44, frameView.bounds.height - (window?.contentLayoutRect.maxY ?? 0) + 12))
-        if chromeTrackingArea != nil, abs(revealHeight - lastTrackingRevealHeight) < 0.5 {
-            return
-        }
-        lastTrackingRevealHeight = revealHeight
         if let chromeTrackingArea {
             frameView.removeTrackingArea(chromeTrackingArea)
         }
         let area = NSTrackingArea(
-            rect: NSRect(x: 0, y: frameView.bounds.maxY - revealHeight, width: frameView.bounds.width, height: revealHeight),
-            options: [.mouseEnteredAndExited, .activeAlways],
+            rect: .zero,
+            options: [.mouseEnteredAndExited, .activeAlways, .inVisibleRect],
             owner: self,
             userInfo: nil
         )
@@ -844,19 +858,18 @@ private final class WidgetPanelController: NSWindowController, NSWindowDelegate,
         chromeHideGeneration += 1
         let generation = chromeHideGeneration
         Task { @MainActor [weak self] in
-            try? await Task.sleep(nanoseconds: 1_800_000_000)
+            try? await Task.sleep(nanoseconds: 2_000_000_000)
             guard let self,
                   self.chromeHideGeneration == generation,
-                  !self.pointerIsInChromeRevealArea
+                  !self.pointerIsInPanel
             else { return }
             self.setChromeVisible(false)
         }
     }
 
-    private var pointerIsInChromeRevealArea: Bool {
+    private var pointerIsInPanel: Bool {
         guard let panel = window, panel.isVisible else { return false }
-        let revealRect = NSRect(x: panel.frame.minX, y: panel.frame.maxY - 48, width: panel.frame.width, height: 48)
-        return revealRect.contains(NSEvent.mouseLocation)
+        return panel.frame.contains(NSEvent.mouseLocation)
     }
 
     private func setChromeVisible(_ visible: Bool) {
@@ -864,6 +877,7 @@ private final class WidgetPanelController: NSWindowController, NSWindowDelegate,
         let effectiveVisibility = visible || NSWorkspace.shared.isVoiceOverEnabled
         guard chromeVisible != effectiveVisibility else { return }
         chromeVisible = effectiveVisibility
+        setWebChromeVisibility()
         panel.titleVisibility = .hidden
         panel.titlebarAppearsTransparent = true
 
@@ -946,14 +960,14 @@ private final class WidgetPanelController: NSWindowController, NSWindowDelegate,
     private static func applySizeConstraints(for descriptor: WidgetPanelDescriptor, to window: NSWindow?) {
         guard let window else { return }
         window.contentMinSize = descriptor.isResizable
-            ? descriptor.minimumContentSize.cgSize
-            : descriptor.preferredContentSize.cgSize
+            ? WidgetPanelContentLayout.panelSize(for: descriptor.minimumContentSize.cgSize)
+            : WidgetPanelContentLayout.panelSize(for: descriptor.preferredContentSize.cgSize)
         window.contentMaxSize = descriptor.isResizable
-            ? descriptor.maximumContentSize?.cgSize ?? NSSize(
+            ? descriptor.maximumContentSize.map { WidgetPanelContentLayout.panelSize(for: $0.cgSize) } ?? NSSize(
                 width: CGFloat.greatestFiniteMagnitude,
                 height: CGFloat.greatestFiniteMagnitude
             )
-            : descriptor.preferredContentSize.cgSize
+            : WidgetPanelContentLayout.panelSize(for: descriptor.preferredContentSize.cgSize)
         window.standardWindowButton(.zoomButton)?.isEnabled = descriptor.isResizable
     }
 
@@ -965,11 +979,34 @@ private final class WidgetPanelController: NSWindowController, NSWindowDelegate,
         return behavior
     }
 
-    private static func contentAspectRatio(for descriptor: WidgetPanelDescriptor) -> NSSize {
-        guard let aspectRatio = descriptor.aspectRatio, aspectRatio > 0 else { return .zero }
-        return NSSize(width: aspectRatio, height: 1)
+}
+
+/// Descriptor sizes refer to the web viewport, not the transparent space below the titlebar.
+enum WidgetPanelContentLayout {
+    static let topGap: CGFloat = 10
+
+    static func panelSize(for webSize: NSSize) -> NSSize {
+        NSSize(width: webSize.width, height: webSize.height + topGap)
     }
 
+    static func constrainedSize(
+        _ proposed: NSSize,
+        current: NSSize,
+        descriptor: WidgetPanelDescriptor
+    ) -> NSSize {
+        guard descriptor.isResizable,
+              let ratio = descriptor.aspectRatio, ratio > 0 else { return proposed }
+        let minimum = descriptor.minimumContentSize.cgSize
+        let maximum = descriptor.maximumContentSize?.cgSize
+        let minimumWidth = max(minimum.width, minimum.height * ratio)
+        let maximumWidth = min(maximum?.width ?? .greatestFiniteMagnitude,
+                               (maximum?.height ?? .greatestFiniteMagnitude) * ratio)
+        let width = abs(proposed.width - current.width) >= abs(proposed.height - current.height) * ratio
+            ? proposed.width
+            : (proposed.height - topGap) * ratio
+        let constrainedWidth = max(minimumWidth, min(width, maximumWidth))
+        return panelSize(for: NSSize(width: constrainedWidth, height: constrainedWidth / ratio))
+    }
 }
 
 private final class WidgetPanel: NSPanel {

--- a/packages/macos-dashboard/Tests/ClassroomWidgetsTests/WidgetPanelContentLayoutTests.swift
+++ b/packages/macos-dashboard/Tests/ClassroomWidgetsTests/WidgetPanelContentLayoutTests.swift
@@ -1,0 +1,71 @@
+import AppKit
+import XCTest
+@testable import ClassroomWidgets
+
+final class WidgetPanelContentLayoutTests: XCTestCase {
+    func testGapIsAddedWithoutReducingPreferredViewport() {
+        XCTAssertEqual(
+            WidgetPanelContentLayout.panelSize(for: NSSize(width: 350, height: 415)),
+            NSSize(width: 350, height: 425)
+        )
+        XCTAssertEqual(
+            WidgetPanelContentLayout.panelSize(for: NSSize(width: 325, height: 325)),
+            NSSize(width: 325, height: 335)
+        )
+    }
+
+    func testTimerAspectRatioExcludesGapWhenResizingEitherAxis() {
+        let timer = descriptor(aspectRatio: 350.0 / 415.0)
+        for proposed in [NSSize(width: 700, height: 425), NSSize(width: 350, height: 840)] {
+            let result = WidgetPanelContentLayout.constrainedSize(
+                proposed, current: NSSize(width: 350, height: 425), descriptor: timer
+            )
+            XCTAssertEqual(result.width, 700, accuracy: 0.001)
+            XCTAssertEqual(result.height, 840, accuracy: 0.001)
+        }
+    }
+
+    func testAspectResizeHonoursBothMinimumDimensions() {
+        let result = WidgetPanelContentLayout.constrainedSize(
+            NSSize(width: 100, height: 100),
+            current: NSSize(width: 350, height: 425),
+            descriptor: descriptor(aspectRatio: 350.0 / 415.0)
+        )
+        XCTAssertGreaterThanOrEqual(result.width, 250)
+        XCTAssertEqual(result.height, 316, accuracy: 0.001)
+        XCTAssertEqual(result.width / (result.height - 10), 350.0 / 415.0, accuracy: 0.001)
+    }
+
+    func testAspectResizeHonoursBothMaximumDimensions() {
+        let result = WidgetPanelContentLayout.constrainedSize(
+            NSSize(width: 1000, height: 1000),
+            current: NSSize(width: 350, height: 425),
+            descriptor: descriptor(aspectRatio: 1, maximum: .init(width: 500, height: 450))
+        )
+        XCTAssertEqual(result, NSSize(width: 450, height: 460))
+    }
+
+    func testUnconstrainedAspectLeavesResizeUnchanged() {
+        let proposed = NSSize(width: 450, height: 600)
+        XCTAssertEqual(
+            WidgetPanelContentLayout.constrainedSize(
+                proposed, current: NSSize(width: 350, height: 425), descriptor: descriptor(aspectRatio: nil)
+            ),
+            proposed
+        )
+    }
+
+    private func descriptor(
+        aspectRatio: CGFloat?,
+        maximum: WidgetPanelDescriptor.Size? = nil
+    ) -> WidgetPanelDescriptor {
+        WidgetPanelDescriptor(
+            id: "test", title: "Test",
+            preferredContentSize: .init(width: 350, height: 415),
+            minimumContentSize: .init(width: 250, height: 306),
+            maximumContentSize: maximum,
+            aspectRatio: aspectRatio,
+            snapshotPayload: [:]
+        )
+    }
+}

--- a/packages/shared/utils/styles.ts
+++ b/packages/shared/utils/styles.ts
@@ -151,7 +151,7 @@ export const widgetWrapper = cn(
 
 // Widget controls section (glassmorphic style)
 export const widgetControls = cn(
-  "flex items-center p-3 mt-1",
+  "flex items-center p-3 mt-[10px]",
   "min-h-16 max-h-16",
   "bg-white/50 dark:bg-warm-gray-800/50",
   "backdrop-blur-md",

--- a/packages/teacher/src/app/App.css
+++ b/packages/teacher/src/app/App.css
@@ -146,6 +146,29 @@ html.compact-widget-panel #root {
   background: transparent;
 }
 
+/* Native panel hover owns both titlebar and widget controls. Never collapse
+   the footer's space: hiding chrome must not resize the widget content. */
+html.compact-widget-panel [data-widget-controls] {
+  transition: opacity 160ms ease;
+}
+
+html.compact-widget-panel[data-widget-chrome-visible="false"] [data-widget-controls] {
+  opacity: 0;
+  pointer-events: none;
+}
+
+/* Keyboard users can still tab into a hidden bar and see their focused control. */
+html.compact-widget-panel [data-widget-controls]:has(:focus-visible) {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html.compact-widget-panel [data-widget-controls] {
+    transition: none;
+  }
+}
+
 html.compact-widget-panel .widget-container-surface:not(.widget-container-custom-surface) {
   background-color: rgb(253 252 251 / calc(0.9 * var(--compact-widget-background-opacity, 1)));
 }

--- a/packages/teacher/src/features/widgets/shared/components/WidgetControlBar.tsx
+++ b/packages/teacher/src/features/widgets/shared/components/WidgetControlBar.tsx
@@ -19,7 +19,7 @@ export const WidgetControlBar: React.FC<WidgetControlBarProps> = ({
   justify = "justify-between"
 }) => {
   return (
-    <div className={cn(widgetControls, gap, justify, className)}>
+    <div data-widget-controls className={cn(widgetControls, gap, justify, className)}>
       {children}
     </div>
   );

--- a/packages/teacher/src/features/widgets/taskCue/taskCue.test.tsx
+++ b/packages/teacher/src/features/widgets/taskCue/taskCue.test.tsx
@@ -20,9 +20,10 @@ describe('TaskCue', () => {
 
   it('restores and publishes the selected task mode', async () => {
     const onStateChange = vi.fn();
-    render(<TaskCue savedState={{ index: 3 }} onStateChange={onStateChange} />);
+    render(<TaskCue isActive savedState={{ index: 3 }} onStateChange={onStateChange} />);
 
     expect(screen.getByText('Work alone')).toBeInTheDocument();
+    expect(screen.getByTitle('Work alone').closest('[data-widget-controls]')).toHaveClass('mt-[10px]');
 
     await userEvent.click(screen.getByTitle('Click to cycle to next state'));
 

--- a/packages/teacher/src/features/widgets/taskCue/taskCue.tsx
+++ b/packages/teacher/src/features/widgets/taskCue/taskCue.tsx
@@ -89,7 +89,7 @@ function TaskCue({ isActive = false, savedState, onStateChange }: TaskCueProps) 
                 </div>
             </div>
             {isActive && (
-                <div className="px-3 pb-3">
+                <div data-widget-controls className="mt-[10px] px-3 pb-3">
                     <div id="widget1inside" className="flex flex-wrap justify-center gap-1">
                         {taskModes.map((mode, i) => {
                             const Icon = mode.icon;

--- a/packages/teacher/src/features/widgets/textBanner/textBanner.test.tsx
+++ b/packages/teacher/src/features/widgets/textBanner/textBanner.test.tsx
@@ -60,12 +60,7 @@ describe('TextBanner text editor', () => {
     expect(screen.getAllByText('First line')).not.toHaveLength(0);
     expect(screen.getAllByText('Second line')).not.toHaveLength(0);
     const editButton = screen.getByRole('button', { name: 'Edit banner' });
-    expect(editButton).toHaveClass(
-      'opacity-0',
-      'group-hover/banner:opacity-100',
-      'focus:opacity-100',
-      'focus-visible:opacity-100'
-    );
+    expect(editButton.closest('[data-widget-controls]')).not.toBeNull();
     await waitFor(() => expect(editButton).toHaveFocus());
   });
 
@@ -280,27 +275,69 @@ describe('TextBanner text editor', () => {
     render(<TextBanner savedState={{ text: 'Column banner', columnHeight: 60 }} />);
 
     const widget = screen.getByRole('button', { name: 'Edit banner' }).closest('.widget-container-custom-surface');
-    expect(widget).toHaveStyle({ height: '60px' });
+    expect(widget).toHaveStyle({ height: '128px' });
 
     await user.click(screen.getByRole('button', { name: 'Edit banner' }));
     expect(widget).toHaveStyle({ height: '260px' });
 
     await user.click(screen.getByRole('button', { name: 'Cancel' }));
     expect(screen.getByRole('button', { name: 'Edit banner' }).closest('.widget-container-custom-surface'))
-      .toHaveStyle({ height: '60px' });
+      .toHaveStyle({ height: '128px' });
   });
 
-  it('keeps the compact-panel Edit action clear of the top-right window control', () => {
-    render(<TextBanner isCompactPanel savedState={{ text: 'Compact banner' }} />);
+  it('puts compact-panel editing and colours in the bottom bar, outside the display', () => {
+    render(<TextBanner isCompactPanel savedState={{ text: 'Compact banner', colorIndex: 6, customColor: '#123456' }} />);
 
-    expect(screen.getByRole('button', { name: 'Edit banner' })).toHaveClass('right-12');
+    const edit = screen.getByRole('button', { name: 'Edit banner' });
+    const bar = edit.closest('[data-widget-controls]');
+    expect(bar).toContainElement(screen.getByRole('group', { name: 'Banner colour' }));
+    expect(bar).toHaveClass('mt-[10px]');
+    expect(screen.getByTestId('text-banner-display')).toHaveStyle({ backgroundColor: '#123456' });
+    expect(bar?.parentElement).not.toHaveStyle({ backgroundColor: '#123456' });
+    expect(screen.getByTestId('text-banner-display')).not.toContainElement(edit);
+    expect(edit).not.toHaveClass('absolute');
   });
 
-  it('keeps the dashboard Edit action clear of the top-right Close control', () => {
+  it('uses the same bottom bar in the dashboard and applies colours without opening the editor', async () => {
     window.history.replaceState({}, '', '/?dashboard=1');
-    render(<TextBanner savedState={{ text: 'Dashboard banner' }} />);
+    const onStateChange = vi.fn();
+    render(<TextBanner savedState={{ text: 'Dashboard banner' }} onStateChange={onStateChange} />);
 
-    expect(screen.getByRole('button', { name: 'Edit banner' })).toHaveClass('right-12');
+    expect(screen.getByRole('button', { name: 'Edit banner' }).closest('[data-widget-controls]')).not.toBeNull();
+    await userEvent.click(screen.getByRole('button', { name: 'Set banner colour to Sage' }));
+    expect(onStateChange).toHaveBeenLastCalledWith(expect.objectContaining({ colorIndex: 1 }));
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+  });
+
+  it('updates text size immediately from the bottom bar and shares it with the editor', async () => {
+    const user = userEvent.setup();
+    const onStateChange = vi.fn();
+    render(<TextBanner savedState={{ text: 'Quick sizing', fontSizeCap: 48 }} onStateChange={onStateChange} />);
+
+    const increase = screen.getByRole('button', { name: 'Increase text size' });
+    expect(increase.closest('[data-widget-controls]')).not.toBeNull();
+    await user.click(increase);
+    expect(onStateChange).toHaveBeenLastCalledWith(expect.objectContaining({ fontSizeCap: 64 }));
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Decrease text size' }));
+    expect(onStateChange).toHaveBeenLastCalledWith(expect.objectContaining({ fontSizeCap: 48 }));
+    await user.click(screen.getByRole('button', { name: 'Edit banner' }));
+    expect(screen.getByLabelText('Maximum text size: 48 pixels')).toBeInTheDocument();
+  });
+
+  it.each([
+    { start: 32, button: 'Decrease text size', limit: 24 },
+    { start: 212, button: 'Increase text size', limit: 220 }
+  ])('clamps quick sizing at $limit and disables further changes', async ({ start, button, limit }) => {
+    const user = userEvent.setup();
+    const onStateChange = vi.fn();
+    render(<TextBanner isCompactPanel savedState={{ text: 'Bounded sizing', fontSizeCap: start }} onStateChange={onStateChange} />);
+
+    await user.click(screen.getByRole('button', { name: button }));
+    expect(onStateChange).toHaveBeenLastCalledWith(expect.objectContaining({ fontSizeCap: limit }));
+    expect(screen.getByRole('button', { name: button })).toBeDisabled();
+    await user.click(screen.getByRole('button', { name: button }));
+    expect(onStateChange).toHaveBeenCalledTimes(1);
   });
 
   it('enforces the editor-sized minimum in canvas and compact-panel hosts', () => {

--- a/packages/teacher/src/features/widgets/textBanner/textBanner.tsx
+++ b/packages/teacher/src/features/widgets/textBanner/textBanner.tsx
@@ -24,8 +24,8 @@ import {
   TextBannerFontFamily
 } from './fonts';
 import { findCodeBlock, highlightCode, normaliseCode, type HighlightedCode } from './highlight';
-import { cn, widgetContainer } from '@shared/utils/styles';
-import { isDesktopDashboardMode } from '@shared/utils/dashboardMode';
+import { cn, widgetContainer, widgetWrapper } from '@shared/utils/styles';
+import { WidgetControlBar } from '../shared/components/WidgetControlBar';
 import { useWidgetState } from '@shared/hooks/useWidgetState';
 import { useWorkspaceStore } from '../../../store/workspaceStore.simple';
 
@@ -43,7 +43,7 @@ interface TextBannerState {
 type TextBannerDraft = Pick<TextBannerState, 'text' | 'colorIndex' | 'customColor' | 'fontFamily' | 'fontSizeCap'>;
 
 const DEFAULT_COLUMN_HEIGHT = 160;
-const MIN_COLUMN_HEIGHT = 60;
+const MIN_COLUMN_HEIGHT = 128;
 const MAX_COLUMN_HEIGHT = 1200;
 const EDITOR_MIN_HEIGHT = 260;
 
@@ -151,8 +151,6 @@ const renderFormattedText = (value: string) => {
 const TextBanner: React.FC<TextBannerProps> = ({ savedState, onStateChange, isCompactPanel = false }) => {
   const workspaceIsColumnLayout = useWorkspaceStore((state) => state.layoutFormat === 'column');
   const isColumnLayout = workspaceIsColumnLayout && !isCompactPanel;
-  const isDashboardMode = isDesktopDashboardMode();
-  const isTouchDevice = typeof window !== 'undefined' && window.matchMedia?.('(hover: none)')?.matches;
 
   const initialState: TextBannerState = {
     text: '',
@@ -339,7 +337,10 @@ const TextBanner: React.FC<TextBannerProps> = ({ savedState, onStateChange, isCo
     document.addEventListener('mouseup', handleUp);
   };
 
-  const effectiveColumnHeight = pendingHeight ?? columnHeight;
+  const requestedColumnHeight = pendingHeight ?? columnHeight;
+  const effectiveColumnHeight = requestedColumnHeight === undefined
+    ? undefined
+    : Math.max(MIN_COLUMN_HEIGHT, requestedColumnHeight);
   const columnStyle = isColumnLayout
     ? isEditorOpen
       ? { height: `${Math.max(effectiveColumnHeight ?? 0, EDITOR_MIN_HEIGHT)}px` }
@@ -347,21 +348,16 @@ const TextBanner: React.FC<TextBannerProps> = ({ savedState, onStateChange, isCo
         ? { height: `${effectiveColumnHeight}px` }
         : undefined
     : undefined;
-  const widgetStyle: React.CSSProperties = {
-    ...(columnStyle ?? {}),
-    ...(isCustomColor ? { backgroundColor: customColor } : {})
-  };
 
   return (
     <div
       ref={widgetRef}
       className={cn(
-        widgetContainer,
+        widgetWrapper,
         'widget-container-custom-surface',
-        !isCustomColor && currentColors.bg,
-        'relative overflow-hidden transition-colors duration-300 flex flex-col group/banner'
+        '@container overflow-hidden rounded-lg group/banner'
       )}
-      style={widgetStyle}
+      style={columnStyle}
     >
       {isEditorOpen && (
         <div className="absolute inset-0 z-20">
@@ -376,27 +372,6 @@ const TextBanner: React.FC<TextBannerProps> = ({ savedState, onStateChange, isCo
         </div>
       )}
 
-      {text && (
-        <button
-          ref={editorTriggerRef}
-          type="button"
-          onClick={openEditor}
-          className={cn(
-            'no-drag absolute top-2 z-10 inline-flex min-h-10 items-center justify-center gap-2 rounded-lg bg-warm-gray-900/70 px-3 py-2 text-sm font-medium text-white shadow-lg transition-all hover:bg-warm-gray-900/85 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white',
-            isCompactPanel || isDashboardMode ? 'right-12' : 'right-2',
-            isTouchDevice
-              ? 'opacity-100'
-              : 'pointer-events-none opacity-0 group-hover/banner:pointer-events-auto group-hover/banner:opacity-100 focus:pointer-events-auto focus:opacity-100 focus-visible:pointer-events-auto focus-visible:opacity-100',
-            isEditorOpen && 'invisible pointer-events-none'
-          )}
-          aria-label="Edit banner"
-          aria-hidden={isEditorOpen || undefined}
-        >
-          <FaPencil aria-hidden="true" />
-          <span>Edit</span>
-        </button>
-      )}
-
       <div
         ref={textAreaContainerRef}
         data-testid="text-banner-display"
@@ -405,8 +380,12 @@ const TextBanner: React.FC<TextBannerProps> = ({ savedState, onStateChange, isCo
           surfacePointerStartRef.current = { x: event.clientX, y: event.clientY };
         }}
         onClick={cycleDisplayedColor}
+        style={isCustomColor ? { backgroundColor: customColor } : undefined}
         className={cn(
-          'flex-1 flex items-center justify-center relative',
+          widgetContainer,
+          'widget-container-custom-surface',
+          !isCustomColor && currentColors.bg,
+          'h-auto flex-1 items-center justify-center relative transition-colors duration-300',
           text ? 'cursor-pointer p-4' : 'p-1',
           // Only constrain the content pane when the widget itself has a bounded height
           // (canvas mode is always bounded via react-rnd; column mode only when columnHeight is set).
@@ -471,6 +450,65 @@ const TextBanner: React.FC<TextBannerProps> = ({ savedState, onStateChange, isCo
           </div>
         )}
       </div>
+
+      {text && !isEditorOpen && (
+        <WidgetControlBar className="no-drag flex-shrink-0 flex-nowrap gap-1 px-2 bg-soft-white text-warm-gray-900 dark:bg-warm-gray-800 dark:text-warm-gray-100">
+          <button
+            ref={editorTriggerRef}
+            type="button"
+            onClick={openEditor}
+            className="inline-flex min-h-8 items-center gap-2 rounded-lg px-2 text-sm font-medium hover:bg-warm-gray-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sage-500 dark:hover:bg-warm-gray-700"
+            aria-label="Edit banner"
+            title="Edit banner"
+          >
+            <FaPencil aria-hidden="true" />
+            <span className="hidden @[360px]:inline">Edit</span>
+          </button>
+          <div role="group" aria-label="Banner text size" className="flex shrink-0 items-center gap-1">
+            <button
+              type="button"
+              onClick={() => updateState({ fontSizeCap: Math.max(MIN_FONT_SIZE_CAP, fontSizeCap - FONT_SIZE_STEP) })}
+              disabled={fontSizeCap <= MIN_FONT_SIZE_CAP}
+              aria-label="Decrease text size"
+              title={`Decrease text size (maximum ${fontSizeCap}px)`}
+              className="inline-flex h-8 w-7 items-center justify-center rounded-md border border-warm-gray-300 text-xs hover:bg-warm-gray-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sage-500 disabled:cursor-not-allowed disabled:opacity-40 dark:border-warm-gray-600 dark:hover:bg-warm-gray-700"
+            >
+              <FaMinus aria-hidden="true" />
+            </button>
+            <button
+              type="button"
+              onClick={() => updateState({ fontSizeCap: Math.min(MAX_FONT_SIZE_CAP, fontSizeCap + FONT_SIZE_STEP) })}
+              disabled={fontSizeCap >= MAX_FONT_SIZE_CAP}
+              aria-label="Increase text size"
+              title={`Increase text size (maximum ${fontSizeCap}px)`}
+              className="inline-flex h-8 w-7 items-center justify-center rounded-md border border-warm-gray-300 text-xs hover:bg-warm-gray-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sage-500 disabled:cursor-not-allowed disabled:opacity-40 dark:border-warm-gray-600 dark:hover:bg-warm-gray-700"
+            >
+              <FaPlus aria-hidden="true" />
+            </button>
+          </div>
+          <div role="group" aria-label="Banner colour" className="flex items-center gap-1">
+            {colorCombinations.map((combo, index) => (
+              <button
+                key={combo.name}
+                type="button"
+                onClick={() => updateState({ colorIndex: index })}
+                className="inline-flex h-5 w-5 items-center justify-center rounded-full border border-black/30 shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sage-500 focus-visible:ring-offset-1"
+                style={{ backgroundColor: combo.swatch, color: getCustomTextColor(combo.swatch) }}
+                aria-label={`Set banner colour to ${combo.name}`}
+                aria-pressed={index === colorIndex}
+                title={combo.name}
+              >
+                {index === colorIndex && <FaCheck className="h-2.5 w-2.5" aria-hidden="true" />}
+              </button>
+            ))}
+            <CustomColourPicker
+              color={customColor}
+              selected={isCustomColor}
+              onChange={nextColor => updateState({ colorIndex: colorCombinations.length, customColor: nextColor })}
+            />
+          </div>
+        </WidgetControlBar>
+      )}
 
       {isColumnLayout && (
         <div

--- a/packages/teacher/src/features/widgets/timer/timer.test.tsx
+++ b/packages/teacher/src/features/widgets/timer/timer.test.tsx
@@ -78,16 +78,19 @@ describe('Timer Widget', () => {
     expect(screen.queryByRole('button', { name: /add 1 minute/i })).not.toBeInTheDocument();
   });
 
-  test('auto-hides compact panel controls when the pointer moves away', () => {
+  test('marks compact controls for shared chrome styling without independently hiding on pointer changes', () => {
     renderWithModal(<Timer isCompactPanel />);
 
     const controlsRegion = screen.getByTestId('timer-bottom-controls-region');
     const controls = screen.getByTestId('timer-bottom-controls');
 
+    expect(controls).toHaveAttribute('data-widget-controls');
+    expect(controls.className).toBe('transition-opacity duration-150 motion-reduce:transition-none');
+
     act(() => {
       vi.advanceTimersByTime(1800);
     });
-    expect(controls).toHaveClass('pointer-events-none', 'opacity-0');
+    expect(controls.className).toBe('transition-opacity duration-150 motion-reduce:transition-none');
 
     fireEvent.mouseEnter(controlsRegion);
     expect(controls).not.toHaveClass('pointer-events-none', 'opacity-0');
@@ -104,10 +107,10 @@ describe('Timer Widget', () => {
     act(() => {
       vi.advanceTimersByTime(1);
     });
-    expect(controls).toHaveClass('pointer-events-none', 'opacity-0');
+    expect(controls.className).toBe('transition-opacity duration-150 motion-reduce:transition-none');
   });
 
-  test('reveals compact panel controls for keyboard focus', () => {
+  test('does not independently hide compact controls after keyboard focus leaves', () => {
     renderWithModal(<Timer isCompactPanel />);
 
     const controls = screen.getByTestId('timer-bottom-controls');
@@ -130,10 +133,10 @@ describe('Timer Widget', () => {
     act(() => {
       vi.advanceTimersByTime(1800);
     });
-    expect(controls).toHaveClass('pointer-events-none', 'opacity-0');
+    expect(controls.className).toBe('transition-opacity duration-150 motion-reduce:transition-none');
   });
 
-  test('re-arms compact auto-hide when keyboard activation replaces the focused control', () => {
+  test('does not independently hide compact controls when starting replaces the focused control', () => {
     renderWithModal(<Timer isCompactPanel />);
 
     const controls = screen.getByTestId('timer-bottom-controls');
@@ -147,10 +150,17 @@ describe('Timer Widget', () => {
     act(() => {
       vi.advanceTimersByTime(1800);
     });
-    expect(controls).toHaveClass('pointer-events-none', 'opacity-0');
+    expect(controls.className).toBe('transition-opacity duration-150 motion-reduce:transition-none');
+
+    fireEvent.click(screen.getByRole('button', { name: /pause/i }));
+    act(() => {
+      vi.advanceTimersByTime(1800);
+    });
+    expect(screen.getByRole('button', { name: /resume/i })).toBeInTheDocument();
+    expect(controls.className).toBe('transition-opacity duration-150 motion-reduce:transition-none');
   });
 
-  test('re-arms compact auto-hide when expiry replaces the keyboard-focused Pause control', () => {
+  test('does not independently hide compact controls when expiry replaces the focused Pause control', () => {
     renderWithModal(<Timer isCompactPanel />);
 
     const controls = screen.getByTestId('timer-bottom-controls');
@@ -168,10 +178,10 @@ describe('Timer Widget', () => {
     act(() => {
       vi.advanceTimersByTime(1800);
     });
-    expect(controls).toHaveClass('pointer-events-none', 'opacity-0');
+    expect(controls.className).toBe('transition-opacity duration-150 motion-reduce:transition-none');
   });
 
-  test('keeps compact panel controls visible while an options tray is open', () => {
+  test('does not independently hide compact controls when an options tray opens or closes', () => {
     renderWithModal(<Timer isCompactPanel />);
 
     const controlsRegion = screen.getByTestId('timer-bottom-controls-region');
@@ -188,17 +198,19 @@ describe('Timer Widget', () => {
     act(() => {
       vi.advanceTimersByTime(1800);
     });
-    expect(controls).toHaveClass('pointer-events-none', 'opacity-0');
+    expect(controls.className).toBe('transition-opacity duration-150 motion-reduce:transition-none');
   });
 
-  test('keeps timer controls visible outside the compact Mac panel', () => {
+  test('marks controls for shared styling outside the compact Mac panel too', () => {
     renderWithModal(<Timer />);
 
     act(() => {
       vi.advanceTimersByTime(1800);
     });
 
-    expect(screen.getByTestId('timer-bottom-controls')).not.toHaveClass('pointer-events-none', 'opacity-0');
+    const controls = screen.getByTestId('timer-bottom-controls');
+    expect(controls).toHaveAttribute('data-widget-controls');
+    expect(controls.className).toBe('transition-opacity duration-150 motion-reduce:transition-none');
   });
 
   test('keeps the outer timer shell transparent in dark mode while filling the circle solid dark', () => {

--- a/packages/teacher/src/features/widgets/timer/timer.tsx
+++ b/packages/teacher/src/features/widgets/timer/timer.tsx
@@ -22,7 +22,6 @@ import timerEndSound2 from "./timer-end-2.wav";
 import timerEndSound3 from "./timer-end-3.mp3";
 
 type SoundMode = 'short' | 'long';
-const COMPACT_CONTROLS_HIDE_DELAY_MS = 1800;
 
 interface TimerProps {
   savedState?: any;
@@ -31,7 +30,7 @@ interface TimerProps {
   isCompactPanel?: boolean;
 }
 
-const Timer: React.FC<TimerProps> = ({ savedState, onStateChange, renderTheme, isCompactPanel = false }) => {
+const Timer: React.FC<TimerProps> = ({ savedState, onStateChange, renderTheme }) => {
   const workspaceTheme = useTheme();
   const isDark = renderTheme ? renderTheme === 'dark' : workspaceTheme.isDark;
   const [soundMode, setSoundMode] = useState<SoundMode>(() =>
@@ -48,76 +47,6 @@ const Timer: React.FC<TimerProps> = ({ savedState, onStateChange, renderTheme, i
   const [quickAddExpanded, setQuickAddExpanded] = useState(false);
   const [targetTimeExpanded, setTargetTimeExpanded] = useState(false);
   const [targetTime, setTargetTime] = useState<ClockTimeSelection>(() => getDefaultTargetSelection());
-  const [compactControlsVisible, setCompactControlsVisible] = useState(true);
-  const compactControlsRegionRef = useRef<HTMLDivElement>(null);
-  const compactControlsHideTimerRef = useRef<number | null>(null);
-  const compactControlsInputModalityRef = useRef<'keyboard' | 'pointer'>('pointer');
-  const compactControlsKeyboardFocusRef = useRef(false);
-
-  const clearCompactControlsHideTimer = useCallback(() => {
-    if (compactControlsHideTimerRef.current !== null) {
-      window.clearTimeout(compactControlsHideTimerRef.current);
-      compactControlsHideTimerRef.current = null;
-    }
-  }, []);
-
-  const revealCompactControls = useCallback(() => {
-    if (!isCompactPanel) return;
-    clearCompactControlsHideTimer();
-    setCompactControlsVisible(true);
-  }, [clearCompactControlsHideTimer, isCompactPanel]);
-
-  const scheduleCompactControlsHide = useCallback(() => {
-    if (!isCompactPanel || quickAddExpanded || targetTimeExpanded) return;
-    clearCompactControlsHideTimer();
-    compactControlsHideTimerRef.current = window.setTimeout(() => {
-      const controlsRegion = compactControlsRegionRef.current;
-      compactControlsHideTimerRef.current = null;
-      if (
-        compactControlsKeyboardFocusRef.current &&
-        controlsRegion?.contains(document.activeElement)
-      ) {
-        return;
-      }
-      compactControlsKeyboardFocusRef.current = false;
-      if (controlsRegion?.matches(':hover')) {
-        return;
-      }
-      setCompactControlsVisible(false);
-    }, COMPACT_CONTROLS_HIDE_DELAY_MS);
-  }, [clearCompactControlsHideTimer, isCompactPanel, quickAddExpanded, targetTimeExpanded]);
-
-  React.useEffect(() => {
-    if (!isCompactPanel) return;
-    const markKeyboardInput = () => {
-      compactControlsInputModalityRef.current = 'keyboard';
-      if (compactControlsRegionRef.current?.contains(document.activeElement)) {
-        compactControlsKeyboardFocusRef.current = true;
-        revealCompactControls();
-      }
-    };
-    const markPointerInput = () => {
-      compactControlsInputModalityRef.current = 'pointer';
-      compactControlsKeyboardFocusRef.current = false;
-    };
-    document.addEventListener('keydown', markKeyboardInput, true);
-    document.addEventListener('pointerdown', markPointerInput, true);
-    return () => {
-      document.removeEventListener('keydown', markKeyboardInput, true);
-      document.removeEventListener('pointerdown', markPointerInput, true);
-    };
-  }, [isCompactPanel, revealCompactControls]);
-
-  const handleCompactControlsFocus = useCallback(() => {
-    compactControlsKeyboardFocusRef.current = compactControlsInputModalityRef.current === 'keyboard';
-    revealCompactControls();
-  }, [revealCompactControls]);
-
-  const handleCompactControlsBlur = useCallback((event: React.FocusEvent<HTMLDivElement>) => {
-    if (event.relatedTarget instanceof Node && event.currentTarget.contains(event.relatedTarget)) return;
-    compactControlsKeyboardFocusRef.current = false;
-    scheduleCompactControlsHide();
-  }, [scheduleCompactControlsHide]);
 
   // Mute gates playback rather than the hooks' enabled flag, so the Audio
   // element stays alive (and preloaded) across mute toggles.
@@ -195,30 +124,6 @@ const Timer: React.FC<TimerProps> = ({ savedState, onStateChange, renderTheme, i
     onTimeUp: playTimerSound,
     restoredState: savedState?.timer
   });
-
-  React.useEffect(() => {
-    if (!isCompactPanel) {
-      clearCompactControlsHideTimer();
-      setCompactControlsVisible(true);
-      return;
-    }
-    if (quickAddExpanded || targetTimeExpanded) {
-      revealCompactControls();
-      return;
-    }
-    scheduleCompactControlsHide();
-    return clearCompactControlsHideTimer;
-  }, [
-    clearCompactControlsHideTimer,
-    isCompactPanel,
-    isPaused,
-    isRunning,
-    quickAddExpanded,
-    revealCompactControls,
-    scheduleCompactControlsHide,
-    targetTimeExpanded,
-    timerFinished
-  ]);
 
   const segmentEditor = useTimeSegmentEditor({
     initialValues: savedState?.segmentValues ?? ['00', '00', '10'],
@@ -519,22 +424,12 @@ const Timer: React.FC<TimerProps> = ({ savedState, onStateChange, renderTheme, i
         </div>
 
         <div
-          ref={compactControlsRegionRef}
           data-testid="timer-bottom-controls-region"
-          onMouseEnter={revealCompactControls}
-          onMouseLeave={scheduleCompactControlsHide}
-          onFocusCapture={handleCompactControlsFocus}
-          onBlurCapture={handleCompactControlsBlur}
-          onClickCapture={scheduleCompactControlsHide}
         >
           <div
             data-testid="timer-bottom-controls"
-            className={cn(
-              'transition-opacity duration-200 motion-reduce:transition-none',
-              isCompactPanel && (
-                compactControlsVisible ? 'opacity-100' : 'pointer-events-none opacity-0'
-              )
-            )}
+            data-widget-controls
+            className="transition-opacity duration-150 motion-reduce:transition-none"
           >
             <TimerControlBar
               timerFinished={timerFinished}


### PR DESCRIPTION
## Summary

- Give Mac title bars a 10pt content gap and bottom control bars a matching 10px gap on web and Mac.
- Use native whole-panel hover as the single Mac chrome visibility source: reveal on entry and hide together two seconds after exit; preserve keyboard and VoiceOver access.
- Move Text Banner editing and preset/custom colours into a separate bottom bar, with quick − / + text sizing and a layout that fits 300px-wide panels.
- Preserve content space while controls are hidden and account for the native titlebar gap in panel sizing/aspect constraints.

## Verification

- `npm test -- --run`: 466 tests passed across 45 files.
- `npm run build`: all workspace builds passed.
- `npm run typecheck -w @classroom-widgets/teacher`: passed.
- `git diff --check`: passed.
- Native sources validated on yjmbpro with Xcode 26.6: `swift build` passed; `swift test` passed (9 tests, including 5 new layout tests).
- Additional temporary AppKit/WKWebView harness passed geometry, visibility bridge, delayed hide and re-entry cancellation checks. It used synthesized callbacks/minimal HTML and a test-only relocation of the unchanged URL-scheme constant; no instrumentation is included in this PR.
- Browser checks measured 10px bottom gaps for Text Banner, Timer, Randomiser, List and Task Cue. Inspected light/dark, minimum-width, hidden-control, editor and short-column renders; exercised quick sizing from 48px to 64px and down to the disabled 24px limit.

## Landing notes

- Independent read-only review of [0de0751](https://github.com/tinkertanker/classroom-widgets/commit/0de0751d07e22d8c38a00f5fd4e7c52e0c55d1a0) by `gpt-6-astra-medium` (OpenAI GPT-6 Astra, medium reasoning), explicitly authorized by yjsoon: no Critical, Required, Optional, or Nit findings. No code changes were needed after review.
- Physical Mac hover/screenshots could not be checked because the runner desktop and UI automation were unavailable.
- Existing saved resizable outer frames are retained; their viewport can be 10pt shorter until resized/rearranged.
- Merging to `master` triggers the repository's existing automatic web deployment. No Mac release is included.
